### PR TITLE
Allow defining kubeconfig to diagram a remote env

### DIFF
--- a/pkg/hhfab/cmddiagram.go
+++ b/pkg/hhfab/cmddiagram.go
@@ -19,7 +19,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Diagram(ctx context.Context, workDir, cacheDir string, live bool, format diagram.Format, style diagram.StyleType, outputPath string) error {
+func Diagram(ctx context.Context, workDir, cacheDir string, live bool, format diagram.Format, style diagram.StyleType, outputPath string, kubeconfigPath string) error {
 	resultDir := filepath.Join(workDir, ResultDir)
 	if err := os.MkdirAll(resultDir, 0o755); err != nil {
 		return fmt.Errorf("creating result directory: %w", err)
@@ -35,7 +35,12 @@ func Diagram(ctx context.Context, workDir, cacheDir string, live bool, format di
 
 		client = c.Client
 	} else {
-		kubeconfig := filepath.Join(workDir, VLABDir, VLABKubeConfig)
+		// Use provided kubeconfig path, or default to vlab kubeconfig
+		kubeconfig := kubeconfigPath
+		if kubeconfig == "" {
+			kubeconfig = filepath.Join(workDir, VLABDir, VLABKubeConfig)
+		}
+
 		cacheCancel, kube, err := kubeutil.NewClientWithCache(ctx, kubeconfig,
 			wiringapi.SchemeBuilder,
 			fabapi.SchemeBuilder,


### PR DESCRIPTION
From: https://github.com/githedgehog/fabricator/pull/1189#discussion_r2583505799

Allows you to get diagram for the running deployment in a given env:
```
pau@pau-TP-P14s:~/fabricator$ bin/hhfab diagram --live -k env-4.kubeconfig
11:48:04 INF Hedgehog Fabricator version=v0.43.1-21-ge552eea8-dirty-HI1128
11:48:07 INF Generated draw.io diagram file=result/diagram.drawio style=default
To use this diagram:
1. Open with https://app.diagrams.net/ or the desktop Draw.io application
2. You can edit the diagram and export to PNG, SVG, PDF or other formats
```