### PR TITLE
chore: publish bash comp package

### DIFF
--- a/pkg/fab/README.md
+++ b/pkg/fab/README.md
@@ -179,3 +179,18 @@ unzip alloy-linux-amd64.zip
 mv alloy-linux-amd64 alloy
 oras push "ghcr.io/githedgehog/fabricator/alloy-bin:${ALLOY_VERSION}" alloy
 ```
+
+## Bash completion
+
+We need https://github.com/scop/bash-completion to be installed on the system. It's under GPL v2, we don't modify it by
+any means and so we publish the whole package as is and only taking needed files from it when building the installer
+with hhfab build.
+
+```bash
+export BASH_COMPLETION_VERSION="2.16.0"
+
+wget "https://github.com/scop/bash-completion/releases/download/${BASH_COMPLETION_VERSION}/bash-completion-${BASH_COMPLETION_VERSION}.tar.xz"
+tar xzf "bash-completion-${BASH_COMPLETION_VERSION}.tar.xz"
+mv bash-completion-${BASH_COMPLETION_VERSION} bash-completion
+oras push "ghcr.io/githedgehog/fabricator/bash-completion:v${BASH_COMPLETION_VERSION}" bash-completion
+```


### PR DESCRIPTION
```
/tmp/t.udt0suVzly 
09:16:36 ➜  oras pull ghcr.io/githedgehog/fabricator/bash-completion:v2.16.0                       
✓ Pulled      bash-completion                                                                                                                    604/604 KB 100.00%  211ms
  └─ sha256:1b924bc8e181b507bf8399a7501e35716dbf1d4d5805b2d0c750eea38ad9c717                                                                                              
✓ Pulled      application/vnd.oci.image.manifest.v1+json                                                                                         744/744  B 100.00%   53µs
  └─ sha256:7c691e3dcb061ed163f24f2b68787dce1dc10d6824ce64379c86b0693c5a6330                                                                                              
Pulled [registry] ghcr.io/githedgehog/fabricator/bash-completion:v2.16.0
Digest: sha256:7c691e3dcb061ed163f24f2b68787dce1dc10d6824ce64379c86b0693c5a6330

/tmp/t.udt0suVzly took 1s488ms 
09:16:42 ➜  ls -lah       
drwx------ frostman wheel  96 B  Wed Sep 17 09:16:42 2025  .
drwxrwxrwt root     wheel 736 B  Wed Sep 17 09:16:36 2025  ..
drwxr-xr-x frostman wheel 1.0 KB Wed Sep 17 09:16:42 2025  bash-completion

/tmp/t.udt0suVzly 
09:16:45 ➜  ls -lah bash-completion 
drwxr-xr-x frostman wheel 1.0 KB Wed Sep 17 09:16:42 2025  .
drwx------ frostman wheel  96 B  Wed Sep 17 09:16:42 2025  ..
.rw-r--r-- frostman wheel 272 B  Wed Dec 25 02:28:39 2024 󰅲 .dir-locals.el
.rw-r--r-- frostman wheel 338 B  Wed Dec 25 02:28:39 2024  .editorconfig
.rw-r--r-- frostman wheel 110 B  Wed Dec 25 02:28:39 2024  .perltidyrc
.rw-r--r-- frostman wheel 384 B  Wed Dec 25 02:28:39 2024  .shellcheckrc
.rw-r--r-- frostman wheel  29 KB Wed Dec 25 02:28:56 2024  aclocal.m4
.rw-r--r-- frostman wheel 285 B  Wed Dec 25 02:28:39 2024  AUTHORS
.rw-r--r-- frostman wheel 257 B  Wed Dec 25 02:28:39 2024  bash-completion-config-version.cmake.in
.rw-r--r-- frostman wheel 396 B  Wed Dec 25 02:28:39 2024  bash-completion-config.cmake.in
.rw-r--r-- frostman wheel 326 B  Wed Dec 25 02:28:39 2024  bash-completion.pc.in
.rw-r--r-- frostman wheel 124 KB Wed Dec 25 02:28:39 2024  bash_completion
drwxr-xr-x frostman wheel  96 B  Wed Sep 17 09:16:42 2025  bash_completion.d
.rw-r--r-- frostman wheel 733 B  Wed Dec 25 02:28:39 2024  bash_completion.sh.in
.rw-r--r-- frostman wheel 324 KB Wed Dec 25 02:28:39 2024  CHANGELOG.md
drwxr-xr-x frostman wheel  16 KB Wed Sep 17 09:16:42 2025  completions
.rwxr-xr-x frostman wheel  48 KB Wed Dec 25 02:28:57 2024  config.guess
.rwxr-xr-x frostman wheel  34 KB Wed Dec 25 02:28:57 2024 󰨖 config.sub
.rwxr-xr-x frostman wheel 117 KB Wed Dec 25 02:28:56 2024  configure
.rw-r--r-- frostman wheel 1.0 KB Wed Dec 25 02:28:39 2024  configure.ac
.rw-r--r-- frostman wheel  12 KB Wed Dec 25 02:28:39 2024  CONTRIBUTING.md
.rw-r--r-- frostman wheel  18 KB Wed Dec 25 02:28:39 2024  COPYING
drwxr-xr-x frostman wheel 256 B  Wed Sep 17 09:16:42 2025  doc
drwxr-xr-x frostman wheel 224 B  Wed Sep 17 09:16:42 2025  helpers
.rwxr-xr-x frostman wheel  15 KB Wed Dec 25 02:28:57 2024  install-sh
.rw-r--r-- frostman wheel 1.5 KB Wed Dec 25 02:28:39 2024  Makefile.am
.rw-r--r-- frostman wheel  31 KB Wed Dec 25 02:28:57 2024  Makefile.in
.rwxr-xr-x frostman wheel 6.7 KB Wed Dec 25 02:28:57 2024  missing
.rw-r--r-- frostman wheel 540 B  Wed Dec 25 02:28:39 2024  pyproject.toml
.rw-r--r-- frostman wheel  15 KB Wed Dec 25 02:28:39 2024  README.md
.rwxr-xr-x frostman wheel 145 B  Wed Dec 25 02:28:39 2024  setup-symlinks.sh
drwxr-xr-x frostman wheel 288 B  Wed Sep 17 09:16:42 2025  test
```