### PR TITLE
Enable LLDP on Server VMs

### DIFF
--- a/pkg/hhfab/vlab_butane.tmpl.yaml
+++ b/pkg/hhfab/vlab_butane.tmpl.yaml
@@ -56,12 +56,14 @@ storage:
           TOOLBOX_DOCKER_TAG=latest
           TOOLBOX_USER=root
 
-    - path: /etc/systemd/network/99-wildcard.network
+    - path: /etc/systemd/network/99-lldp.network
       mode: 0644
       contents:
         inline: |
           [Match]
-          Name=en*
+          Name=*
+          Type=ether
+          Kind=!vlan
 
           [Network]
           DHCP=yes

--- a/pkg/hhfab/vlab_butane.tmpl.yaml
+++ b/pkg/hhfab/vlab_butane.tmpl.yaml
@@ -55,3 +55,15 @@ storage:
           TOOLBOX_DOCKER_IMAGE=ghcr.io/githedgehog/toolbox
           TOOLBOX_DOCKER_TAG=latest
           TOOLBOX_USER=root
+
+    - path: /etc/systemd/network/99-wildcard.network
+      mode: 0644
+      contents:
+        inline: |
+          [Match]
+          Name=en*
+
+          [Network]
+          DHCP=yes
+          LLDP=yes
+          EmitLLDP=yes


### PR DESCRIPTION
Enables LLDP on server VM interfaces to cross-check topology:

```
core@server-1 ~ $ networkctl -l lldp 
LINK   CHASSIS-ID        SYSTEM-NAME CAPS        PORT-ID   PORT-DESCRIPTION                                      
enp2s1 54:bf:64:ba:3d:c0 s5248-01    ....r...... Ethernet1 PC2 MCLAG server-1 server-1--mclag--s5248-01--s5248-02
enp2s2 3c:2c:30:66:f0:00 s5248-02    ....r...... Ethernet1 PC2 MCLAG server-1 server-1--mclag--s5248-01--s5248-02

Capability Flags:
r - Router

2 neighbors listed.
```

Also enables DHCP on the same interfaces