### PR TITLE
Resolve todos

### DIFF
--- a/pkg/fab/recipe/control_build_usb.go
+++ b/pkg/fab/recipe/control_build_usb.go
@@ -30,7 +30,7 @@ var (
 	espSize             uint64 = 500 * 1024 * 1024
 	oemSize             uint64 = (6 * 1024 * 1024 * 1024) + (500 * 1024 * 1024)
 	dataSize                   = espSize + oemSize
-	blkSize                    = diskfs.SectorSize512 // TODO(mrbojangles3) do we want 4k?
+	blkSize                    = diskfs.SectorSize512
 	diskSize                   = int64(dataSize + 2*16896 + (1024 * 1024))
 	espPartitionStart   uint64 = 2048
 	espPartitionSectors        = espSize / uint64(blkSize)

--- a/pkg/fab/recipe/control_build_usb.go
+++ b/pkg/fab/recipe/control_build_usb.go
@@ -90,14 +90,14 @@ func (b *ControlInstallBuilder) buildUSBImage(ctx context.Context) error {
 
 	table.Partitions = []*gpt.Partition{
 		{
-			Name:  "HHA", // TODO(mrbojangles3) ESP?
+			Name:  "HHA",
 			Type:  gpt.EFISystemPartition,
 			Size:  espSize,
 			Start: espPartitionStart,
 			End:   espPartitionEnd,
 		},
 		{
-			Name:  "HHB", // TODO(mrbojangles3) OEM?
+			Name:  "HHB",
 			Type:  gpt.LinuxFilesystem,
 			Size:  oemSize,
 			Start: oemPartitionStart,


### PR DESCRIPTION
Additional context is provided in the longer commit messages. I am adding them here for visibility:

- go-diskfs makes the 512 byte sector size assumption in a lot of places FAT does as well. Best to stay at 512
- The partition labels don't need to match the filesystem labels, so we are okay to keep them. Additionally it is helpful to to see our disk in the output of lsblk