### PR TITLE
chore: default joinToken for --dev init

### DIFF
--- a/pkg/fab/initconfig.go
+++ b/pkg/fab/initconfig.go
@@ -5,6 +5,7 @@ package fab
 
 import (
 	"context"
+	"crypto/rand"
 	_ "embed"
 	"fmt"
 	"log/slog"
@@ -50,6 +51,11 @@ func InitConfig(ctx context.Context, in InitConfigInput) ([]byte, error) {
 
 		in.DefaultPasswordHash = DevAdminPasswordHash
 		in.DefaultAuthorizedKeys = append(in.DefaultAuthorizedKeys, DevSSHKey)
+
+		if in.Gateway && in.JoinToken == "" {
+			in.JoinToken = rand.Text()
+			in.SaveJoinToken = true
+		}
 	}
 
 	if in.DefaultPasswordHash != "" && !strings.HasPrefix(in.DefaultPasswordHash, "$5$") {

--- a/pkg/fab/initconfig_test.go
+++ b/pkg/fab/initconfig_test.go
@@ -388,6 +388,7 @@ func TestInitConfig(t *testing.T) {
 			f.Kind = ""
 			f.ResourceVersion = ""
 			f.Status = fabapi.FabricatorStatus{}
+			f.Spec.Config.Control.JoinToken = ""
 
 			require.NotNil(t, controls)
 


### PR DESCRIPTION
just a little QoL improvement for development and testing, as I often forget to add the joinToken until I try to run vlab up