### PR TITLE
chore: smart default for gw uplinks

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -254,9 +254,8 @@ func Run(ctx context.Context) error {
 		},
 		&cli.UintFlag{
 			Name:        "gateway-uplinks",
-			Usage:       "number of uplinks for gateway",
+			Usage:       "number of uplinks for gateway, if 0 defaults to the number of spines or mesh nodes (up to 2)",
 			Destination: &wgGatewayUplinks,
-			Value:       2,
 		},
 		&cli.StringFlag{
 			Name:        "gateway-driver",


### PR DESCRIPTION
unless specified, vlab gen will now create as many gw uplinks as spines (for spine-leaf topologies) or mesh nodes (for mesh topologies). specifying a non-zero value from the command line will override this default.

Fix #1047 