### PR TITLE
chore: ignore iperf speed for virtual switches

### DIFF
--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -46,7 +46,6 @@ import (
 
 const (
 	ServerNamePrefix        = "server-"
-	VSIPerfSpeed            = 1
 	HashPolicyL2            = "layer2"
 	HashPolicyL2And3        = "layer2+3"
 	HashPolicyL3And4        = "layer3+4"
@@ -958,12 +957,8 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 		}
 	}
 	if allVS {
-		if opts.IPerfsMinSpeed > 10*VSIPerfSpeed {
-			slog.Warn("Lowering IPerf min speed as all switches are virtual", "speed", VSIPerfSpeed)
-			opts.IPerfsMinSpeed = VSIPerfSpeed
-		} else if opts.IPerfsMinSpeed > VSIPerfSpeed {
-			slog.Warn("IPerf min speed is higher than default virtual switch speed", "speed", VSIPerfSpeed)
-		}
+		slog.Warn("All switches are virtual, ignoring IPerf min speed")
+		opts.IPerfsMinSpeed = 0
 	}
 
 	if opts.WaitSwitchesReady {


### PR DESCRIPTION
the minimal speed is a helpful tool to detect whether physical switches are software-forwarding traffic, but for virtual switches this does not apply. often release-tests on virtual switches will fail with some iperf flow being slower than the already low limit we were setting, and we have not done anything in response to that anyway otehr than restarting the test, so stop checking for that condition.