### PR TITLE
Address CI VLAB stability with targeted waits when using Virtual Switches

### DIFF
--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	waitAppliedFor = 15 * time.Second
-	waitTimeout    = 5 * time.Minute
+	waitAppliedFor   = 15 * time.Second
+	waitAppliedForVS = 60 * time.Second // extended wait for virtual switches
+	waitTimeout      = 5 * time.Minute
 )
 
 var (
@@ -675,6 +676,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 			if sw.Spec.Profile == meta.SwitchProfileVS {
 				slog.Warn("Virtual switch found, some tests will be skipped", "switch", sw.Name)
 				skipFlags.VirtualSwitch = true
+				testCtx.wrOpts.AppliedFor = waitAppliedForVS
 			}
 		}
 		// check for leaf switches supporting subinterfaces and/or RoCE


### PR DESCRIPTION
This PR contains a few commits that were tested in a previous experimental PR that was addressing CI failures incrementally and grew out of control: https://github.com/githedgehog/fabricator/pull/1201

Addresses: 
https://github.com/githedgehog/fabricator/issues/981 https://github.com/githedgehog/fabricator/issues/1223