### PR TITLE
ci: migrate workflows from unavailable 'lab' runner to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ permissions:
 
 jobs:
   test-build:
-    runs-on: lab
+    runs-on: ubuntu-latest-8-cores
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   commitlint:
-    runs-on: lab
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/govulncheck-scan.yaml
+++ b/.github/workflows/govulncheck-scan.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   govulncheck:
-    runs-on: lab
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
Closes #9

## Summary
This PR migrates the `test-build`, `commitlint`, and `govulncheck` CI jobs from the unavailable self-hosted `lab` runner to GitHub-hosted runners, unblocking the CI/CD pipeline for all PRs.

## Problem Solved
- All PRs were stuck queuing indefinitely because no self-hosted runners with the `lab` label are currently online
- This was blocking all planning/design work as nothing could merge
- Specifically blocked PR #7 and any subsequent PRs

## Changes Made

### 1. `.github/workflows/ci.yaml` - test-build job
- **Before:** `runs-on: lab`
- **After:** `runs-on: ubuntu-latest-8-cores`
- **Rationale:** This job requires significant resources (Go, Docker, Just, multi-architecture builds) and the 8-core GitHub-hosted runner provides sufficient capacity

### 2. `.github/workflows/commitlint.yaml` - commitlint job
- **Before:** `runs-on: lab`
- **After:** `runs-on: ubuntu-latest`
- **Rationale:** Commitlint is a lightweight job that only validates commit message format

### 3. `.github/workflows/govulncheck-scan.yaml` - govulncheck job
- **Before:** `runs-on: lab`
- **After:** `runs-on: ubuntu-latest`
- **Rationale:** Security scanning job doesn't require special runner capabilities

## Jobs Intentionally NOT Changed

The following jobs remain on self-hosted runners as they require specific infrastructure:

- `publish-test-results`, `publish-release`, `publish-master` (in ci.yaml, lines 381, 403, 492) - These jobs run on `lab` runner for publishing and likely need specific credentials/access
- `run-vlab` workflow - Uses `vlab`/`hlab` runners for actual lab testing with physical or virtual infrastructure

## Testing
- [x] Workflows use valid GitHub-hosted runner labels
- [x] No syntax errors in YAML files
- [x] All required tooling (Go, Just, Docker) is available via GitHub Actions marketplace
- [ ] CI should execute successfully on this PR (proof that the queue clears)

## Acceptance Criteria Met
- [x] Updated `.github/workflows/ci.yaml` so test-build job runs on GitHub-hosted runner
- [x] Updated `.github/workflows/commitlint.yaml` to use GitHub-hosted runner  
- [x] Confirmed no other workflows incorrectly reference `runs-on: lab` (govulncheck also updated)
- [x] Opened PR targeting origin/master with conventional commit format
- [ ] CI runs complete successfully (will be verified by this PR)

## Additional Notes
- This change enables immediate unblocking of the CI pipeline
- The solution is fully compatible with the existing workflow structure
- No changes to actual build/test logic - only runner selection