### PR TITLE
Prevent hang on download for OCI images with uncompressed layers

### DIFF
--- a/pkg/artificer/oci.go
+++ b/pkg/artificer/oci.go
@@ -98,6 +98,8 @@ func copyOCI(ctx context.Context, src, dst string, srcAuth, dstAuth *types.Docke
 					))
 			case types.ProgressEventSkipped:
 				// bars[digest].SetCurrent(p.Artifact.Size)
+			case types.ProgressEventDone:
+				bars[digest].SetCurrent(p.Artifact.Size)
 			default:
 				bars[digest].EwmaIncrInt64(int64(p.OffsetUpdate), time.Since(barStart[digest])) //nolint:gosec
 			}


### PR DESCRIPTION
Fix a hang that occurs when downloading OCI images containing uncompressed tar layers, caused by progress bars never completing and blocking `pb.Wait()`.

More specifically, the progress event handler was missing a case for `ProgressEventDone`, causing these events to fall through to the `default` case which only increments progress via `EwmaIncrInt64()`. This works for most images but fails for images with uncompressed layers due to a size mismatch in progress tracking.

Here's why only some images cause the process to hang. The OCI destination's `DesiredLayerCompression()` returns `types.Compress` by default, triggering different behaviour based on layer compression:

- For compressed layers (`application/vnd.oci.image.layer.v1.tar+gzip`): The source data is already compressed (for example, 30MB compressed size). No compression step is needed, data flows directly through the pipeline. `progressReader` tracks `srcInfo.Size` (30MB) compressed, and reads 30MB from source. `OffsetUpdate` events sum to 30MB and progress reaches 100%: the progress bar completes via the accumulated increments, even without explicit `ProgressEventDone` handling.

- For uncompressed layers (`application/vnd.oci.image.layer.v1.tar`): The source data is uncompressed (for example, 30MB uncompressed size). The compression step wraps the stream with the compression pipe. `progressReader` tracks the original `srcInfo.Size` (30MB, uncompressed), but actually reads from compression pipe outputting, say, ~3MB compressed instead. `OffsetUpdate` events sum to only ~3MB (10% of expected 30MB), and the progress bar remains stuck at 10% incomplete, causing `pb.Wait()` to hang indefinitely.

The size mismatch occurs because:

1. `blobPipelineCompressionStep()` sets `stream.info.Size = -1` (unknown compressed size) when compressing on-the-fly (vendor/github.com/containers/image/v5/copy/compression.go:168-170)
2. `progressReader` is created with the original `srcInfo` containing uncompressed size (vendor/github.com/containers/image/v5/copy/blob.go:92)
3. But `progressReader` reads compressed bytes from the pipe, not uncompressed bytes, so it reads fewer bytes than the expected size, so progress never reaches 100%.

It is unclear why we're now dealing with images with uncompressed layers, after seemingly avoiding it so far. We've observed the bug with dataplane images containing a different structure than before, with the root manifest being an index referring to an "attestation" in addition to the main image, but it's unclear how this change appeared.

To address the issue, we add explicit handling for `ProgressEventDone`, calling `bars[digest].SetCurrent()` to force progress bar completion regardless of accumulated increments. This bypasses the size mismatch by explicitly marking bars as complete when the `ProgressEventDone` event is received, which happens after the stream is fully consumed (via defer `progressReader.reportDone()` in vendor/github.com/containers/image/v5/copy/blob.go:94).

Identified by Claude.

:toolbox: Minimal reproducer: [reproducer.tar.gz](https://github.com/user-attachments/files/23677096/reproducer.tar.gz)