### PR TITLE
bump control-usb-root, improper command line args meant no graphical …

### DIFF
--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -30,7 +30,7 @@ var Versions = fabapi.Versions{
 	Fabricator: fabapi.FabricatorVersions{
 		API:            FabricatorVersion,
 		Controller:     FabricatorVersion,
-		ControlUSBRoot: "v3815.2.5-hh1",
+		ControlUSBRoot: "v3815.2.5-hh2",
 	},
 	Fabric: fabapi.FabricVersions{
 		API:        FabricVersion,


### PR DESCRIPTION
…output on tty0
closes #215 