### PR TITLE
fix: remove second k3s upgrade attempt

### DIFF
--- a/pkg/fab/recipe/control_upgrade.go
+++ b/pkg/fab/recipe/control_upgrade.go
@@ -149,10 +149,6 @@ func (c *ControlUpgrade) Run(ctx context.Context) error {
 		return fmt.Errorf("copying k9s bin: %w", err)
 	}
 
-	if err := c.upgradeK8s(ctx, kube); err != nil {
-		return fmt.Errorf("upgrading K8s: %w", err)
-	}
-
 	if err := upgradeFlatcar(ctx, string(flatcar.Version(c.Fab)), c.Yes); err != nil {
 		return fmt.Errorf("upgrading Flatcar: %w", err)
 	}


### PR DESCRIPTION
It was introduced in the https://github.com/githedgehog/fabricator/commit/66454e9026bf66734f1b6d052853afd78b3a1898