### PR TITLE
feat: test-connectivity flag all-servers

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1042,6 +1042,12 @@ func Run(ctx context.Context) error {
 								Usage: "TOS value to use for iperf3 tests (0 to disable TOS)",
 								Value: 0,
 							},
+							&cli.BoolFlag{
+								Name:    "all-servers",
+								Aliases: []string{"all"},
+								Usage:   "requires all servers to be attached to a VPC",
+								Value:   false,
+							},
 						}),
 						Before: before(false),
 						Action: func(c *cli.Context) error {
@@ -1063,6 +1069,7 @@ func Run(ctx context.Context) error {
 								Destinations:      c.StringSlice("destination"),
 								IPerfsDSCP:        uint8(cliDSCP),
 								IPerfsTOS:         uint8(cliTOS),
+								RequireAllServers: c.Bool("all-servers"),
 							}); err != nil {
 								return fmt.Errorf("test-connectivity: %w", err)
 							}

--- a/pkg/hhfab/release.go
+++ b/pkg/hhfab/release.go
@@ -2283,6 +2283,7 @@ func makeTestCtx(kube kclient.Client, opts SetupVPCsOpts, workDir, cacheDir stri
 		IPerfsSeconds:     3,
 		IPerfsMinSpeed:    8200,
 		CurlsCount:        1,
+		RequireAllServers: opts.VPCMode == vpcapi.VPCModeL2VNI, // L3VNI will skip eslag servers
 	}
 	if rtOpts.Extended {
 		testCtx.tcOpts.IPerfsSeconds = 10


### PR DESCRIPTION
we are already skipping servers that are not attached to any VPC as part of the checks to make test-connectivity work with ESLAG and L3VNIs. However at the moment this prints a warning re ESLAG, and it could simply be that the server has no attachment. Regardless, there are situations when someone is calling test-connectivity on a manual setup where only some servers are attached to a VPC, and it is useful to be able to do so. This PR introduces a flag (all-servers) which will make the test fail if it detects that some server has no vpc attach, and fixes the message when we skip a server due to this reason. By default the flag is not set, and tests will simply skip non-attached servers.