### PR TITLE
ci: run show tech for release tests

### DIFF
--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -435,8 +435,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 				if opts.CollectShowTech {
 					if err := c.VLABShowTech(ctx, vlab); err != nil {
 						slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-						return fmt.Errorf("getting show-tech: %w", err)
 					}
 				}
 
@@ -457,8 +455,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 					if opts.CollectShowTech {
 						if err := c.VLABShowTech(ctx, vlab); err != nil {
 							slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-							return fmt.Errorf("getting show-tech: %w", err)
 						}
 					}
 
@@ -593,8 +589,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						if opts.CollectShowTech {
 							if err := c.VLABShowTech(ctx, vlab); err != nil {
 								slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-								return fmt.Errorf("getting show-tech: %w", err)
 							}
 						}
 
@@ -618,8 +612,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						if opts.CollectShowTech {
 							if err := c.VLABShowTech(ctx, vlab); err != nil {
 								slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-								return fmt.Errorf("getting show-tech: %w", err)
 							}
 						}
 
@@ -638,8 +630,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						if opts.CollectShowTech {
 							if err := c.VLABShowTech(ctx, vlab); err != nil {
 								slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-								return fmt.Errorf("getting show-tech: %w", err)
 							}
 						}
 
@@ -649,8 +639,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 					if opts.CollectShowTech {
 						if err := c.VLABShowTech(ctx, vlab); err != nil {
 							slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-							return fmt.Errorf("getting show-tech: %w", err)
 						}
 					}
 
@@ -668,8 +656,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						if opts.CollectShowTech {
 							if err := c.VLABShowTech(ctx, vlab); err != nil {
 								slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-								return fmt.Errorf("getting show-tech: %w", err)
 							}
 						}
 
@@ -686,8 +672,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						if opts.CollectShowTech {
 							if err := c.VLABShowTech(ctx, vlab); err != nil {
 								slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-								return fmt.Errorf("getting show-tech: %w", err)
 							}
 						}
 
@@ -704,8 +688,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						if opts.CollectShowTech {
 							if err := c.VLABShowTech(ctx, vlab); err != nil {
 								slog.Warn("Failed to collect show-tech diagnostics", "err", err)
-
-								return fmt.Errorf("getting show-tech: %w", err)
 							}
 						}
 

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -701,6 +701,14 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 					}); err != nil {
 						slog.Warn("Failed to run release test", "err", err)
 
+						if opts.CollectShowTech {
+							if err := c.VLABShowTech(ctx, vlab); err != nil {
+								slog.Warn("Failed to collect show-tech diagnostics", "err", err)
+
+								return fmt.Errorf("getting show-tech: %w", err)
+							}
+						}
+
 						return fmt.Errorf("release test: %w", err)
 					}
 				}


### PR DESCRIPTION
Run show tech when release tests fail. Currently it is not collecting them:

https://github.com/githedgehog/fabricator/actions/runs/15806736430/job/44552621163