### PR TITLE
Nvme partition name

### DIFF
--- a/pkg/fab/recipe/flatcar/control_os_install.go
+++ b/pkg/fab/recipe/flatcar/control_os_install.go
@@ -162,7 +162,7 @@ func (i *ControlOSInstal) Run(ctx context.Context) error {
 	}
 
 	// 9 is the partition number for the root partition
-	if err := i.execCmd(ctx, true, "mount", "-t", "auto", dev+"9", MountDir); err != nil {
+	if err := i.execCmd(ctx, true, "mount", "-t", "auto", dev+partition, MountDir); err != nil {
 		return fmt.Errorf("mounting root: %w", err)
 	}
 

--- a/pkg/fab/recipe/flatcar/control_os_install.go
+++ b/pkg/fab/recipe/flatcar/control_os_install.go
@@ -145,9 +145,9 @@ func (i *ControlOSInstal) Run(ctx context.Context) error {
 	// The partition resize didn't wipe out the exisiting filesystem so we don't
 	// need to remake it, just expand the one that is on disk already. In our
 	// case we just moving the end of it, not the start
-	partition := "p9"
-	if strings.Contains(dev, "sd") {
-		partition = "9"
+	partition := "9"
+	if strings.Contains(dev, "nvme") {
+		partition = "p9"
 	}
 	if err := i.execCmd(ctx, true, "resize2fs", dev+partition); err != nil {
 		return fmt.Errorf("resizing filesystem on partition 9 on existing block device: %w", err)

--- a/pkg/fab/recipe/flatcar/control_os_install.go
+++ b/pkg/fab/recipe/flatcar/control_os_install.go
@@ -145,7 +145,11 @@ func (i *ControlOSInstal) Run(ctx context.Context) error {
 	// The partition resize didn't wipe out the exisiting filesystem so we don't
 	// need to remake it, just expand the one that is on disk already. In our
 	// case we just moving the end of it, not the start
-	if err := i.execCmd(ctx, true, "resize2fs", dev+"9"); err != nil {
+	partition := "p9"
+	if strings.Contains(dev, "sd") {
+		partition = "9"
+	}
+	if err := i.execCmd(ctx, true, "resize2fs", dev+partition); err != nil {
 		return fmt.Errorf("resizing filesystem on partition 9 on existing block device: %w", err)
 	}
 


### PR DESCRIPTION
nvme drives add `p9` to the partition name not a simple 9. 

Fixes #209 