### PR TITLE
Switch onie-vlab to the version without net boot

### DIFF
--- a/pkg/fab/README.md
+++ b/pkg/fab/README.md
@@ -113,7 +113,7 @@ oras push "ghcr.io/githedgehog/fabricator/k9s:${K9S_VERSION}" k9s
 Manually prepared ONIE image. Probably should be shrunk to the minimum size using `qemu-img convert -O qcow2 <from> <to>`.
 
 ```bash
-export ONIE_VERSION="test"
+export ONIE_VERSION="v0.2.0"
 
 oras push "ghcr.io/githedgehog/fabricator/onie-vlab:${ONIE_VERSION}" onie-kvm_x86_64.qcow2 onie_efi_code.fd onie_efi_vars.fd
 ```

--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -61,7 +61,7 @@ var Versions = fabapi.Versions{
 		},
 	},
 	VLAB: fabapi.VLABVersions{
-		ONIE:    "v0.1.0",
+		ONIE:    "v0.2.0",
 		Flatcar: "v3975.2.1",
 	},
 }


### PR DESCRIPTION
@cesargithedgehog prepared new fd files for onie with 

```
  DEFINE NETWORK_SNP_ENABLE       = FALSE
  DEFINE NETWORK_IP6_ENABLE       = FALSE
  DEFINE NETWORK_TLS_ENABLE       = FALSE
  DEFINE NETWORK_HTTP_BOOT_ENABLE = FALSE
  DEFINE NETWORK_HTTP_ENABLE      = FALSE
  DEFINE NETWORK_ISCSI_ENABLE     = FALSE
  DEFINE SECURE_BOOT_ENABLE       = FALSE
```