### PR TITLE
ci: fix workflow dispatch to run test-connectivity again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,6 +237,7 @@ jobs:
             || matrix.upgradefrom != '' && contains(github.event.pull_request.labels.*.name, 'ci:-upgrade')
           )
           || github.event_name == 'workflow_dispatch'
+          && (inputs.releasetest_vlab == true || inputs.releasetest_hlab == true)
           && (
             matrix.hybrid && inputs.releasetest_hlab != true
             || !matrix.hybrid && inputs.releasetest_vlab != true


### PR DESCRIPTION
When we merged https://github.com/githedgehog/fabricator/pull/1241 I tested that we could run release tests separately on vlab/hlab/both but I didn't check what happened if we didn't select any checkbox

In master, currently if we run via workflow dispatch without any option selected no VLAB is run:
<img width="381" height="493" alt="image" src="https://github.com/user-attachments/assets/0d4ef351-ded4-4868-8c36-a371313c3899" />
https://github.com/githedgehog/fabricator/actions/runs/20713961745
