### PR TITLE
make seriallog output more readable

### DIFF
--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -201,7 +201,7 @@ func (c *Config) VLABAccess(ctx context.Context, vlab *VLAB, t VLABAccessType, n
 			slog.Info("Serial log", "name", name, "path", entry.SerialLog)
 
 			cmdName = VLABCmdLess
-			args = []string{entry.SerialLog}
+			args = []string{"-r", entry.SerialLog}
 		} else {
 			return fmt.Errorf("Serial log not available: %s", name) //nolint:goerr113
 		}


### PR DESCRIPTION
Small PR to prettify the output of `vlab switch seriallog` adding `-r` option to `less`

Before:
![Screenshot From 2024-12-16 09-11-19](https://github.com/user-attachments/assets/8f5be3ce-2c81-4778-bc62-0f740690b4c3)

After:
![Screenshot From 2024-12-16 09-11-07](https://github.com/user-attachments/assets/017d912a-f689-4cfc-828b-8db32e3ae007)

