### PR TITLE
ci(vlab): test upgrades from 25.02

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -358,6 +358,9 @@ jobs:
             fromversion: "25.01"
             fromflags: "-m=iso"
           - fabricmode: spine-leaf
+            fromversion: "25.02"
+            fromflags: "-m=iso"
+          - fabricmode: spine-leaf
             fromversion: "dev"
             fromflags: "-m=iso"
 


### PR DESCRIPTION
Fixes githedgehog/internal#166