### PR TITLE
chore: double fabricator-controller mem limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,9 +87,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 64Mi
+              memory: 128Mi
       serviceAccountName: ctrl
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
It's running over 70% mem limit, worse looking into in the future, but for now it's ok just to raise the limit to avoid OOMs.