### PR TITLE
fix: revert "Bump golang.org/x/crypto from 0.34.0 to 0.35.0"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/vbauerster/mpb/v8 v8.9.3
 	github.com/vishvananda/netlink v1.3.0
 	go.githedgehog.com/fabric v0.65.0
-	golang.org/x/crypto v0.35.0
+	golang.org/x/crypto v0.34.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/term v0.29.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -938,8 +938,8 @@ golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
-golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
-golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
+golang.org/x/crypto v0.34.0 h1:+/C6tk6rf/+t5DhUketUbD1aNGqiSX3j15Z6xuIDlBA=
+golang.org/x/crypto v0.34.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -25,11 +25,6 @@ const debugHandshake = false
 // quickly.
 const chanSize = 16
 
-// maxPendingPackets sets the maximum number of packets to queue while waiting
-// for KEX to complete. This limits the total pending data to maxPendingPackets
-// * maxPacket bytes, which is ~16.8MB.
-const maxPendingPackets = 64
-
 // keyingTransport is a packet based transport that supports key
 // changes. It need not be thread-safe. It should pass through
 // msgNewKeys in both directions.
@@ -78,19 +73,11 @@ type handshakeTransport struct {
 	incoming  chan []byte
 	readError error
 
-	mu sync.Mutex
-	// Condition for the above mutex. It is used to notify a completed key
-	// exchange or a write failure. Writes can wait for this condition while a
-	// key exchange is in progress.
-	writeCond      *sync.Cond
-	writeError     error
-	sentInitPacket []byte
-	sentInitMsg    *kexInitMsg
-	// Used to queue writes when a key exchange is in progress. The length is
-	// limited by pendingPacketsSize. Once full, writes will block until the key
-	// exchange is completed or an error occurs. If not empty, it is emptied
-	// all at once when the key exchange is completed in kexLoop.
-	pendingPackets   [][]byte
+	mu               sync.Mutex
+	writeError       error
+	sentInitPacket   []byte
+	sentInitMsg      *kexInitMsg
+	pendingPackets   [][]byte // Used when a key exchange is in progress.
 	writePacketsLeft uint32
 	writeBytesLeft   int64
 	userAuthComplete bool // whether the user authentication phase is complete
@@ -147,7 +134,6 @@ func newHandshakeTransport(conn keyingTransport, config *Config, clientVersion, 
 
 		config: config,
 	}
-	t.writeCond = sync.NewCond(&t.mu)
 	t.resetReadThresholds()
 	t.resetWriteThresholds()
 
@@ -274,7 +260,6 @@ func (t *handshakeTransport) recordWriteError(err error) {
 	defer t.mu.Unlock()
 	if t.writeError == nil && err != nil {
 		t.writeError = err
-		t.writeCond.Broadcast()
 	}
 }
 
@@ -378,8 +363,6 @@ write:
 			}
 		}
 		t.pendingPackets = t.pendingPackets[:0]
-		// Unblock writePacket if waiting for KEX.
-		t.writeCond.Broadcast()
 		t.mu.Unlock()
 	}
 
@@ -594,20 +577,11 @@ func (t *handshakeTransport) writePacket(p []byte) error {
 	}
 
 	if t.sentInitMsg != nil {
-		if len(t.pendingPackets) < maxPendingPackets {
-			// Copy the packet so the writer can reuse the buffer.
-			cp := make([]byte, len(p))
-			copy(cp, p)
-			t.pendingPackets = append(t.pendingPackets, cp)
-			return nil
-		}
-		for t.sentInitMsg != nil {
-			// Block and wait for KEX to complete or an error.
-			t.writeCond.Wait()
-			if t.writeError != nil {
-				return t.writeError
-			}
-		}
+		// Copy the packet so the writer can reuse the buffer.
+		cp := make([]byte, len(p))
+		copy(cp, p)
+		t.pendingPackets = append(t.pendingPackets, cp)
+		return nil
 	}
 
 	if t.writeBytesLeft > 0 {
@@ -624,7 +598,6 @@ func (t *handshakeTransport) writePacket(p []byte) error {
 
 	if err := t.pushPacket(p); err != nil {
 		t.writeError = err
-		t.writeCond.Broadcast()
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1700,7 +1700,7 @@ gocloud.dev/internal/oc
 gocloud.dev/internal/openurl
 gocloud.dev/internal/retry
 gocloud.dev/internal/useragent
-# golang.org/x/crypto v0.35.0
+# golang.org/x/crypto v0.34.0
 ## explicit; go 1.23.0
 golang.org/x/crypto/argon2
 golang.org/x/crypto/bcrypt


### PR DESCRIPTION
This reverts commit d4e93ec3188e9db02980cac33455cb9170a543e2

Fixes #428 