### PR TITLE
ci: make controls unrestricted so ntp upstream works

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -445,7 +445,9 @@ jobs:
         run: |
           source "./lab-ci/envs/$KUBE_NODE/source.sh"
           bin/hhfab init -v --dev --include-onie=${{ matrix.includeonie }} -w "./lab-ci/envs/$KUBE_NODE/wiring.yaml"
-          bin/hhfab vlab up -v --ready switch-reinstall --ready inspect --ready setup-vpcs --ready test-connectivity --ready exit --mode=${{ matrix.buildmode }}
+
+          # TODO: make controls restricted again when we figure out how to get NTP upstream working for isolated VMs
+          bin/hhfab vlab up -v --ready switch-reinstall --ready inspect --ready setup-vpcs --ready test-connectivity --ready exit --mode=${{ matrix.buildmode }} --controls-restricted=false
 
       - name: Upload show-tech artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Seems like we're facing issues caused by switches time getting out of sync over time due to the upstream NTP server not being reacheable from the control node (and so strata is too high).