### PR TITLE
diagram: fix output name across formats

### DIFF
--- a/pkg/hhfab/cmddiagram.go
+++ b/pkg/hhfab/cmddiagram.go
@@ -124,8 +124,7 @@ func Diagram(workDir, format string, styleType diagram.StyleType) error {
 		if err := diagram.GenerateDrawio(resultDir, jsonData, styleType); err != nil {
 			return fmt.Errorf("generating draw.io diagram: %w", err)
 		}
-		fileName := "diagram.drawio"
-		filePath := filepath.Join("result", fileName)
+		filePath := filepath.Join("result", diagram.DrawioFilename)
 		slog.Info("Generated draw.io diagram", "file", filePath, "style", styleType)
 		fmt.Printf("To use this diagram:\n")
 		fmt.Printf("1. Open with https://app.diagrams.net/ or the desktop Draw.io application\n")
@@ -135,8 +134,7 @@ func Diagram(workDir, format string, styleType diagram.StyleType) error {
 		if err := diagram.GenerateDOT(resultDir, jsonData); err != nil {
 			return fmt.Errorf("generating DOT diagram: %w", err)
 		}
-		fileName := "diagram.dot"
-		filePath := filepath.Join("result", fileName)
+		filePath := filepath.Join("result", diagram.DotFilename)
 		slog.Info("Generated graphviz diagram", "file", filePath)
 		fmt.Printf("To render this diagram with Graphviz:\n")
 		fmt.Printf("1. Install Graphviz: https://graphviz.org/download/\n")
@@ -148,8 +146,7 @@ func Diagram(workDir, format string, styleType diagram.StyleType) error {
 		if err := diagram.GenerateMermaid(resultDir, jsonData); err != nil {
 			return fmt.Errorf("generating Mermaid diagram: %w", err)
 		}
-		fileName := "diagram.mmd"
-		filePath := filepath.Join("result", fileName)
+		filePath := filepath.Join("result", diagram.MermaidFilename)
 		slog.Info("Generated Mermaid diagram", "file", filePath)
 		fmt.Printf("To render this diagram with Mermaid:\n")
 		fmt.Printf("1. Visit https://mermaid.live/ or use a Markdown editor with Mermaid support\n")

--- a/pkg/hhfab/diagram/drawio.go
+++ b/pkg/hhfab/diagram/drawio.go
@@ -68,7 +68,7 @@ type Point struct {
 }
 
 func GenerateDrawio(workDir string, jsonData []byte, styleType StyleType) error {
-	outputFile := filepath.Join(workDir, "vlab-diagram.drawio")
+	outputFile := filepath.Join(workDir, DrawioFilename)
 	topo, err := ConvertJSONToTopology(jsonData)
 	if err != nil {
 		return fmt.Errorf("converting JSON to topology: %w", err)

--- a/pkg/hhfab/diagram/graphviz.go
+++ b/pkg/hhfab/diagram/graphviz.go
@@ -23,7 +23,7 @@ const (
 )
 
 func GenerateDOT(workDir string, jsonData []byte) error {
-	outputFile := filepath.Join(workDir, "vlab-diagram.dot")
+	outputFile := filepath.Join(workDir, DotFilename)
 	topo, err := ConvertJSONToTopology(jsonData)
 	if err != nil {
 		return fmt.Errorf("converting JSON to topology: %w", err)

--- a/pkg/hhfab/diagram/mermaid.go
+++ b/pkg/hhfab/diagram/mermaid.go
@@ -13,7 +13,7 @@ import (
 )
 
 func GenerateMermaid(workDir string, jsonData []byte) error {
-	outputFile := filepath.Join(workDir, "vlab-diagram.mmd")
+	outputFile := filepath.Join(workDir, MermaidFilename)
 	topo, err := ConvertJSONToTopology(jsonData)
 	if err != nil {
 		return fmt.Errorf("converting JSON to topology: %w", err)

--- a/pkg/hhfab/diagram/types.go
+++ b/pkg/hhfab/diagram/types.go
@@ -45,3 +45,9 @@ const (
 	SwitchRoleSpine   = "spine"
 	SwitchRoleLeaf    = "leaf"
 )
+
+const (
+	DrawioFilename  = "diagram.drawio"
+	DotFilename     = "diagram.dot"
+	MermaidFilename = "diagram.mmd"
+)


### PR DESCRIPTION
The reported name VS the file saved were not matching. Now it is fixed:

```
pau@fedora:~/fabricator$ bin/hhfab diagram
18:06:10 INF Hedgehog Fabricator version=v0.36.0-dirty-bv1751
18:06:10 INF Generated draw.io diagram file=result/diagram.drawio style=default
To use this diagram:
1. Open with https://app.diagrams.net/ or the desktop Draw.io application
2. You can edit the diagram and export to PNG, SVG, PDF or other formats
pau@fedora:~/fabricator$ ls result/
diagram.drawio
```