### PR TITLE
bump: k3s to v1.32.3+k3s1 (currently latest in stable channel)

### DIFF
--- a/pkg/fab/README.md
+++ b/pkg/fab/README.md
@@ -29,7 +29,7 @@ oras push "ghcr.io/githedgehog/fabricator/flatcar-update:${FLATCAR_VERSION}" fla
 When bumping k3s version you may need to update the Fabricator's pause version as well as we're using the one from k3s.
 
 ```bash
-export K3S_VERSION="v1.32.1-k3s1"
+export K3S_VERSION="v1.32.3-k3s1"
 export K3S_VERSION_UPSTREAM="${K3S_VERSION//-/+}"
 
 wget "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION_UPSTREAM}/k3s"

--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -19,7 +19,7 @@ var (
 
 var Versions = fabapi.Versions{
 	Platform: fabapi.PlatformVersions{
-		K3s:         "v1.32.1-k3s1",
+		K3s:         "v1.32.3-k3s1",
 		Zot:         "v2.1.1",
 		CertManager: "v1.17.1",
 		K9s:         "v0.40.6",


### PR DESCRIPTION
Fixes #569 