### PR TITLE
chore: revert "ci: temp disable macos builds due to GHA issues"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
         os:
           - ubuntu-latest-x86-4-cores
           - ubuntu-24.04-arm64-4-core
-          # - macos-latest
+          - macos-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This reverts commit 0a825aebc2959e7e95a9dd427814a6c50d1044a8.