### PR TITLE
Revert "ci: fix vlabs/bundles status checks skip logic"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - bundle
-    if: ${{ needs.bundle.result != 'skipped' }}
+    if: ${{ always() }}
 
     steps:
       - run: |
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - vlab
-    if: ${{ needs.vlab.result != 'skipped' }}
+    if: ${{ always() }}
 
     steps:
       - run: |


### PR DESCRIPTION
This reverts commit c4e12be17693d1be106de6efacbebdbf376fdeb1.

We should never skip vlabs.