### PR TITLE
vlab: generate wiring for externals

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -721,7 +721,7 @@ func Run(ctx context.Context) error {
 						Name:    "generate",
 						Aliases: []string{"gen"},
 						Usage:   "generate VLAB wiring diagram",
-						Flags:   flatten(defaultFlags, vlabWiringGenFlags),
+						Flags:   flatten(defaultFlags, vlabWiringGenFlags, []cli.Flag{yesFlag}),
 						Before:  before(false),
 						Action: func(_ *cli.Context) error {
 							builder := hhfab.VLABBuilder{
@@ -743,6 +743,7 @@ func Run(ctx context.Context) error {
 								ExtMCLAGConnCount:  uint8(wgExtMCLAGConns),  //nolint:gosec
 								ExtESLAGConnCount:  uint8(wgExtESLAGConns),  //nolint:gosec
 								ExtOrphanConnCount: uint8(wgExtOrphanConns), //nolint:gosec
+								YesFlag:            yes,
 							}
 
 							if err := hhfab.VLABGenerate(ctx, workDir, cacheDir, builder, hhfab.DefaultVLABGeneratedFile); err != nil {

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -173,6 +173,7 @@ func Run(ctx context.Context) error {
 	var wgMCLAGServers, wgESLAGServers, wgUnbundledServers, wgBundledServers uint
 	var wgNoSwitches bool
 	var wgGatewayUplinks uint
+	var wgExternals, wgExtMCLAGConns, wgExtESLAGConns, wgExtOrphanConns uint
 	vlabWiringGenFlags := []cli.Flag{
 		&cli.UintFlag{
 			Name:        "spines-count",
@@ -249,6 +250,26 @@ func Run(ctx context.Context) error {
 			Hidden:      !preview,
 			Destination: &wgGatewayUplinks,
 			Value:       2,
+		},
+		&cli.UintFlag{
+			Name:        "externals",
+			Usage:       "number of externals to generate",
+			Destination: &wgExternals,
+		},
+		&cli.UintFlag{
+			Name:        "external-mclag-connections",
+			Usage:       "number of external connections from MCLAG switches. NOTE: only 1 external connection in total is supported if using virtual switches",
+			Destination: &wgExtMCLAGConns,
+		},
+		&cli.UintFlag{
+			Name:        "external-eslag-connections",
+			Usage:       "number of external connections from ESLAG switches. NOTE: only 1 external connection in total is supported if using virtual switches",
+			Destination: &wgExtESLAGConns,
+		},
+		&cli.UintFlag{
+			Name:        "external-orphan-connections",
+			Usage:       "number of external connections from orphan switches. NOTE: only 1 external connection in total is supported if using virtual switches",
+			Destination: &wgExtOrphanConns,
 		},
 	}
 
@@ -704,20 +725,24 @@ func Run(ctx context.Context) error {
 						Before:  before(false),
 						Action: func(_ *cli.Context) error {
 							builder := hhfab.VLABBuilder{
-								SpinesCount:       uint8(wgSpinesCount),      //nolint:gosec
-								FabricLinksCount:  uint8(wgFabricLinksCount), //nolint:gosec
-								MeshLinksCount:    uint8(wgMeshLinksCount),   //nolint:gosec
-								MCLAGLeafsCount:   uint8(wgMCLAGLeafsCount),  //nolint:gosec
-								ESLAGLeafGroups:   wgESLAGLeafGroups,
-								OrphanLeafsCount:  uint8(wgOrphanLeafsCount),  //nolint:gosec
-								MCLAGSessionLinks: uint8(wgMCLAGSessionLinks), //nolint:gosec
-								MCLAGPeerLinks:    uint8(wgMCLAGPeerLinks),    //nolint:gosec
-								MCLAGServers:      uint8(wgMCLAGServers),      //nolint:gosec
-								ESLAGServers:      uint8(wgESLAGServers),      //nolint:gosec
-								UnbundledServers:  uint8(wgUnbundledServers),  //nolint:gosec
-								BundledServers:    uint8(wgBundledServers),    //nolint:gosec
-								NoSwitches:        wgNoSwitches,
-								GatewayUplinks:    uint8(wgGatewayUplinks), //nolint:gosec
+								SpinesCount:        uint8(wgSpinesCount),      //nolint:gosec
+								FabricLinksCount:   uint8(wgFabricLinksCount), //nolint:gosec
+								MeshLinksCount:     uint8(wgMeshLinksCount),   //nolint:gosec
+								MCLAGLeafsCount:    uint8(wgMCLAGLeafsCount),  //nolint:gosec
+								ESLAGLeafGroups:    wgESLAGLeafGroups,
+								OrphanLeafsCount:   uint8(wgOrphanLeafsCount),  //nolint:gosec
+								MCLAGSessionLinks:  uint8(wgMCLAGSessionLinks), //nolint:gosec
+								MCLAGPeerLinks:     uint8(wgMCLAGPeerLinks),    //nolint:gosec
+								MCLAGServers:       uint8(wgMCLAGServers),      //nolint:gosec
+								ESLAGServers:       uint8(wgESLAGServers),      //nolint:gosec
+								UnbundledServers:   uint8(wgUnbundledServers),  //nolint:gosec
+								BundledServers:     uint8(wgBundledServers),    //nolint:gosec
+								NoSwitches:         wgNoSwitches,
+								GatewayUplinks:     uint8(wgGatewayUplinks), //nolint:gosec
+								ExtCount:           uint8(wgExternals),      //nolint:gosec
+								ExtMCLAGConnCount:  uint8(wgExtMCLAGConns),  //nolint:gosec
+								ExtESLAGConnCount:  uint8(wgExtESLAGConns),  //nolint:gosec
+								ExtOrphanConnCount: uint8(wgExtOrphanConns), //nolint:gosec
 							}
 
 							if err := hhfab.VLABGenerate(ctx, workDir, cacheDir, builder, hhfab.DefaultVLABGeneratedFile); err != nil {

--- a/pkg/hhfab/vlab_external_butane.tmpl.yaml
+++ b/pkg/hhfab/vlab_external_butane.tmpl.yaml
@@ -293,6 +293,8 @@ systemd:
         ExecStart=/usr/bin/iptables -t nat -A POSTROUTING -o enp2s0 -j MASQUERADE
 
         # Forward rules in DOCKER-USER chain
+        # Drop all traffic with both source and destination in the fabric IP range, that is, 10.0.0.0/8. TODO: make this configurable
+        ExecStart=/usr/bin/iptables -I DOCKER-USER -s 10.0.0.0/8 -d 10.0.0.0/8 -j DROP
         {{range $vrfkey, $vrf := .ExternalVRFs}}
         ExecStart=/usr/bin/iptables -I DOCKER-USER -i {{$vrfkey}} -o enp2s0 -j ACCEPT
         {{range $connNicKey, $connNic := $.ExternalNICs}}{{range $attach := $connNic.Attachments}}{{if eq $attach.VRF $vrfkey}}

--- a/pkg/hhfab/vlab_external_butane.tmpl.yaml
+++ b/pkg/hhfab/vlab_external_butane.tmpl.yaml
@@ -143,6 +143,7 @@ storage:
           !{{end}}{{range $vrfkey, $vrf := .ExternalVRFs}}
           router bgp {{$vrf.ASN}} vrf {{$vrfkey}}
            bgp log-neighbor-changes
+           bgp bestpath as-path multipath-relax
            no bgp ebgp-requires-policy
            no bgp network import-check {{range $connNicKey, $connNic := $.ExternalNICs}}{{range $attach := $connNic.Attachments}}{{if eq $attach.VRF $vrfkey}}
            neighbor {{$attach.NeighborIP}} remote-as {{$attach.NeighborASN}}
@@ -154,23 +155,19 @@ storage:
            address-family ipv4 unicast {{range $attach := $connNic.Attachments}}{{if eq $attach.VRF $vrfkey}}
             neighbor {{$attach.NeighborIP}} activate
             no neighbor {{$attach.NeighborIP}} send-community large
+            neighbor {{$attach.NeighborIP}} soft-reconfiguration inbound
             neighbor {{$attach.NeighborIP}} route-map {{$vrfkey}}In in
             neighbor {{$attach.NeighborIP}} route-map {{$vrfkey}}Out out {{end}}{{end}}{{if and ($connNic.Untagged) (eq $connNic.UntaggedCfg.VRF $vrfkey)}}
             neighbor {{$connNic.UntaggedCfg.NeighborIP}} activate
             no neighbor {{$connNic.UntaggedCfg.NeighborIP}} send-community large
             neighbor {{$connNic.UntaggedCfg.NeighborIP}} route-map {{$vrfkey}}In in
             neighbor {{$connNic.UntaggedCfg.NeighborIP}} route-map {{$vrfkey}}Out out{{end}}
-            maximum-paths 1
-            maximum-paths ibgp 1
             redistribute static
             import vrf default
            !
-           address-family ipv6 unicast
-            maximum-paths 1
-            maximum-paths ibgp 1
-           !
           !{{end}}{{end}}
           router bgp 1
+           bgp bestpath as-path multipath-relax
            address-family ipv4 unicast
             redistribute static{{range $vrfkey, $vrf := .ExternalVRFs}}
             import vrf {{$vrfkey}}{{end}}

--- a/pkg/hhfab/vlabbuilder.go
+++ b/pkg/hhfab/vlabbuilder.go
@@ -178,6 +178,14 @@ func (b *VLABBuilder) Build(ctx context.Context, l *apiutil.Loader, fabricMode m
 			eslagLeafGroups = append(eslagLeafGroups, uint8(leafs))
 		}
 	}
+	// this has no effect but the log output can be confusing, so if there
+	// is no **LAG leaf set the corresponding **LAG servers to 0
+	if totalESLAGLeafs == 0 {
+		b.ESLAGServers = 0
+	}
+	if b.MCLAGLeafsCount == 0 {
+		b.MCLAGServers = 0
+	}
 
 	if b.MCLAGLeafsCount%2 != 0 {
 		return fmt.Errorf("MCLAG leafs count must be even") //nolint:goerr113


### PR DESCRIPTION
Generate wirings for externals as part of hhfab vlab gen. Add parameters to determine how many externals and external connections are created, and where the ext. connections are placed (i.e. mclag, eslag or orphan leaves).

All attachments are currently vlan tagged, I didn't want to over complicate things with extra params for untagged.
Also all externals are in the same namespace, and attachments are created for all externals and all connections.

Closes: #521  