### PR TITLE
Misc release test fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,7 +221,7 @@ jobs:
     needs:
       - test
       - builds
-    timeout-minutes: 120
+    timeout-minutes: 150
 
     strategy:
       fail-fast: false
@@ -479,7 +479,7 @@ jobs:
     needs:
       - test
       - builds
-    timeout-minutes: 210
+    timeout-minutes: 250
 
     strategy:
       fail-fast: false
@@ -572,7 +572,7 @@ jobs:
       - name: Setup tmate session for debug
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 120
+        timeout-minutes: 150
         with:
           limit-access-to-actor: true
 

--- a/pkg/hhfab/release.go
+++ b/pkg/hhfab/release.go
@@ -52,6 +52,8 @@ type VPCPeeringTestCtx struct {
 	pauseOnFail      bool
 }
 
+var AllZeroPrefix = []string{"0.0.0.0/0"}
+
 // prepare for a test: wipe the fabric and then create the VPCs according to the
 // options in the test context
 func (testCtx *VPCPeeringTestCtx) setupTest(ctx context.Context) error {
@@ -150,7 +152,7 @@ func populateAllExternalVpcPeerings(ctx context.Context, kube kclient.Client, ex
 	}
 	for i := 0; i < len(vpcs.Items); i++ {
 		for j := 0; j < len(exts.Items); j++ {
-			appendExtPeeringSpec(extPeerings, i+1, exts.Items[j].Name, []string{"subnet-01"}, []string{})
+			appendExtPeeringSpec(extPeerings, i+1, exts.Items[j].Name, []string{"subnet-01"}, AllZeroPrefix)
 		}
 	}
 
@@ -347,12 +349,12 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsStarterTest(ctx context.Context) (b
 	appendVpcPeeringSpec(vpcPeerings, 8, 9, "", []string{}, []string{})
 
 	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec, 6)
-	appendExtPeeringSpec(externalPeerings, 5, testCtx.extName, []string{"subnet-01"}, []string{})
-	appendExtPeeringSpec(externalPeerings, 6, testCtx.extName, []string{"subnet-01"}, []string{})
-	appendExtPeeringSpec(externalPeerings, 1, testCtx.extName, []string{"subnet-01"}, []string{})
-	appendExtPeeringSpec(externalPeerings, 2, testCtx.extName, []string{"subnet-01"}, []string{})
-	appendExtPeeringSpec(externalPeerings, 9, testCtx.extName, []string{"subnet-01"}, []string{})
-	appendExtPeeringSpec(externalPeerings, 7, testCtx.extName, []string{"subnet-01"}, []string{})
+	appendExtPeeringSpec(externalPeerings, 5, testCtx.extName, []string{"subnet-01"}, AllZeroPrefix)
+	appendExtPeeringSpec(externalPeerings, 6, testCtx.extName, []string{"subnet-01"}, AllZeroPrefix)
+	appendExtPeeringSpec(externalPeerings, 1, testCtx.extName, []string{"subnet-01"}, AllZeroPrefix)
+	appendExtPeeringSpec(externalPeerings, 2, testCtx.extName, []string{"subnet-01"}, AllZeroPrefix)
+	appendExtPeeringSpec(externalPeerings, 9, testCtx.extName, []string{"subnet-01"}, AllZeroPrefix)
+	appendExtPeeringSpec(externalPeerings, 7, testCtx.extName, []string{"subnet-01"}, AllZeroPrefix)
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, true); err != nil {
 		return false, nil, fmt.Errorf("setting up peerings: %w", err)
@@ -464,7 +466,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsSergeisSpecialTest(ctx context.Cont
 	appendVpcPeeringSpec(vpcPeerings, 2, 4, remote, []string{}, []string{})
 	appendVpcPeeringSpec(vpcPeerings, 6, 5, "", []string{}, []string{})
 	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec, 6)
-	appendExtPeeringSpec(externalPeerings, 1, testCtx.extName, []string{"subnet-01"}, []string{})
+	appendExtPeeringSpec(externalPeerings, 1, testCtx.extName, []string{"subnet-01"}, AllZeroPrefix)
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, true); err != nil {
 		return false, nil, fmt.Errorf("setting up peerings: %w", err)
 	}

--- a/pkg/hhfab/release.go
+++ b/pkg/hhfab/release.go
@@ -1533,6 +1533,8 @@ func doRunTests(ctx context.Context, testCtx *VPCPeeringTestCtx, ts *JUnitTestSu
 			} else {
 				skipMsg = "Skipped by test function (unspecified reason)"
 			}
+			// error message is only used to convey skipping reason
+			err = nil
 			ts.TestCases[i].Skipped = &Skipped{
 				Message: skipMsg,
 			}
@@ -1773,6 +1775,7 @@ func makeVpcPeeringsMultiVPCSuiteRun(testCtx *VPCPeeringTestCtx) *JUnitTestSuite
 			F:    testCtx.multiSubnetsSubnetFilteringTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
+				SubInterfaces: true,
 			},
 		},
 	}

--- a/pkg/hhfab/release.go
+++ b/pkg/hhfab/release.go
@@ -1395,10 +1395,11 @@ func makeTestCtx(kube kclient.Client, opts SetupVPCsOpts, workDir, cacheDir stri
 		PingsCount:        3,
 		IPerfsSeconds:     3,
 		IPerfsMinSpeed:    8200,
+		CurlsCount:        1,
 	}
 	if rtOpts.Extended {
-		testCtx.tcOpts.CurlsCount = 1
 		testCtx.tcOpts.IPerfsSeconds = 10
+		testCtx.tcOpts.CurlsCount = 3
 	}
 	testCtx.wipeBetweenTests = wipeBetweenTests
 	testCtx.extName = extName


### PR DESCRIPTION
* the 'Multi-Subnets with filtering' is using local peering and so can fail if subinterfaces are not supported, tag it accordingly
* the total failure count at the end of the test was wrong if some test had been skipped at execution time, due to us not resetting the error (used for the skip message) and also counting it as a failure
* curls were not being executed unless the extended flag was selected. this was intentional to reduce testing time, but it was the wrong decision, as it's the only way we actually test external peerings right now. enable them by default
* we were not importing the default prefix from externals, so we were only testing the fact that we could not curl (as expected)
  * note that the contrary is true now, i.e. we always import the default prefix. It is probably worth covering negative tests too, as well as importing specific prefixes and testing against those, but that can be done in a separate PR

