### PR TITLE
chore(show-tech): fix hardware switch collection

### DIFF
--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -598,7 +598,12 @@ func (c *Config) VLABShowTech(ctx context.Context, vlab *VLAB) error {
 				return
 			}
 
-			collectionCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			// Use longer timeout for switches since they can take 5+ minutes
+			timeout := 5 * time.Minute
+			if vmType == VMTypeSwitch {
+				timeout = 10 * time.Minute
+			}
+			collectionCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 
 			script := scriptConfig.Scripts[vmType]


### PR DESCRIPTION
Comes from https://github.com/githedgehog/fabricator/pull/1117/files but just fixing the listing of hardware switches. I will fix the collection when VLAB is being shut down in another PR