### PR TITLE
fix(release): always use single resulting port breakout

### DIFF
--- a/pkg/hhfab/release.go
+++ b/pkg/hhfab/release.go
@@ -2246,8 +2246,9 @@ func (testCtx *VPCPeeringTestCtx) breakoutTest(ctx context.Context) (bool, []Rev
 
 			// pick a random non-default supported breakout mode
 			targetMode := ""
-			for mode := range breakoutProfile.Supported {
-				if mode != defaultBreakouts[unusedPort] {
+			for mode, breakout := range breakoutProfile.Supported {
+				// only use the breakout mode that has a single resulting port to avoid issues with max ports for the pipelines
+				if mode != defaultBreakouts[unusedPort] && len(breakout.Offsets) == 1 {
 					targetMode = mode
 
 					break


### PR DESCRIPTION
It allows to avoid issues with the pipelines and any other potential issues with finding the right port for the test. We just need to test the fact that we can change a breakout, doesn't matter which mode we're going to use.

Fixes githedgehog/internal#221