### PR TITLE
Run iperf with 4 threads to get more stable numbers

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -788,7 +788,7 @@ func Run(ctx context.Context) error {
 							&cli.Float64Flag{
 								Name:  "iperfs-speed",
 								Usage: "minimum speed in Mbits/s for iperf3 test to consider successful (0 to not check speeds)",
-								Value: 7000,
+								Value: 8500,
 							},
 							&cli.IntFlag{
 								Name:  "curls",

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -1208,7 +1208,7 @@ func checkIPerf(ctx context.Context, opts TestConnectivityOpts, iperfs *semaphor
 	g.Go(func() error {
 		time.Sleep(1 * time.Second) // TODO think about more reliable way to wait for server to start
 
-		cmd := fmt.Sprintf("toolbox -q timeout -v %d iperf3 -J -c %s -t %d", opts.IPerfsSeconds+25, toIP.String(), opts.IPerfsSeconds)
+		cmd := fmt.Sprintf("toolbox -q timeout -v %d iperf3 -P 4 -J -c %s -t %d", opts.IPerfsSeconds+25, toIP.String(), opts.IPerfsSeconds)
 		out, err := fromSSH.RunContext(ctx, cmd)
 		if err != nil {
 			return fmt.Errorf("running iperf client: %w: %s", err, string(out))


### PR DESCRIPTION
With `-P 4` it's WAY more stable on all 3 envs (env-1/2/3) and hitting ~9300 Mbps very reliably while it wasn't hitting 8000 all the time previously. Additionally rising default to 8500.

<img width="1492" alt="Screenshot 2024-12-02 at 4 45 34 PM" src="https://github.com/user-attachments/assets/e4da4568-c7ef-4beb-b3da-5e356d5766f6">
<img width="1485" alt="Screenshot 2024-12-02 at 4 45 22 PM" src="https://github.com/user-attachments/assets/aa6d3c7c-c147-4cd5-ba3e-3c3ccf256009">
<img width="1485" alt="Screenshot 2024-12-02 at 4 45 13 PM" src="https://github.com/user-attachments/assets/4cc5f57e-f2c7-4e05-a733-6ed9d607e58c">
