### PR TITLE
initial version of switch reinstall

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -834,6 +834,39 @@ func Run(ctx context.Context) error {
 							return nil
 						},
 					},
+					{
+						Name:   "switch",
+						Usage:  "manage switch reinstall or power",
+						Flags:  append(defaultFlags, accessNameFlag),
+						Before: before(false),
+						Subcommands: []*cli.Command{
+							{
+								Name:  "reinstall",
+								Usage: "reinstall one or all switches",
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:    "name",
+										Aliases: []string{"n"},
+										Usage:   "name of the switch to reinstall, or use '--all' for all switches",
+									},
+								},
+								Action: func(c *cli.Context) error {
+									switchName := c.String("name")
+									if switchName == "" {
+										return fmt.Errorf("missing switch name or --all") //nolint:goerr113
+									}
+
+									err := hhfab.DoSwitchReinstall(ctx, workDir, cacheDir, switchName)
+									if err != nil {
+										return fmt.Errorf("reinstall failed: %w", err)
+									}
+
+									return nil
+								},
+								HelpName: "hhfab vlab switch reinstall",
+							},
+						},
+					},
 				},
 			},
 			{

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -23,6 +24,7 @@ import (
 	"go.githedgehog.com/fabricator/pkg/fab/recipe"
 	"go.githedgehog.com/fabricator/pkg/hhfab"
 	"go.githedgehog.com/fabricator/pkg/version"
+	"golang.org/x/term"
 	"gopkg.in/natefinch/lumberjack.v2"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -866,6 +868,19 @@ func Run(ctx context.Context) error {
 										Name:  "all",
 										Usage: "apply action to all switches",
 									},
+									&cli.StringFlag{
+										Name:  "mode",
+										Usage: "restart mode: reload, soft-reset, or hard-reset",
+										Value: "reload",
+									},
+									&cli.StringFlag{
+										Name:  "username",
+										Usage: "required for reload mode (if empty, user is prompted)",
+									},
+									&cli.StringFlag{
+										Name:  "password",
+										Usage: "required for reload mode (if empty, user is prompted)",
+									},
 									yesFlag,
 								},
 								Action: func(c *cli.Context) error {
@@ -877,12 +892,37 @@ func Run(ctx context.Context) error {
 										return fmt.Errorf("missing switch name or --all") //nolint:goerr113
 									}
 
+									mode := c.String("mode")
+									validModes := map[string]bool{"reload": true, "soft-reset": true, "hard-reset": true}
+									if !validModes[mode] {
+										return fmt.Errorf("invalid mode: %s", mode) //nolint:goerr113
+									}
+
 									if err := yesCheck(c); err != nil {
 										return err
 									}
 
-									err := hhfab.DoSwitchReinstall(ctx, workDir, cacheDir, switchName, verbose)
-									if err != nil {
+									username := c.String("username")
+									password := c.String("password")
+									if mode == "reload" && (username == "" || password == "") {
+										fmt.Print("Enter username: ")
+										if _, err := fmt.Scanln(&username); err != nil {
+											return fmt.Errorf("failed to read username: %w", err)
+										}
+										fmt.Print("Enter password: ")
+										bytePassword, err := term.ReadPassword(syscall.Stdin)
+										if err != nil {
+											return fmt.Errorf("failed to read password: %w", err)
+										}
+										password = string(bytePassword)
+										fmt.Println()
+
+										if username == "" || password == "" {
+											return fmt.Errorf("credentials required for reload mode") //nolint:goerr113
+										}
+									}
+
+									if err := hhfab.DoSwitchReinstall(ctx, workDir, cacheDir, switchName, mode, username, password, verbose); err != nil {
 										return fmt.Errorf("reinstall failed: %w", err)
 									}
 

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -856,7 +856,7 @@ func Run(ctx context.Context) error {
 										return fmt.Errorf("missing switch name or --all") //nolint:goerr113
 									}
 
-									err := hhfab.DoSwitchReinstall(ctx, workDir, cacheDir, switchName)
+									err := hhfab.DoSwitchReinstall(ctx, workDir, cacheDir, switchName, verbose)
 									if err != nil {
 										return fmt.Errorf("reinstall failed: %w", err)
 									}

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -171,5 +171,5 @@ func DoSwitchReinstall(ctx context.Context, workDir, cacheDir, name string) erro
 		return err
 	}
 
-	return c.SwitchReinstall(ctx, workDir, name)
+	return c.SwitchReinstall(ctx, name)
 }

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -165,11 +165,11 @@ func DoVLABTestConnectivity(ctx context.Context, workDir, cacheDir string, opts 
 	return c.TestConnectivity(ctx, vlab, opts)
 }
 
-func DoSwitchReinstall(ctx context.Context, workDir, cacheDir, name string) error {
+func DoSwitchReinstall(ctx context.Context, workDir, cacheDir, name string, verbose bool) error {
 	c, _, err := loadVLABForHelpers(ctx, workDir, cacheDir)
 	if err != nil {
 		return err
 	}
 
-	return c.SwitchReinstall(ctx, name)
+	return c.SwitchReinstall(ctx, name, verbose)
 }

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -165,11 +165,11 @@ func DoVLABTestConnectivity(ctx context.Context, workDir, cacheDir string, opts 
 	return c.TestConnectivity(ctx, vlab, opts)
 }
 
-func DoSwitchReinstall(ctx context.Context, workDir, cacheDir, name string, verbose bool) error {
+func DoSwitchReinstall(ctx context.Context, workDir, cacheDir, name, mode, username, password string, verbose bool) error {
 	c, _, err := loadVLABForHelpers(ctx, workDir, cacheDir)
 	if err != nil {
 		return err
 	}
 
-	return c.SwitchReinstall(ctx, name, verbose)
+	return c.SwitchReinstall(ctx, name, mode, username, password, verbose)
 }

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -164,3 +164,12 @@ func DoVLABTestConnectivity(ctx context.Context, workDir, cacheDir string, opts 
 
 	return c.TestConnectivity(ctx, vlab, opts)
 }
+
+func DoSwitchReinstall(ctx context.Context, workDir, cacheDir, name string) error {
+	c, _, err := loadVLABForHelpers(ctx, workDir, cacheDir)
+	if err != nil {
+		return err
+	}
+
+	return c.SwitchReinstall(ctx, workDir, name)
+}

--- a/pkg/hhfab/grub-selector.exp
+++ b/pkg/hhfab/grub-selector.exp
@@ -1,0 +1,180 @@
+#!/usr/bin/expect -f
+# Copyright 2024 Hedgehog
+# SPDX-License-Identifier: Apache-2.0
+
+set force_conservative 1
+set timeout -1
+
+if {[llength $argv] == 1} {
+	puts "No credentials are provided, assume external power reset"
+	lassign $argv SW_NAME
+	set POWER_RESET 1
+} elseif {[llength $argv] == 3} {
+	puts "Credentials are provided, will attempt reboot"
+	lassign $argv SW_NAME USER PASSWORD
+	set POWER_RESET 0
+} else {
+	puts "Usage: $argv0 SW_NAME \[USER\] \[PASSWORD\]"
+	exit 1
+}
+
+# Define ANSI escape codes for colors
+set GREY "\033\[38;5;242m"
+set INF "\033\[0;92m"
+set ERR "\033\[0;31m"
+set RESET "\033\[0m"
+set LOG_BG "\033\[49m"
+
+# Helper function to send colorized output to stderr
+proc log_message {loglevel SW_NAME msg} {
+	set current_time [clock format [clock seconds] -format "%H:%M:%S"]
+
+	if {$loglevel == "INF"} {
+		puts stderr "$::LOG_BG$::GREY$current_time$::RESET $::INF$loglevel$::RESET $SW_NAME: $msg"
+	} elseif {$loglevel == "ERR"} {
+		puts stderr "$::LOG_BG$::GREY$current_time$::RESET $::ERR$loglevel$::RESET $SW_NAME: $msg"
+	} else {
+		puts stderr "$::LOG_BG$::GREY$current_time$::RESET $SW_NAME: $msg"
+	}
+}
+
+set KEY_UP   "\033\[A"
+set KEY_DOWN "\033\[B"
+set KEY_HOME "\033\[H"
+set KEY_PGUP "\033\[5~"
+set ONIE_HIGHLIGHT "*ONIE"
+set ONIE_CHAIN_INSTALL "*ONIE: Install OS"
+
+set ERROR_CONNECTION 1
+set ERROR_LOGIN 2
+set ERROR_GRUB 3
+set ERROR_INSTALL 4
+
+# Define a procedure for GRUB menu handling
+proc handle_grub_menu {SW_NAME KEY_HOME KEY_DOWN ONIE_HIGHLIGHT} {
+    log_message "INF" $SW_NAME "GRUB Menu detected"
+    # Select the ONIE option, and finally the Install OS option
+    sleep 1
+    send -- "$KEY_HOME"
+    set timeout 1
+    expect {
+        -ex $ONIE_HIGHLIGHT {
+            set timeout -1
+            send "\r"
+            expect -ex "GNU GRUB"
+            send -- "$KEY_HOME"
+            sleep 1
+            send "\r"
+            expect {
+                "ONIE: OS Install Mode ..." {
+                    log_message "INF" $SW_NAME "ONIE OS Installing..."
+                }
+                timeout {
+                    send "\r"
+                }
+            }
+        }
+        timeout {
+            send -- "$KEY_DOWN"
+            exp_continue
+        }
+    }
+}
+
+# connect to the serial console of the switch
+# using hhfab now for simplicity but might want to do it directly instead?
+puts "connecting to serial of $SW_NAME via hhfab serial..."
+# check if hhfab is in the local folder or in the path
+set HHFAB "NO"
+if {[file exists "./hhfab"]} {
+	set HHFAB "./hhfab"
+} else {
+	set HHFAB [exec which hhfab]
+}
+spawn $HHFAB vlab serial -n $SW_NAME
+expect {
+	-ex "Type the hot key to suspend the connection: <CTRL>Z" {
+		send "\r"
+	}
+	-ex "Use Ctrl+] to escape, if no output try Enter, safe to use Ctrl+C/Ctrl+Z" {
+		send "\r"
+	}
+	-ex "The connection was unsuccessful" {
+		exit $ERROR_CONNECTION
+	}
+}
+
+if { ! $POWER_RESET} {
+	expect {
+		# handle wrong user/password
+		-ex "Login incorrect" {
+			exit $ERROR_LOGIN
+		}
+		# handle user login if not already logged in
+		-re "$SW_NAME login:" {
+			send "$USER\r"
+			exp_continue
+		}
+		-ex "Password:" {
+			send "$PASSWORD\r"
+			exp_continue
+		}
+		# reboot in case we are at the prompt - eventually this will be done via PDU
+		-ex "admin@$SW_NAME:~$" {
+			log_message "INF" $SW_NAME "Rebooting..."
+			send "sudo reboot\r"
+			exp_continue
+		}
+		# same for rescue mode
+		-ex "ONIE:/ #" {
+			send "reboot\r"
+			sleep 5
+			exp_continue
+		}
+		-ex "GNU GRUB" {
+	            handle_grub_menu $SW_NAME $KEY_HOME $KEY_DOWN $ONIE_HIGHLIGHT
+		}
+	}
+} else {
+	expect -timeout 60 -ex "GNU GRUB" {
+        	handle_grub_menu $SW_NAME $KEY_HOME $KEY_DOWN $ONIE_HIGHLIGHT
+	} timeout {
+		log_message "ERR" $SW_NAME "Failed to reset. GRUB not detected."
+		exit $ERROR_INSTALL
+	}
+}
+
+# Wait for confirmation of the Install OS option
+expect -timeout 60 -ex "Starting ONIE Service Discovery" {
+	# Wait for successful NOS installation
+	expect -timeout 300 -ex "ONIE: NOS install successful" {
+		log_message "INF" $SW_NAME "NOS installed successfully."
+		set install_success 1
+	} timeout {
+		log_message "ERR" $SW_NAME "Failed to install NOS within 5 minutes from service discovery."
+	}
+} timeout {
+	log_message "ERR" $SW_NAME "Failed to select install mode."
+}
+
+# Exit if install failed
+if {$install_success == 0} {
+	exit $ERROR_INSTALL
+}
+
+# Wait for the login prompt
+expect -timeout 300 -ex "sonic login:" {
+	log_message "INF" $SW_NAME "Sonic login prompt detected."
+} timeout {
+	log_message "ERR" $SW_NAME "Login prompt not detected within 5 minutes."
+	exit $ERROR_INSTALL
+}
+
+# Wait for the "System is ready" message
+expect -timeout 300 -ex "System is ready" {
+	log_message "INF" $SW_NAME "System is ready message detected."
+	exit 0
+} timeout {
+	log_message "ERR" $SW_NAME "System did not become ready within 5 minutes."
+	exit $ERROR_INSTALL
+}

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -291,23 +291,19 @@ func (c *Config) SwitchReinstall(ctx context.Context, name string, verbose bool)
 				cmd.Stderr = os.Stderr // expect messages logged to stderr to show progress
 			}
 
-			slog.Info("Running", "cmd", strings.Join(append([]string{cmdName}, sw.Name+"..."), " "))
+			slog.Debug("Running", "cmd", strings.Join(append([]string{cmdName}, "switch", sw.Name+"..."), " "))
 			if err := cmd.Run(); err != nil {
 				mu.Lock()
-				errs = append(errs, fmt.Errorf("\n%s failed for switch %s: %w", cmdName, sw.Name, err))
+				errs = append(errs, fmt.Errorf("%s", sw.Name)) //nolint:goerr113
 				mu.Unlock()
 			}
 		}(sw)
 	}
 
 	for _, sw := range targets {
+		time.Sleep(1 * time.Second)
 		slog.Info("Executing soft-reset on", "switch", sw.Name+"...")
-		if err := hhfctl.SwitchPowerReset(ctx, sw.Name); err != nil {
-			mu.Lock()
-			errs = append(errs, fmt.Errorf("\nfailed to run soft-reset switch %s: %w", sw.Name, err))
-			mu.Unlock()
-			time.Sleep(500 * time.Millisecond)
-		}
+		_ = hhfctl.SwitchPowerReset(ctx, sw.Name)
 	}
 	wg.Wait()
 

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -59,7 +59,7 @@ const (
 	VLABCmdSocat      = "socat"
 	VLABCmdSSH        = "ssh"
 	VLABCmdLess       = "less"
-	VLABCmdGrubSelect = "grub-selector.exp"
+	VLABCmdExpect     = "expect"
 
 	VLABIgnition = "ignition.json"
 
@@ -73,7 +73,7 @@ var VLABCmds = []string{
 	VLABCmdSocat,
 	VLABCmdSSH,
 	VLABCmdLess,
-	VLABCmdGrubSelect,
+	VLABCmdExpect,
 }
 
 type VLABRunOpts struct {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -59,6 +59,7 @@ const (
 	VLABCmdSocat      = "socat"
 	VLABCmdSSH        = "ssh"
 	VLABCmdLess       = "less"
+	VLABCmdGrubSelect = "grub-selector.exp"
 
 	VLABIgnition = "ignition.json"
 
@@ -72,6 +73,7 @@ var VLABCmds = []string{
 	VLABCmdSocat,
 	VLABCmdSSH,
 	VLABCmdLess,
+	VLABCmdGrubSelect,
 }
 
 type VLABRunOpts struct {


### PR DESCRIPTION
Adds `reinstall` suboption to `vlab switch` in `hhfab` to enable the NOS reinstall of one or all switches. For example:

```
hhfab vlab switch reinstall --yes --all --mode soft-reset
hhfab vlab switch --verbose reinstall  --yes -n leaf-01
```

Three modes of operations are available:
- reload: current default. Connects to the switch via serial and reloads (requires username/password)
- soft reset: queries the power reset from the Agent API
- hard-reset: will be the default option
  - queries the PDU API and issues a power cycle (pending)
  - Depends On https://github.com/githedgehog/fabricator/pull/256
