### PR TITLE
replace on-ready setup-vpcs / setup-peerings / test-connectivity with basic release test scenario

### DIFF
--- a/.github/workflows/ci-normal-run-test-coverage.md
+++ b/.github/workflows/ci-normal-run-test-coverage.md
@@ -1,0 +1,68 @@
+# CI Normal Run — Test Coverage
+
+This describes what is tested when `releasetest=false` (the default for non-release CI runs).
+
+## What runs
+
+With `releasetest=false`, the workflow passes `--release-test-on-ready-only`, which runs **only** the `OnReady Suite` (a single compact test — `New VLAB OnReady Test`) rather than the full release test matrix.
+
+## VLAB topology generated
+
+The topology is parameterized by `vpcmode` and `mesh`:
+
+| Input | MCLAG leaves | ESLAG groups | Orphan leaves | Unbundled servers | Externals |
+|---|---|---|---|---|---|
+| `vpcmode=l2vni,mesh=false` (default) | 2 | 2 | 1 | 1 | 1 BGP + 1 static |
+| `vpcmode=l3vni,mesh=false` | 0 | 0 | 3 | 2 | 1 BGP + 1 static |
+| `vpcmode=l2vni,mesh=true` | 0 | 2 | 1 | 2 | 1 BGP + 1 static |
+| `vpcmode=l3vni,mesh=true` | 0 | 0 | 3 | 2 | 1 BGP + 1 static |
+
+All topologies include one external BGP attachment and one non-proxy static external attachment (via `--externals-bgp=1 --externals-static=1 --external-orphan-connections=1`).
+
+Gateway (`--gateways=2 / 0`) is controlled independently by the `gateway` input.
+
+## What the OnReady test covers
+
+### Preconditions (test fails if not met)
+- At least 7 eligible servers (ESLAG servers excluded in non-l2vni mode)
+- At least one BGP external with an attachment
+- At least one static external with a non-proxy attachment
+
+### VPC and attachment setup
+
+| VPC | Subnets | Servers | Notes |
+|---|---|---|---|
+| `ort-a` | 2 regular DHCP subnets | 1 per subnet | Any available servers |
+| `ort-b` | 1 hostBGP subnet | 1 unbundled, non-MCLAG | Runs `host-bgp` docker container; waits for VIP acquisition |
+| `ort-c` | 1 regular DHCP subnet | 2 non-MCLAG servers on **different switches** | Tests multi-switch attachment to the same subnet |
+| `ort-d1..N` | 1 regular DHCP subnet each | 1 server each | All remaining servers |
+
+All VPCs are created with the active `vpcmode`. Server networking is configured via `hhnet`; L3VNI/L3Flat mode gets an extra 10 s propagation wait after server setup.
+
+### Peerings applied
+
+| Type | Participants |
+|---|---|
+| ExternalPeering | `ort-d1` → BGP external (subnet-01, 0.0.0.0/0) |
+| ExternalPeering | `ort-d2` → static non-proxy external (subnet-01, 0.0.0.0/0) |
+| VPCPeering | `ort-b` ↔ `ort-a` (hostBGP VPC ↔ regular dual-subnet VPC) |
+| GatewayPeering *(gateway only)* | Consecutive pairs: `ort-d2` ↔ `ort-d3`, `ort-d3` ↔ `ort-d4`, … |
+
+`ort-d1` (BGP external peer) is intentionally excluded from gateway peerings to avoid an LPM route asymmetry with the static external VRF.
+
+### Connectivity test
+
+After all peerings are applied, `DoVLABTestConnectivity` runs against the configured topology.
+
+### Cleanup
+
+All created VPCs, peerings, and server network configurations are torn down regardless of test outcome.
+
+## Effect of key CI inputs on test behaviour
+
+| Input | Effect |
+|---|---|
+| `vpcmode=l3vni` | ESLAG servers skipped; no MCLAG topology; extra route propagation wait |
+| `gateway=true` | GatewayPeerings created between consecutive `ort-d2..N` VPCs; `NoGateway` skip lifted |
+| `gateway=false` | Gateway peerings skipped; test still passes as long as other preconditions are met |
+| `mesh=true` | No MCLAG topology; mesh-only switch connections (does not affect the on-ready test logic directly) |

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -272,7 +272,24 @@ jobs:
             --include-onie=${{ inputs.includeonie }} \
             --gateways=${{ inputs.gateway && 2 || 0 }} \
             ${{ inputs.custom_init_args }}
-          bin/hhfab vlab gen -v ${{ inputs.mesh && '--mesh-links-count=3 --unbundled-servers=2' || '' }} \
+          VLAB_MCLAG_LEAVES=2
+          VLAB_ESLAG_GROUPS=2
+          VLAB_ORPHAN_LEAVES=1
+          VLAB_MESH_LINKS=0
+          VLAB_UNBUNDLED_SERVERS=1
+          if [[ ${{ inputs.vpcmode }} == "l3vni" ]]; then
+            VLAB_MCLAG_LEAVES=0
+            VLAB_ESLAG_GROUPS=""
+            VLAB_ORPHAN_LEAVES=3
+            VLAB_UNBUNDLED_SERVERS=2
+          fi
+          if [[ ${{ inputs.mesh }} == "true" ]]; then
+            VLAB_MESH_LINKS=3
+            VLAB_MCLAG_LEAVES=0
+            VLAB_ORPHAN_LEAVES=3
+          fi
+          bin/hhfab vlab gen -v --mesh-links-count=$VLAB_MESH_LINKS --mclag-leafs-count=$VLAB_MCLAG_LEAVES \
+            --eslag-leaf-groups=$VLAB_ESLAG_GROUPS --orphan-leafs-count=$VLAB_ORPHAN_LEAVES --unbundled-servers=$VLAB_UNBUNDLED_SERVERS \
             --externals-bgp=1 --externals-static=1 --externals-static-proxy=1 --external-orphan-connections=1 \
             ${{ inputs.custom_gen_args }}
 

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -321,16 +321,28 @@ jobs:
           fi
 
           export HHFAB_JOIN_TOKEN=$(openssl rand -base64 24)
+
+          HHFAB_TEST_ARGS=(--ready=release-test)
+          if [[ "${{ inputs.releasetest }}" == "true" ]]; then
+            if [[ -n "${{ inputs.releasetest_regex }}" ]]; then
+              HHFAB_TEST_ARGS+=("--release-test-regexes=${{ inputs.releasetest_regex }}")
+              if [[ "${{ inputs.releasetest_regex_invert }}" == "true" ]]; then
+                HHFAB_TEST_ARGS+=(--release-test-regexes-invert)
+              fi
+            fi
+          elif [[ -n "${{ inputs.upgradefrom }}" ]]; then
+            HHFAB_TEST_ARGS=(--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity)
+          else
+            HHFAB_TEST_ARGS+=(--release-test-on-ready-only)
+          fi
+          echo "HHFAB_TEST_ARGS: ${HHFAB_TEST_ARGS[*]}"
           bin/hhfab vlab up -v \
             --build-mode="${{ inputs.buildmode }}" \
             --vpc-mode="${{ inputs.vpcmode }}" \
             ${{ inputs.hybrid && '--controls-restricted=false' || '' }} \
             ${{ (inputs.upgradefrom == '' && inputs.hybrid) && '--ready switch-reinstall' || '' }} \
             --ready=inspect \
-            ${{ inputs.upgradefrom != '' && '--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity' || '--ready=release-test' }} \
-            ${{ (inputs.upgradefrom == '' && !inputs.releasetest) && '--release-test-on-ready-only' || '' }} \
-            ${{ (inputs.releasetest && inputs.releasetest_regex) && format('--release-test-regexes="{0}"', inputs.releasetest_regex) || '' }} \
-            ${{ (inputs.releasetest && inputs.releasetest_regex_invert) && '--release-test-regexes-invert' || '' }} \
+            "${HHFAB_TEST_ARGS[@]}" \
             --ready=exit \
             ${{ inputs.pause_on_failure && inputs.debug && '--pause-on-failure' || '' }} \
             ${{ inputs.upgradefrom != '' && '--upgrade' || '' }}

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -272,7 +272,9 @@ jobs:
             --include-onie=${{ inputs.includeonie }} \
             --gateways=${{ inputs.gateway && 2 || 0 }} \
             ${{ inputs.custom_init_args }}
-          bin/hhfab vlab gen -v ${{ inputs.mesh && '--mesh-links-count=3' || '' }} ${{ inputs.custom_gen_args }}
+          bin/hhfab vlab gen -v ${{ inputs.mesh && '--mesh-links-count=3 --unbundled-servers=2' || '' }} \
+            --externals-bgp=1 --externals-static=1 --externals-static-proxy=1 --external-orphan-connections=1 \
+            ${{ inputs.custom_gen_args }}
 
       - name: Init hhfab for hybrid mode
         if: ${{ inputs.upgradefrom == '' && inputs.hybrid }}
@@ -308,12 +310,10 @@ jobs:
             ${{ inputs.hybrid && '--controls-restricted=false' || '' }} \
             ${{ (inputs.upgradefrom == '' && inputs.hybrid) && '--ready switch-reinstall' || '' }} \
             --ready=inspect \
-            --ready=setup-vpcs \
-            --ready=setup-peerings \
-            --ready=test-connectivity \
-            ${{ inputs.releasetest && '--ready=release-test' || '' }} \
-            ${{ inputs.releasetest_regex && format('--release-test-regexes="{0}"', inputs.releasetest_regex) || '' }} \
-            ${{ inputs.releasetest_regex_invert && '--release-test-regexes-invert' || '' }} \
+            ${{ inputs.upgradefrom != '' && '--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity' || '--ready=release-test' }} \
+            ${{ (inputs.upgradefrom == '' && !inputs.releasetest) && '--release-test-on-ready-only' || '' }} \
+            ${{ (inputs.releasetest && inputs.releasetest_regex) && format('--release-test-regexes="{0}"', inputs.releasetest_regex) || '' }} \
+            ${{ (inputs.releasetest && inputs.releasetest_regex_invert) && '--release-test-regexes-invert' || '' }} \
             --ready=exit \
             ${{ inputs.pause_on_failure && inputs.debug && '--pause-on-failure' || '' }} \
             ${{ inputs.upgradefrom != '' && '--upgrade' || '' }}

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -290,7 +290,7 @@ jobs:
           fi
           bin/hhfab vlab gen -v --mesh-links-count=$VLAB_MESH_LINKS --mclag-leafs-count=$VLAB_MCLAG_LEAVES \
             --eslag-leaf-groups=$VLAB_ESLAG_GROUPS --orphan-leafs-count=$VLAB_ORPHAN_LEAVES --unbundled-servers=$VLAB_UNBUNDLED_SERVERS \
-            --externals-bgp=1 --externals-static=1 --externals-static-proxy=1 --external-orphan-connections=1 \
+            --externals-bgp=1 --externals-static=1 --external-orphan-connections=1 \
             ${{ inputs.custom_gen_args }}
 
       - name: Init hhfab for hybrid mode

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -265,6 +265,9 @@ jobs:
           path: build-diagnostics
 
       - name: Init hhfab for virtual mode
+        env:
+          INPUT_VPC_MODE: ${{ inputs.vpcmode }}
+          INPUT_MESH: ${{ inputs.mesh }}
         if: ${{ inputs.upgradefrom == '' && !inputs.hybrid }}
         run: |
           bin/hhfab init -v --dev \
@@ -277,16 +280,16 @@ jobs:
           VLAB_ORPHAN_LEAVES=1
           VLAB_MESH_LINKS=0
           VLAB_UNBUNDLED_SERVERS=1
-          if [[ ${{ inputs.vpcmode }} == "l3vni" ]]; then
+          if [[ "$INPUT_MESH" == "true" ]]; then
+            VLAB_MESH_LINKS=3
+            VLAB_MCLAG_LEAVES=0
+            VLAB_UNBUNDLED_SERVERS=2
+          fi
+          if [[ "$INPUT_VPC_MODE" == "l3vni" ]]; then
             VLAB_MCLAG_LEAVES=0
             VLAB_ESLAG_GROUPS=""
             VLAB_ORPHAN_LEAVES=3
             VLAB_UNBUNDLED_SERVERS=2
-          fi
-          if [[ ${{ inputs.mesh }} == "true" ]]; then
-            VLAB_MESH_LINKS=3
-            VLAB_MCLAG_LEAVES=0
-            VLAB_ORPHAN_LEAVES=3
           fi
           bin/hhfab vlab gen -v --mesh-links-count=$VLAB_MESH_LINKS --mclag-leafs-count=$VLAB_MCLAG_LEAVES \
             --eslag-leaf-groups=$VLAB_ESLAG_GROUPS --orphan-leafs-count=$VLAB_ORPHAN_LEAVES --unbundled-servers=$VLAB_UNBUNDLED_SERVERS \
@@ -314,6 +317,10 @@ jobs:
 
       # TODO: make controls restricted again when we figure out how to get NTP upstream working for isolated VMs
       - name: ${{ inputs.upgradefrom != '' && 'Upgrade' || 'Run' }} and test ${{ inputs.hybrid && 'hybrid ' || '' }}VLAB
+        env:
+          INPUT_VPC_MODE: ${{ inputs.vpcmode }}
+          INPUT_BUILD_MODE: ${{ inputs.buildmode }}
+          INPUT_RT_REGEX: ${{ inputs.releasetest_regex }}
         id: test-current
         run: |
           if [[ "${{ inputs.hybrid }}" == "true" ]]; then
@@ -321,16 +328,28 @@ jobs:
           fi
 
           export HHFAB_JOIN_TOKEN=$(openssl rand -base64 24)
+
+          HHFAB_TEST_ARGS=(--ready=release-test)
+          if [[ "${{ inputs.releasetest }}" == "true" ]]; then
+            if [[ -n "$INPUT_RT_REGEX" ]]; then
+              HHFAB_TEST_ARGS+=("--release-test-regexes=$INPUT_RT_REGEX")
+              if [[ "${{ inputs.releasetest_regex_invert }}" == "true" ]]; then
+                HHFAB_TEST_ARGS+=(--release-test-regexes-invert)
+              fi
+            fi
+          elif [[ -n "${{ inputs.upgradefrom }}" ]]; then
+            HHFAB_TEST_ARGS=(--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity)
+          else
+            HHFAB_TEST_ARGS+=(--release-test-on-ready-only)
+          fi
+          echo "HHFAB_TEST_ARGS: ${HHFAB_TEST_ARGS[*]}"
           bin/hhfab vlab up -v \
-            --build-mode="${{ inputs.buildmode }}" \
-            --vpc-mode="${{ inputs.vpcmode }}" \
+            --build-mode="$INPUT_BUILD_MODE" \
+            --vpc-mode="$INPUT_VPC_MODE" \
             ${{ inputs.hybrid && '--controls-restricted=false' || '' }} \
             ${{ (inputs.upgradefrom == '' && inputs.hybrid) && '--ready switch-reinstall' || '' }} \
             --ready=inspect \
-            ${{ inputs.upgradefrom != '' && '--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity' || '--ready=release-test' }} \
-            ${{ (inputs.upgradefrom == '' && !inputs.releasetest) && '--release-test-on-ready-only' || '' }} \
-            ${{ (inputs.releasetest && inputs.releasetest_regex) && format('--release-test-regexes="{0}"', inputs.releasetest_regex) || '' }} \
-            ${{ (inputs.releasetest && inputs.releasetest_regex_invert) && '--release-test-regexes-invert' || '' }} \
+            "${HHFAB_TEST_ARGS[@]}" \
             --ready=exit \
             ${{ inputs.pause_on_failure && inputs.debug && '--pause-on-failure' || '' }} \
             ${{ inputs.upgradefrom != '' && '--upgrade' || '' }}

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -272,7 +272,9 @@ jobs:
             --include-onie=${{ inputs.includeonie }} \
             --gateways=${{ inputs.gateway && 2 || 0 }} \
             ${{ inputs.custom_init_args }}
-          bin/hhfab vlab gen -v --externals-bgp=1 --externals-static=1 --external-orphan-connections=1 ${{ inputs.mesh && '--mesh-links-count=3' || '' }} ${{ inputs.custom_gen_args }}
+          bin/hhfab vlab gen -v ${{ inputs.mesh && '--mesh-links-count=3 --unbundled-servers=2' || '' }} \
+            --externals-bgp=1 --externals-static=1 --externals-static-proxy=1 --external-orphan-connections=1 \
+            ${{ inputs.custom_gen_args }}
 
       - name: Init hhfab for hybrid mode
         if: ${{ inputs.upgradefrom == '' && inputs.hybrid }}
@@ -308,12 +310,10 @@ jobs:
             ${{ inputs.hybrid && '--controls-restricted=false' || '' }} \
             ${{ (inputs.upgradefrom == '' && inputs.hybrid) && '--ready switch-reinstall' || '' }} \
             --ready=inspect \
-            --ready=setup-vpcs \
-            --ready=setup-peerings \
-            --ready=test-connectivity \
-            ${{ inputs.releasetest && '--ready=release-test' || '' }} \
-            ${{ inputs.releasetest_regex && format('--release-test-regexes="{0}"', inputs.releasetest_regex) || '' }} \
-            ${{ inputs.releasetest_regex_invert && '--release-test-regexes-invert' || '' }} \
+            ${{ inputs.upgradefrom != '' && '--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity' || '--ready=release-test' }} \
+            ${{ (inputs.upgradefrom == '' && !inputs.releasetest) && '--release-test-on-ready-only' || '' }} \
+            ${{ (inputs.releasetest && inputs.releasetest_regex) && format('--release-test-regexes="{0}"', inputs.releasetest_regex) || '' }} \
+            ${{ (inputs.releasetest && inputs.releasetest_regex_invert) && '--release-test-regexes-invert' || '' }} \
             --ready=exit \
             ${{ inputs.pause_on_failure && inputs.debug && '--pause-on-failure' || '' }} \
             ${{ inputs.upgradefrom != '' && '--upgrade' || '' }}

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -89,6 +89,8 @@ const (
 	FlagGatewayLogLevel           = "gateway-log-level"
 	FlagGatewayTag                = "gateway-tag"
 	FlagShowTech                  = "show-tech"
+	FlagReleaseTestOnReadyOnly    = "release-test-on-ready-only"
+	FlagOnReadyOnly               = "on-ready-only"
 )
 
 func main() {
@@ -1151,6 +1153,11 @@ func Run(ctx context.Context) error {
 								Aliases: []string{"rt-invert"},
 								Usage:   "invert regex selection for release tests (used when --ready=release-test)",
 							},
+							&cli.BoolFlag{
+								Name:    FlagReleaseTestOnReadyOnly,
+								Aliases: []string{"rt-or"},
+								Usage:   "run only the special on-ready suite (used when --ready=release-test)",
+							},
 							&cli.UintFlag{
 								Category: FlagCatVMSizes,
 								Name:     "control-cpus",
@@ -1261,6 +1268,7 @@ func Run(ctx context.Context) error {
 									VPCMode:                  vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
 									ReleaseTestRegexes:       c.StringSlice(FlagReleaseTestRegexes),
 									ReleaseTestRegexesInvert: c.Bool(FlagReleaseTestRegexesInvert),
+									ReleaseTestOnReadyOnly:   c.Bool(FlagReleaseTestOnReadyOnly),
 									InterfaceMTU:             ifMTU,
 								},
 							}); err != nil {
@@ -1725,6 +1733,11 @@ func Run(ctx context.Context) error {
 								Usage:   "collect show-tech diagnostics on failure",
 								Value:   true,
 							},
+							&cli.BoolFlag{
+								Name:    FlagOnReadyOnly,
+								Aliases: []string{"on-ready", "o"},
+								Usage:   "Run only the special OnReady test suite, replacing old on-ready vlab jobs",
+							},
 						}),
 						Before: before(false),
 						Action: func(c *cli.Context) error {
@@ -1739,6 +1752,7 @@ func Run(ctx context.Context) error {
 								VPCMode:        vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
 								ListTests:      c.Bool(FlagListTests),
 								ShowTechDump:   c.Bool(FlagShowTech),
+								OnReadyTest:    c.Bool(FlagOnReadyOnly),
 							}
 							if err := hhfab.DoVLABReleaseTest(ctx, workDir, cacheDir, opts); err != nil {
 								return fmt.Errorf("release-test: %w", err)

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -90,6 +90,8 @@ const (
 	FlagGatewayTag                = "gateway-tag"
 	FlagShowTech                  = "show-tech"
 	FlagIPerfsSpeed               = "iperfs-speed"
+	FlagReleaseTestOnReadyOnly    = "release-test-on-ready-only"
+	FlagOnReadyOnly               = "on-ready-only"
 )
 
 func main() {
@@ -1152,6 +1154,11 @@ func Run(ctx context.Context) error {
 								Aliases: []string{"rt-invert"},
 								Usage:   "invert regex selection for release tests (used when --ready=release-test)",
 							},
+							&cli.BoolFlag{
+								Name:    FlagReleaseTestOnReadyOnly,
+								Aliases: []string{"rt-or"},
+								Usage:   "run only the special on-ready suite (used when --ready=release-test)",
+							},
 							&cli.UintFlag{
 								Category: FlagCatVMSizes,
 								Name:     "control-cpus",
@@ -1262,6 +1269,7 @@ func Run(ctx context.Context) error {
 									VPCMode:                  vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
 									ReleaseTestRegexes:       c.StringSlice(FlagReleaseTestRegexes),
 									ReleaseTestRegexesInvert: c.Bool(FlagReleaseTestRegexesInvert),
+									ReleaseTestOnReadyOnly:   c.Bool(FlagReleaseTestOnReadyOnly),
 									InterfaceMTU:             ifMTU,
 								},
 							}); err != nil {
@@ -1740,6 +1748,11 @@ Examples:
 								Usage: "minimum speed in Mbits/s for iperf3 test to consider successful (0 to not check speeds)",
 								Value: 8200,
 							},
+							&cli.BoolFlag{
+								Name:    FlagOnReadyOnly,
+								Aliases: []string{"on-ready", "o"},
+								Usage:   "Run only the special OnReady test suite, replacing old on-ready vlab jobs",
+							},
 						}),
 						Before: before(false),
 						Action: func(c *cli.Context) error {
@@ -1759,6 +1772,7 @@ Examples:
 								ListTests:      c.Bool(FlagListTests),
 								ShowTechDump:   c.Bool(FlagShowTech),
 								IPerfsMinSpeed: iperfsSpeed,
+								OnReadyTest:    c.Bool(FlagOnReadyOnly),
 							}
 							if err := hhfab.DoVLABReleaseTest(ctx, workDir, cacheDir, opts); err != nil {
 								return fmt.Errorf("release-test: %w", err)

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -230,11 +230,11 @@ func DoVLABInspect(ctx context.Context, workDir, cacheDir string, opts InspectOp
 
 func DoVLABReleaseTest(ctx context.Context, workDir, cacheDir string, opts ReleaseTestOpts) error {
 	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
-	if err != nil {
+	if err != nil && !opts.ListTests {
 		return err
 	}
 
-	return c.ReleaseTest(ctx, vlab, opts)
+	return ReleaseTest(ctx, c, vlab, opts)
 }
 
 type SwitchPowerOpts struct {

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -66,6 +66,7 @@ type VPCPeeringTestCtx struct {
 	roceLeaves       []string
 	noSetup          bool
 	showTechDump     bool
+	skipFlags        SkipFlags
 }
 
 // Test function types
@@ -719,6 +720,28 @@ func selectAndRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, suite *J
 	return suite, nil
 }
 
+func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
+	slog.Info("*** Recap of the test results ***")
+	for _, suite := range results {
+		printSuiteResults(&suite)
+	}
+
+	if rtOtps.ResultsFile != "" {
+		report := JUnitReport{
+			Suites: results,
+		}
+		output, err := xml.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshalling XML: %w", err)
+		}
+		if err := os.WriteFile(rtOtps.ResultsFile, output, 0o600); err != nil {
+			return fmt.Errorf("writing XML file: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOtps ReleaseTestOpts) error {
 	testStart := time.Now()
 
@@ -762,11 +785,18 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	}
 
 	testCtx := makeTestCtx(ctx, kube, setupOpts, vlabCfg, vlab, false, rtOtps)
+	var suites []*JUnitTestSuite
 	noVpcSuite := makeNoVpcsSuite(testCtx)
 	singleVpcSuite := makeSingleVPCSuite(testCtx)
 	multiVPCMultiSubnetSuite := makeMultiVPCMultiSubnetSuite(testCtx)
 	multiVPCSingleSubnetSuite := makeMultiVPCSingleSubnetSuite(testCtx)
-	suites := []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
+	ortSuite := makeOnReadyTestSuite(testCtx)
+
+	if rtOtps.OnReadyTest {
+		suites = []*JUnitTestSuite{ortSuite}
+	} else {
+		suites = []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
+	}
 
 	if rtOtps.ListTests {
 		for _, suite := range suites {
@@ -972,8 +1002,29 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		slog.Info("No Prometheus target found, Prometheus test will be skipped")
 	}
 
+	// save skip flags in test context so that tests can adapt to the limitations of the topology
+	testCtx.skipFlags = skipFlags
+
 	results := []JUnitTestSuite{}
 	testCtx.noSetup = true
+
+	if rtOtps.OnReadyTest {
+		ortResults, err := selectAndRunSuite(ctx, testCtx, ortSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
+		if err != nil && rtOtps.FailFast {
+			return fmt.Errorf("running on-ready test suite: %w", err)
+		}
+		results = append(results, *ortResults)
+		if err := recapAndReport(results, rtOtps); err != nil {
+			return fmt.Errorf("recapping and reporting results: %w", err)
+		}
+		slog.Info("OnReady Test Suite completed", "duration", time.Since(testStart).String())
+		if ortResults.Failures > 0 {
+			return fmt.Errorf("some tests failed: onReady=%d", ortResults.Failures) //nolint:goerr113
+		}
+
+		return nil
+	}
+
 	noVpcResults, err := selectAndRunSuite(ctx, testCtx, noVpcSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
 	if err != nil && rtOtps.FailFast {
 		return fmt.Errorf("running no VPC suite: %w", err)
@@ -1002,22 +1053,8 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	}
 	results = append(results, *basicResults)
 
-	slog.Info("*** Recap of the test results ***")
-	for _, suite := range results {
-		printSuiteResults(&suite)
-	}
-
-	if rtOtps.ResultsFile != "" {
-		report := JUnitReport{
-			Suites: results,
-		}
-		output, err := xml.MarshalIndent(report, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshalling XML: %w", err)
-		}
-		if err := os.WriteFile(rtOtps.ResultsFile, output, 0o600); err != nil {
-			return fmt.Errorf("writing XML file: %w", err)
-		}
+	if err := recapAndReport(results, rtOtps); err != nil {
+		return fmt.Errorf("recapping and reporting results: %w", err)
 	}
 
 	slog.Info("All tests completed", "duration", time.Since(testStart).String())

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -150,16 +150,38 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		return false
 	}
 
-	// hasStaticAttachment checks that at least one attachment for the external has
-	// Spec.Static configured, which is required for static external tests to work.
-	hasStaticAttachment := func(extName string) bool {
+	// hasStaticAttachments checks that all attachments for the external are static,
+	// which is required for static external tests to work.
+	// externals with proxied attachments are discarded (they need gw peering instead)
+	hasStaticAttachments := func(extName string) bool {
+		var proxy, nonProxy, retVal bool
 		for _, attach := range extAttachList.Items {
-			if attach.Spec.External == extName && attach.Spec.Static != nil {
-				return true
+			if attach.Spec.External == extName {
+				if attach.Spec.Static == nil {
+					slog.Warn("Non-static attachment for static external", "attachment", attach.Name, "external", extName)
+
+					return false
+				}
+				if attach.Spec.Static.Proxy {
+					proxy = true
+				} else {
+					nonProxy = true
+				}
 			}
 		}
 
-		return false
+		switch {
+		case !proxy && !nonProxy:
+			slog.Debug("Skipping static external with no attachments", "external", extName)
+		case proxy && nonProxy:
+			slog.Warn("Mixed proxied and non-proxied static external attachments, skipping external", "external", extName)
+		case proxy:
+			slog.Debug("Skipping proxied static external", "external", extName)
+		case nonProxy:
+			retVal = true
+		}
+
+		return retVal
 	}
 
 	allAttachmentsHW := func(extName string) bool {
@@ -184,7 +206,7 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		if !isHardware(&ext) || !hasAttachment(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachments(ext.Name) {
 			staticExt = ext.Name
 			slog.Info("Using hardware static external", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {
@@ -201,7 +223,7 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		if !hasAttachment(ext.Name) || !allAttachmentsHW(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachments(ext.Name) {
 			staticExt = ext.Name
 			slog.Info("Using virtual static external (hw-attached)", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -742,13 +742,13 @@ func selectAndRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, suite *J
 	return suite, nil
 }
 
-func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
+func recapAndReport(results []JUnitTestSuite, rtOpts ReleaseTestOpts) error {
 	slog.Info("*** Recap of the test results ***")
 	for _, suite := range results {
 		printSuiteResults(&suite)
 	}
 
-	if rtOtps.ResultsFile != "" {
+	if rtOpts.ResultsFile != "" {
 		report := JUnitReport{
 			Suites: results,
 		}
@@ -756,7 +756,7 @@ func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
 		if err != nil {
 			return fmt.Errorf("marshalling XML: %w", err)
 		}
-		if err := os.WriteFile(rtOtps.ResultsFile, output, 0o600); err != nil {
+		if err := os.WriteFile(rtOpts.ResultsFile, output, 0o600); err != nil {
 			return fmt.Errorf("writing XML file: %w", err)
 		}
 	}
@@ -764,7 +764,7 @@ func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
 	return nil
 }
 
-func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOtps ReleaseTestOpts) error {
+func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOpts ReleaseTestOpts) error {
 	testStart := time.Now()
 
 	cacheCancel, kube, err := getKubeClientWithCache(ctx, vlabCfg.WorkDir)
@@ -794,8 +794,8 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		SubnetsPerVPC:     subnetsPerVpc,
 		VLANNamespace:     "default",
 		IPv4Namespace:     "default",
-		HashPolicy:        rtOtps.HashPolicy,
-		VPCMode:           rtOtps.VPCMode,
+		HashPolicy:        rtOpts.HashPolicy,
+		VPCMode:           rtOpts.VPCMode,
 	}
 
 	// Resolve the default server MTU up front so testCtx.setupOpts.InterfaceMTU
@@ -806,7 +806,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		return fmt.Errorf("resolving default server MTU: %w", err)
 	}
 
-	testCtx := makeTestCtx(ctx, kube, setupOpts, vlabCfg, vlab, false, rtOtps)
+	testCtx := makeTestCtx(ctx, kube, setupOpts, vlabCfg, vlab, false, rtOpts)
 	var suites []*JUnitTestSuite
 	noVpcSuite := makeNoVpcsSuite(testCtx)
 	singleVpcSuite := makeSingleVPCSuite(testCtx)
@@ -814,13 +814,13 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	multiVPCSingleSubnetSuite := makeMultiVPCSingleSubnetSuite(testCtx)
 	ortSuite := makeOnReadyTestSuite(testCtx)
 
-	if rtOtps.OnReadyTest {
+	if rtOpts.OnReadyTest {
 		suites = []*JUnitTestSuite{ortSuite}
 	} else {
 		suites = []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
 	}
 
-	if rtOtps.ListTests {
+	if rtOpts.ListTests {
 		for _, suite := range suites {
 			printTestSuite(suite)
 		}
@@ -829,7 +829,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	}
 
 	regexesCompiled := make([]*regexp.Regexp, 0)
-	for _, regex := range rtOtps.Regexes {
+	for _, regex := range rtOpts.Regexes {
 		compiled, err := regexp.Compile(regex)
 		if err != nil {
 			return fmt.Errorf("compiling regex %s: %w", regex, err)
@@ -839,7 +839,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 
 	// detect if any of the skipFlags conditions are true
 	skipFlags := SkipFlags{
-		ExtendedOnly: rtOtps.Extended,
+		ExtendedOnly: rtOpts.Extended,
 		NoServers:    noServers,
 	}
 	connList := &wiringapi.ConnectionList{}
@@ -1030,13 +1030,13 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	results := []JUnitTestSuite{}
 	testCtx.noSetup = true
 
-	if rtOtps.OnReadyTest {
-		ortResults, err := selectAndRunSuite(ctx, testCtx, ortSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-		if err != nil && rtOtps.FailFast {
+	if rtOpts.OnReadyTest {
+		ortResults, err := selectAndRunSuite(ctx, testCtx, ortSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+		if err != nil && rtOpts.FailFast {
 			return fmt.Errorf("running on-ready test suite: %w", err)
 		}
 		results = append(results, *ortResults)
-		if err := recapAndReport(results, rtOtps); err != nil {
+		if err := recapAndReport(results, rtOpts); err != nil {
 			return fmt.Errorf("recapping and reporting results: %w", err)
 		}
 		slog.Info("OnReady Test Suite completed", "duration", time.Since(testStart).String())
@@ -1047,35 +1047,35 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		return nil
 	}
 
-	noVpcResults, err := selectAndRunSuite(ctx, testCtx, noVpcSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	noVpcResults, err := selectAndRunSuite(ctx, testCtx, noVpcSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running no VPC suite: %w", err)
 	}
 	results = append(results, *noVpcResults)
 
 	testCtx.noSetup = false
-	singleVpcResults, err := selectAndRunSuite(ctx, testCtx, singleVpcSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	singleVpcResults, err := selectAndRunSuite(ctx, testCtx, singleVpcSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running single VPC suite: %w", err)
 	}
 	results = append(results, *singleVpcResults)
 
 	testCtx.setupOpts.ServersPerSubnet = 1
-	multiVpcResults, err := selectAndRunSuite(ctx, testCtx, multiVPCMultiSubnetSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	multiVpcResults, err := selectAndRunSuite(ctx, testCtx, multiVPCMultiSubnetSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running multi VPC suite: %w", err)
 	}
 	results = append(results, *multiVpcResults)
 
 	testCtx.setupOpts.SubnetsPerVPC = 1
 	testCtx.wipeBetweenTests = true
-	basicResults, err := selectAndRunSuite(ctx, testCtx, multiVPCSingleSubnetSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	basicResults, err := selectAndRunSuite(ctx, testCtx, multiVPCSingleSubnetSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running basic VPC suite: %w", err)
 	}
 	results = append(results, *basicResults)
 
-	if err := recapAndReport(results, rtOtps); err != nil {
+	if err := recapAndReport(results, rtOpts); err != nil {
 		return fmt.Errorf("recapping and reporting results: %w", err)
 	}
 

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -151,16 +151,38 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		return false
 	}
 
-	// hasStaticAttachment checks that at least one attachment for the external has
-	// Spec.Static configured, which is required for static external tests to work.
-	hasStaticAttachment := func(extName string) bool {
+	// hasStaticAttachments checks that all attachments for the external are static,
+	// which is required for static external tests to work.
+	// externals with proxied attachments are discarded (they need gw peering instead)
+	hasStaticAttachments := func(extName string) bool {
+		var proxy, nonProxy, retVal bool
 		for _, attach := range extAttachList.Items {
-			if attach.Spec.External == extName && attach.Spec.Static != nil {
-				return true
+			if attach.Spec.External == extName {
+				if attach.Spec.Static == nil {
+					slog.Warn("Non-static attachment for static external", "attachment", attach.Name, "external", extName)
+
+					return false
+				}
+				if attach.Spec.Static.Proxy {
+					proxy = true
+				} else {
+					nonProxy = true
+				}
 			}
 		}
 
-		return false
+		switch {
+		case !proxy && !nonProxy:
+			slog.Debug("Skipping static external with no attachments", "external", extName)
+		case proxy && nonProxy:
+			slog.Warn("Mixed proxied and non-proxied static external attachments, skipping external", "external", extName)
+		case proxy:
+			slog.Debug("Skipping proxied static external", "external", extName)
+		case nonProxy:
+			retVal = true
+		}
+
+		return retVal
 	}
 
 	allAttachmentsHW := func(extName string) bool {
@@ -185,7 +207,7 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		if !isHardware(&ext) || !hasAttachment(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachments(ext.Name) {
 			staticExt = ext.Name
 			slog.Info("Using hardware static external", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {
@@ -202,7 +224,7 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		if !hasAttachment(ext.Name) || !allAttachmentsHW(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachments(ext.Name) {
 			staticExt = ext.Name
 			slog.Info("Using virtual static external (hw-attached)", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {
@@ -219,7 +241,7 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		if !hasAttachment(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachments(ext.Name) {
 			staticExt = ext.Name
 			slog.Info("Using virtual static external (virtual switch)", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {
@@ -939,46 +961,6 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 			slog.Warn("No viable static external found, static external tests will be skipped")
 			skipFlags.NoStaticExternals = true
 		}
-	}
-
-	// Check for static externals have attachments
-	skipFlags.NoStaticExternals = true
-	for _, ext := range extList.Items {
-		if ext.Spec.Static != nil && len(ext.Spec.Static.Prefixes) > 0 {
-			// Check if it has at least one static attachment configured
-			extAttachList := &vpcapi.ExternalAttachmentList{}
-			if err := kube.List(ctx, extAttachList, kclient.MatchingLabels{vpcapi.LabelExternal: ext.Name}); err != nil {
-				slog.Warn("Failed to list external attachments for static external", "external", ext.Name, "error", err)
-
-				continue
-			}
-
-			// Find an attachment with static config
-			hasStaticAttach := false
-			for _, attach := range extAttachList.Items {
-				if attach.Spec.Static != nil {
-					hasStaticAttach = true
-					slog.Debug("Found static attachment", "external", ext.Name, "attachment", attach.Name)
-
-					break
-				}
-			}
-
-			if !hasStaticAttach {
-				slog.Debug("Static external has no static attachments configured", "external", ext.Name)
-
-				continue
-			}
-
-			testCtx.staticExtName = ext.Name
-			skipFlags.NoStaticExternals = false
-			slog.Info("Found static external with attachment for testing", "external", ext.Name)
-
-			break
-		}
-	}
-	if skipFlags.NoStaticExternals {
-		slog.Info("No static externals with attachments found, static external tests will be skipped")
 	}
 
 	fabricator := &fabricatorapi.Fabricator{}

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -75,11 +75,11 @@ type VPCPeeringTestCtx struct {
 // to be run after the test is done, regardless of whether it succeeded or failed.
 type RevertFunc func(context.Context) error
 
-// A test function is a function that runs a test. It takes a context and returns
+// A test function is a function that runs a test. It takes a go context and a test context, and returns
 // a boolean indicating whether the test was skipped (e.g. due to missing resources),
 // a list of revert functions to be run after the test, and an error if the test failed.
 // note that the error contains the reason for the skip if the test was skipped.
-type TestFunc func(context.Context) (bool, []RevertFunc, error)
+type TestFunc func(context.Context, *VPCPeeringTestCtx) (bool, []RevertFunc, error)
 
 // Utilities and suite runners
 
@@ -492,7 +492,7 @@ func doRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, ts *JUnitTestSu
 		}
 		prevRevertsFailed = false
 		testStart := time.Now()
-		skip, reverts, err := test.F(ctx)
+		skip, reverts, err := test.F(ctx, testCtx)
 		ts.TestCases[i].Time = time.Since(testStart).Seconds()
 		ranSomeTests = true
 		// logic is getting complex, so let's make a recap:
@@ -785,6 +785,27 @@ func recapAndReport(results []JUnitTestSuite, rtOpts ReleaseTestOpts) error {
 func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOpts ReleaseTestOpts) error {
 	testStart := time.Now()
 
+	var suites []*JUnitTestSuite
+	noVpcSuite := makeNoVpcsSuite()
+	singleVpcSuite := makeSingleVPCSuite()
+	multiVPCMultiSubnetSuite := makeMultiVPCMultiSubnetSuite()
+	multiVPCSingleSubnetSuite := makeMultiVPCSingleSubnetSuite()
+	ortSuite := makeOnReadyTestSuite()
+
+	if rtOpts.OnReadyTest {
+		suites = []*JUnitTestSuite{ortSuite}
+	} else {
+		suites = []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
+	}
+
+	if rtOpts.ListTests {
+		for _, suite := range suites {
+			printTestSuite(suite)
+		}
+
+		return nil
+	}
+
 	cacheCancel, kube, err := getKubeClientWithCache(ctx, vlabCfg.WorkDir)
 	if err != nil {
 		return err
@@ -825,26 +846,6 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOp
 	}
 
 	testCtx := makeTestCtx(ctx, kube, setupOpts, vlabCfg, vlab, false, rtOpts)
-	var suites []*JUnitTestSuite
-	noVpcSuite := makeNoVpcsSuite(testCtx)
-	singleVpcSuite := makeSingleVPCSuite(testCtx)
-	multiVPCMultiSubnetSuite := makeMultiVPCMultiSubnetSuite(testCtx)
-	multiVPCSingleSubnetSuite := makeMultiVPCSingleSubnetSuite(testCtx)
-	ortSuite := makeOnReadyTestSuite(testCtx)
-
-	if rtOpts.OnReadyTest {
-		suites = []*JUnitTestSuite{ortSuite}
-	} else {
-		suites = []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
-	}
-
-	if rtOpts.ListTests {
-		for _, suite := range suites {
-			printTestSuite(suite)
-		}
-
-		return nil
-	}
 
 	regexesCompiled := make([]*regexp.Regexp, 0)
 	for _, regex := range rtOpts.Regexes {

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -760,13 +760,13 @@ func selectAndRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, suite *J
 	return suite, nil
 }
 
-func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
+func recapAndReport(results []JUnitTestSuite, rtOpts ReleaseTestOpts) error {
 	slog.Info("*** Recap of the test results ***")
 	for _, suite := range results {
 		printSuiteResults(&suite)
 	}
 
-	if rtOtps.ResultsFile != "" {
+	if rtOpts.ResultsFile != "" {
 		report := JUnitReport{
 			Suites: results,
 		}
@@ -774,7 +774,7 @@ func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
 		if err != nil {
 			return fmt.Errorf("marshalling XML: %w", err)
 		}
-		if err := os.WriteFile(rtOtps.ResultsFile, output, 0o600); err != nil {
+		if err := os.WriteFile(rtOpts.ResultsFile, output, 0o600); err != nil {
 			return fmt.Errorf("writing XML file: %w", err)
 		}
 	}
@@ -782,7 +782,7 @@ func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
 	return nil
 }
 
-func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOtps ReleaseTestOpts) error {
+func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOpts ReleaseTestOpts) error {
 	testStart := time.Now()
 
 	cacheCancel, kube, err := getKubeClientWithCache(ctx, vlabCfg.WorkDir)
@@ -812,8 +812,8 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		SubnetsPerVPC:     subnetsPerVpc,
 		VLANNamespace:     "default",
 		IPv4Namespace:     "default",
-		HashPolicy:        rtOtps.HashPolicy,
-		VPCMode:           rtOtps.VPCMode,
+		HashPolicy:        rtOpts.HashPolicy,
+		VPCMode:           rtOpts.VPCMode,
 	}
 
 	// Resolve the default server MTU up front so testCtx.setupOpts.InterfaceMTU
@@ -824,7 +824,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		return fmt.Errorf("resolving default server MTU: %w", err)
 	}
 
-	testCtx := makeTestCtx(ctx, kube, setupOpts, vlabCfg, vlab, false, rtOtps)
+	testCtx := makeTestCtx(ctx, kube, setupOpts, vlabCfg, vlab, false, rtOpts)
 	var suites []*JUnitTestSuite
 	noVpcSuite := makeNoVpcsSuite(testCtx)
 	singleVpcSuite := makeSingleVPCSuite(testCtx)
@@ -832,13 +832,13 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	multiVPCSingleSubnetSuite := makeMultiVPCSingleSubnetSuite(testCtx)
 	ortSuite := makeOnReadyTestSuite(testCtx)
 
-	if rtOtps.OnReadyTest {
+	if rtOpts.OnReadyTest {
 		suites = []*JUnitTestSuite{ortSuite}
 	} else {
 		suites = []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
 	}
 
-	if rtOtps.ListTests {
+	if rtOpts.ListTests {
 		for _, suite := range suites {
 			printTestSuite(suite)
 		}
@@ -847,7 +847,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	}
 
 	regexesCompiled := make([]*regexp.Regexp, 0)
-	for _, regex := range rtOtps.Regexes {
+	for _, regex := range rtOpts.Regexes {
 		compiled, err := regexp.Compile(regex)
 		if err != nil {
 			return fmt.Errorf("compiling regex %s: %w", regex, err)
@@ -857,7 +857,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 
 	// detect if any of the skipFlags conditions are true
 	skipFlags := SkipFlags{
-		ExtendedOnly: rtOtps.Extended,
+		ExtendedOnly: rtOpts.Extended,
 		NoServers:    noServers,
 	}
 	connList := &wiringapi.ConnectionList{}
@@ -1008,13 +1008,13 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	results := []JUnitTestSuite{}
 	testCtx.noSetup = true
 
-	if rtOtps.OnReadyTest {
-		ortResults, err := selectAndRunSuite(ctx, testCtx, ortSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-		if err != nil && rtOtps.FailFast {
+	if rtOpts.OnReadyTest {
+		ortResults, err := selectAndRunSuite(ctx, testCtx, ortSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+		if err != nil && rtOpts.FailFast {
 			return fmt.Errorf("running on-ready test suite: %w", err)
 		}
 		results = append(results, *ortResults)
-		if err := recapAndReport(results, rtOtps); err != nil {
+		if err := recapAndReport(results, rtOpts); err != nil {
 			return fmt.Errorf("recapping and reporting results: %w", err)
 		}
 		slog.Info("OnReady Test Suite completed", "duration", time.Since(testStart).String())
@@ -1025,35 +1025,35 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		return nil
 	}
 
-	noVpcResults, err := selectAndRunSuite(ctx, testCtx, noVpcSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	noVpcResults, err := selectAndRunSuite(ctx, testCtx, noVpcSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running no VPC suite: %w", err)
 	}
 	results = append(results, *noVpcResults)
 
 	testCtx.noSetup = false
-	singleVpcResults, err := selectAndRunSuite(ctx, testCtx, singleVpcSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	singleVpcResults, err := selectAndRunSuite(ctx, testCtx, singleVpcSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running single VPC suite: %w", err)
 	}
 	results = append(results, *singleVpcResults)
 
 	testCtx.setupOpts.ServersPerSubnet = 1
-	multiVpcResults, err := selectAndRunSuite(ctx, testCtx, multiVPCMultiSubnetSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	multiVpcResults, err := selectAndRunSuite(ctx, testCtx, multiVPCMultiSubnetSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running multi VPC suite: %w", err)
 	}
 	results = append(results, *multiVpcResults)
 
 	testCtx.setupOpts.SubnetsPerVPC = 1
 	testCtx.wipeBetweenTests = true
-	basicResults, err := selectAndRunSuite(ctx, testCtx, multiVPCSingleSubnetSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
-	if err != nil && rtOtps.FailFast {
+	basicResults, err := selectAndRunSuite(ctx, testCtx, multiVPCSingleSubnetSuite, regexesCompiled, rtOpts.InvertRegex, skipFlags)
+	if err != nil && rtOpts.FailFast {
 		return fmt.Errorf("running basic VPC suite: %w", err)
 	}
 	results = append(results, *basicResults)
 
-	if err := recapAndReport(results, rtOtps); err != nil {
+	if err := recapAndReport(results, rtOpts); err != nil {
 		return fmt.Errorf("recapping and reporting results: %w", err)
 	}
 

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -66,6 +66,7 @@ type VPCPeeringTestCtx struct {
 	roceLeaves       []string
 	noSetup          bool
 	showTechDump     bool
+	skipFlags        SkipFlags
 }
 
 // Test function types
@@ -737,6 +738,28 @@ func selectAndRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, suite *J
 	return suite, nil
 }
 
+func recapAndReport(results []JUnitTestSuite, rtOtps ReleaseTestOpts) error {
+	slog.Info("*** Recap of the test results ***")
+	for _, suite := range results {
+		printSuiteResults(&suite)
+	}
+
+	if rtOtps.ResultsFile != "" {
+		report := JUnitReport{
+			Suites: results,
+		}
+		output, err := xml.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshalling XML: %w", err)
+		}
+		if err := os.WriteFile(rtOtps.ResultsFile, output, 0o600); err != nil {
+			return fmt.Errorf("writing XML file: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOtps ReleaseTestOpts) error {
 	testStart := time.Now()
 
@@ -780,11 +803,18 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	}
 
 	testCtx := makeTestCtx(ctx, kube, setupOpts, vlabCfg, vlab, false, rtOtps)
+	var suites []*JUnitTestSuite
 	noVpcSuite := makeNoVpcsSuite(testCtx)
 	singleVpcSuite := makeSingleVPCSuite(testCtx)
 	multiVPCMultiSubnetSuite := makeMultiVPCMultiSubnetSuite(testCtx)
 	multiVPCSingleSubnetSuite := makeMultiVPCSingleSubnetSuite(testCtx)
-	suites := []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
+	ortSuite := makeOnReadyTestSuite(testCtx)
+
+	if rtOtps.OnReadyTest {
+		suites = []*JUnitTestSuite{ortSuite}
+	} else {
+		suites = []*JUnitTestSuite{noVpcSuite, singleVpcSuite, multiVPCMultiSubnetSuite, multiVPCSingleSubnetSuite}
+	}
 
 	if rtOtps.ListTests {
 		for _, suite := range suites {
@@ -990,8 +1020,29 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 		slog.Info("No Prometheus target found, Prometheus test will be skipped")
 	}
 
+	// save skip flags in test context so that tests can adapt to the limitations of the topology
+	testCtx.skipFlags = skipFlags
+
 	results := []JUnitTestSuite{}
 	testCtx.noSetup = true
+
+	if rtOtps.OnReadyTest {
+		ortResults, err := selectAndRunSuite(ctx, testCtx, ortSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
+		if err != nil && rtOtps.FailFast {
+			return fmt.Errorf("running on-ready test suite: %w", err)
+		}
+		results = append(results, *ortResults)
+		if err := recapAndReport(results, rtOtps); err != nil {
+			return fmt.Errorf("recapping and reporting results: %w", err)
+		}
+		slog.Info("OnReady Test Suite completed", "duration", time.Since(testStart).String())
+		if ortResults.Failures > 0 {
+			return fmt.Errorf("some tests failed: onReady=%d", ortResults.Failures) //nolint:goerr113
+		}
+
+		return nil
+	}
+
 	noVpcResults, err := selectAndRunSuite(ctx, testCtx, noVpcSuite, regexesCompiled, rtOtps.InvertRegex, skipFlags)
 	if err != nil && rtOtps.FailFast {
 		return fmt.Errorf("running no VPC suite: %w", err)
@@ -1020,22 +1071,8 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	}
 	results = append(results, *basicResults)
 
-	slog.Info("*** Recap of the test results ***")
-	for _, suite := range results {
-		printSuiteResults(&suite)
-	}
-
-	if rtOtps.ResultsFile != "" {
-		report := JUnitReport{
-			Suites: results,
-		}
-		output, err := xml.MarshalIndent(report, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshalling XML: %w", err)
-		}
-		if err := os.WriteFile(rtOtps.ResultsFile, output, 0o600); err != nil {
-			return fmt.Errorf("writing XML file: %w", err)
-		}
+	if err := recapAndReport(results, rtOtps); err != nil {
+		return fmt.Errorf("recapping and reporting results: %w", err)
 	}
 
 	slog.Info("All tests completed", "duration", time.Since(testStart).String())

--- a/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
@@ -27,18 +27,18 @@ const (
 	StaticExternalDummyIface = "10.199.0.100"
 )
 
-func makeMultiVPCMultiSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
+func makeMultiVPCMultiSubnetSuite() *JUnitTestSuite {
 	suite := &JUnitTestSuite{
 		Name: "Multi-Subnet Multi-VPC Suite",
 	}
 	suite.TestCases = []JUnitTestCase{
 		{
 			Name: "Multi-Subnets no restrictions",
-			F:    testCtx.noRestrictionsTest,
+			F:    noRestrictionsTest,
 		},
 		{
 			Name: "Multi-Subnets isolation",
-			F:    testCtx.multiSubnetsIsolationTest,
+			F:    multiSubnetsIsolationTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoServers:     true,
@@ -46,7 +46,7 @@ func makeMultiVPCMultiSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Multi-Subnets with filtering",
-			F:    testCtx.multiSubnetsSubnetFilteringTest,
+			F:    multiSubnetsSubnetFilteringTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				SubInterfaces: true,
@@ -55,7 +55,7 @@ func makeMultiVPCMultiSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "StaticExternal",
-			F:    testCtx.staticExternalTest,
+			F:    staticExternalTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoServers:     true,
@@ -74,7 +74,7 @@ func makeMultiVPCMultiSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 // 2. Override isolation with explicit permit list, test connectivity
 // 3. Set restricted flag in subnet-02 in vpc2, test connectivity
 // 4. Remove all restrictions and peerings
-func (testCtx *VPCPeeringTestCtx) multiSubnetsIsolationTest(ctx context.Context) (bool, []RevertFunc, error) {
+func multiSubnetsIsolationTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	var returnErr error
 	var vpc1, vpc2 *vpcapi.VPC
 
@@ -210,7 +210,7 @@ func (testCtx *VPCPeeringTestCtx) multiSubnetsIsolationTest(ctx context.Context)
 // Assumes the scenario has at least 2 VPCs with at least 2 subnets each.
 // It creates peering between them, but restricts the peering to only
 // one subnet each. It then tests connectivity.
-func (testCtx *VPCPeeringTestCtx) multiSubnetsSubnetFilteringTest(ctx context.Context) (bool, []RevertFunc, error) {
+func multiSubnetsSubnetFilteringTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcList := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcList); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -311,7 +311,7 @@ func (testCtx *VPCPeeringTestCtx) pingStaticExternal(ctx context.Context, source
  * 10a. repeat tests 7a and 7b from a switch that's not the one the static external is attached to (should succeed)
  * 11. cleanup everything and restore the original state
  */
-func (testCtx *VPCPeeringTestCtx) staticExternalTest(ctx context.Context) (bool, []RevertFunc, error) {
+func staticExternalTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// find an unbundled connection not attached to an MCLAG switch (see https://github.com/githedgehog/fabricator/issues/673#issuecomment-3028423762)
 	connList := &wiringapi.ConnectionList{}
 	if err := testCtx.kube.List(ctx, connList, kclient.MatchingLabels{wiringapi.LabelConnectionType: wiringapi.ConnectionTypeUnbundled}); err != nil {

--- a/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
@@ -179,9 +179,13 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullMeshAllExternalsTest(ctx contex
 		return false, nil, fmt.Errorf("populating full mesh VPC peerings: %w", err)
 	}
 
-	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec, 6)
-	if err := populateAllExternalVpcPeerings(ctx, testCtx.kube, externalPeerings); err != nil {
-		return false, nil, fmt.Errorf("populating all external VPC peerings: %w", err)
+	externalPeerings := map[string]*vpcapi.ExternalPeeringSpec{}
+	if testCtx.skipFlags.VirtualSwitch {
+		slog.Warn("Skipping external peerings as there are virtual switches, which would lead to unwanted VPC peerings via the external")
+	} else {
+		if err := populateAllExternalVpcPeerings(ctx, testCtx.kube, externalPeerings); err != nil {
+			return false, nil, fmt.Errorf("populating all external VPC peerings: %w", err)
+		}
 	}
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, nil, true); err != nil {
@@ -191,7 +195,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullMeshAllExternalsTest(ctx contex
 		return false, nil, err
 	}
 
-	// bonus: remove one external to make sure we do not leek access to it, test again
+	// bonus: remove one external to make sure we do not leak access to it, test again
 	if len(externalPeerings) < 2 {
 		slog.Warn("Not enough external peerings to remove one and check for leaks, skipping next step")
 	} else {
@@ -235,14 +239,20 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsOnlyExternalsTest(ctx context.Conte
 }
 
 // Test connectivity between all VPCs in a full loop configuration, including all externals.
+// Note: if switches are virtual we skip external peerings, as VS do not implement ACLs and VPCs
+// end up peering via the external, making the test fail
 func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullLoopAllExternalsTest(ctx context.Context) (bool, []RevertFunc, error) {
-	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec, 6)
+	vpcPeerings := map[string]*vpcapi.VPCPeeringSpec{}
 	if err := populateFullLoopVpcPeerings(ctx, testCtx.kube, vpcPeerings); err != nil {
 		return false, nil, fmt.Errorf("populating full loop VPC peerings: %w", err)
 	}
-	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec, 6)
-	if err := populateAllExternalVpcPeerings(ctx, testCtx.kube, externalPeerings); err != nil {
-		return false, nil, fmt.Errorf("populating all external VPC peerings: %w", err)
+	externalPeerings := map[string]*vpcapi.ExternalPeeringSpec{}
+	if testCtx.skipFlags.VirtualSwitch {
+		slog.Warn("Skipping external peerings as there are virtual switches, which would lead to unwanted VPC peerings via the external")
+	} else {
+		if err := populateAllExternalVpcPeerings(ctx, testCtx.kube, externalPeerings); err != nil {
+			return false, nil, fmt.Errorf("populating all external VPC peerings: %w", err)
+		}
 	}
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, nil, true); err != nil {
 		return false, nil, fmt.Errorf("setting up peerings: %w", err)

--- a/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
@@ -13,14 +13,14 @@ import (
 	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
 )
 
-func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
+func makeMultiVPCSingleSubnetSuite() *JUnitTestSuite {
 	suite := &JUnitTestSuite{
 		Name: "Multi-VPC Single-Subnet Suite",
 	}
 	suite.TestCases = []JUnitTestCase{
 		{
 			Name: "Starter Test",
-			F:    testCtx.vpcPeeringsStarterTest,
+			F:    vpcPeeringsStarterTest,
 			SkipFlags: SkipFlags{
 				NoBGPExternals: true,
 				SubInterfaces:  true,
@@ -30,7 +30,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Only Externals",
-			F:    testCtx.vpcPeeringsOnlyExternalsTest,
+			F:    vpcPeeringsOnlyExternalsTest,
 			SkipFlags: SkipFlags{
 				NoBGPExternals: true,
 				SubInterfaces:  true,
@@ -40,7 +40,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Full Mesh All Externals",
-			F:    testCtx.vpcPeeringsFullMeshAllExternalsTest,
+			F:    vpcPeeringsFullMeshAllExternalsTest,
 			SkipFlags: SkipFlags{
 				SubInterfaces: true,
 				NoServers:     true,
@@ -48,7 +48,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Full Loop All Externals",
-			F:    testCtx.vpcPeeringsFullLoopAllExternalsTest,
+			F:    vpcPeeringsFullLoopAllExternalsTest,
 			SkipFlags: SkipFlags{
 				SubInterfaces: true,
 				NoServers:     true,
@@ -57,7 +57,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Sergei's Special Test",
-			F:    testCtx.vpcPeeringsSergeisSpecialTest,
+			F:    vpcPeeringsSergeisSpecialTest,
 			SkipFlags: SkipFlags{
 				NoBGPExternals: true,
 				SubInterfaces:  true,
@@ -66,7 +66,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Gateway Peering",
-			F:    testCtx.gatewayPeeringTest,
+			F:    gatewayPeeringTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 				NoServers: true,
@@ -74,7 +74,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Gateway Failover",
-			F:    testCtx.gatewayFailoverTest,
+			F:    gatewayFailoverTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 				NoServers: true,
@@ -82,7 +82,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Gateway Peering Loop",
-			F:    testCtx.gatewayPeeringLoopTest,
+			F:    gatewayPeeringLoopTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 				NoServers: true,
@@ -90,7 +90,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Mixed VPC and Gateway Peering Loop",
-			F:    testCtx.gatewayMixedPeeringLoopTest,
+			F:    gatewayMixedPeeringLoopTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 				NoServers: true,
@@ -98,7 +98,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Mixed Gateway and Fabric External Peering",
-			F:    testCtx.mixedGatewayAndFabricExternals,
+			F:    mixedGatewayAndFabricExternals,
 			SkipFlags: SkipFlags{
 				NoBGPExternals: true,
 				NoGateway:      true,
@@ -108,7 +108,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Static External Peering",
-			F:    testCtx.staticExternalPeeringTest,
+			F:    staticExternalPeeringTest,
 			SkipFlags: SkipFlags{
 				NoStaticExternals: true,
 				SubInterfaces:     true,
@@ -118,9 +118,9 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 	}
 
 	// Add NAT test cases
-	suite.TestCases = append(suite.TestCases, getNATTestCases(testCtx)...)
+	suite.TestCases = append(suite.TestCases, getNATTestCases()...)
 	// Add external NAT test cases
-	suite.TestCases = append(suite.TestCases, getExternalNATTestCases(testCtx)...)
+	suite.TestCases = append(suite.TestCases, getExternalNATTestCases()...)
 	suite.Tests = len(suite.TestCases)
 
 	return suite
@@ -130,7 +130,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 // It was presumably chosen because going from this to a full mesh configuration could trigger
 // the gNMI bug. Note that in order to reproduce it one should disable the forced cleanup between
 // tests.
-func (testCtx *VPCPeeringTestCtx) vpcPeeringsStarterTest(ctx context.Context) (bool, []RevertFunc, error) {
+func vpcPeeringsStarterTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// 1+2:r=border 1+3 3+5 2+4 4+6 5+6 6+7 7+8 8+9  5~default--5835:s=subnet-01 6~default--5835:s=subnet-01  1~default--5835:s=subnet-01  2~default--5835:s=subnet-01  9~default--5835:s=subnet-01  7~default--5835:s=subnet-01
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
@@ -177,7 +177,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsStarterTest(ctx context.Context) (b
 
 // Test connectivity between all VPCs in a full mesh configuration, including all externals
 // Then, remove one external peering and test connectivity again.
-func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullMeshAllExternalsTest(ctx context.Context) (bool, []RevertFunc, error) {
+func vpcPeeringsFullMeshAllExternalsTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec, 15)
 	if err := populateFullMeshVpcPeerings(ctx, testCtx.kube, vpcPeerings); err != nil {
 		return false, nil, fmt.Errorf("populating full mesh VPC peerings: %w", err)
@@ -195,7 +195,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullMeshAllExternalsTest(ctx contex
 		return false, nil, err
 	}
 
-	// bonus: remove one external to make sure we do not leek access to it, test again
+	// bonus: remove one external to make sure we do not leak access to it, test again
 	if len(externalPeerings) < 2 {
 		slog.Warn("Not enough external peerings to remove one and check for leaks, skipping next step")
 	} else {
@@ -217,7 +217,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullMeshAllExternalsTest(ctx contex
 }
 
 // Test connectivity between all VPCs with no peering except of the external ones.
-func (testCtx *VPCPeeringTestCtx) vpcPeeringsOnlyExternalsTest(ctx context.Context) (bool, []RevertFunc, error) {
+func vpcPeeringsOnlyExternalsTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec, 0)
 	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec, 6)
 	if err := populateAllExternalVpcPeerings(ctx, testCtx.kube, externalPeerings); err != nil {
@@ -239,7 +239,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsOnlyExternalsTest(ctx context.Conte
 }
 
 // Test connectivity between all VPCs in a full loop configuration, including all externals.
-func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullLoopAllExternalsTest(ctx context.Context) (bool, []RevertFunc, error) {
+func vpcPeeringsFullLoopAllExternalsTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec, 6)
 	if err := populateFullLoopVpcPeerings(ctx, testCtx.kube, vpcPeerings); err != nil {
 		return false, nil, fmt.Errorf("populating full loop VPC peerings: %w", err)
@@ -259,7 +259,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsFullLoopAllExternalsTest(ctx contex
 }
 
 // Arbitrary configuration which again was shown to occasionally trigger the gNMI bug.
-func (testCtx *VPCPeeringTestCtx) vpcPeeringsSergeisSpecialTest(ctx context.Context) (bool, []RevertFunc, error) {
+func vpcPeeringsSergeisSpecialTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// 1+2 2+3 2+4:r=border 6+5 1~default--5835:s=subnet-01
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
@@ -296,7 +296,7 @@ func (testCtx *VPCPeeringTestCtx) vpcPeeringsSergeisSpecialTest(ctx context.Cont
 // Test basic gateway peering connectivity between two VPCs.
 // Creates a gateway peering between the first two VPCs found, exposing all subnets
 // from each VPC, then tests connectivity to ensure traffic flows through the gateway.
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -330,7 +330,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringTest(ctx context.Context) (bool,
 
 // Test gateway peering in a loop configuration where each VPC peers with the next one.
 // VPC1↔VPC2↔VPC3↔...↔VPCn↔VPC1. Test connectivity in a complete loop.
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringLoopTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringLoopTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -409,7 +409,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringLoopTest(ctx context.Context) (b
 
 // Test combining VPC peering and gateway peering in an alternating loop configuration.
 // Create alternating VPC and gateway peerings to form a complete loop through all VPCs.
-func (testCtx *VPCPeeringTestCtx) gatewayMixedPeeringLoopTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayMixedPeeringLoopTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -456,7 +456,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayMixedPeeringLoopTest(ctx context.Contex
 }
 
 // Test combining external peering via fabric and via gateway.
-func (testCtx *VPCPeeringTestCtx) mixedGatewayAndFabricExternals(ctx context.Context) (bool, []RevertFunc, error) {
+func mixedGatewayAndFabricExternals(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)

--- a/pkg/hhfab/rt_nat_external_tests.go
+++ b/pkg/hhfab/rt_nat_external_tests.go
@@ -137,7 +137,7 @@ func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Contex
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) bgpExternalNoNatTest(ctx context.Context) (bool, []RevertFunc, error) {
+func bgpExternalNoNatTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.extName == "" {
 		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
 	}
@@ -194,7 +194,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalNoNatTest(ctx context.Context) (boo
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) bgpExternalStaticNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func bgpExternalStaticNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.extName == "" {
 		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
 	}
@@ -269,7 +269,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalStaticNATTest(ctx context.Context) 
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradeNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func bgpExternalMasqueradeNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.extName == "" {
 		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
 	}
@@ -352,7 +352,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradeNATTest(ctx context.Conte
 //	          - Protocol: TCP
 //	            Port: 5201
 //	            As: 15201
-func (testCtx *VPCPeeringTestCtx) bgpExternalPortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func bgpExternalPortForwardNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.extName == "" {
 		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
 	}
@@ -456,7 +456,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalPortForwardNATTest(ctx context.Cont
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradePortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func bgpExternalMasqueradePortForwardNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.extName == "" {
 		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
 	}
@@ -530,7 +530,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradePortForwardNATTest(ctx co
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) staticExternalNoNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+func staticExternalNoNATGatewayTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.staticExtName == "" {
 		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
 	}
@@ -587,7 +587,7 @@ func (testCtx *VPCPeeringTestCtx) staticExternalNoNATGatewayTest(ctx context.Con
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) staticExternalStaticNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+func staticExternalStaticNATGatewayTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.staticExtName == "" {
 		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
 	}
@@ -662,7 +662,7 @@ func (testCtx *VPCPeeringTestCtx) staticExternalStaticNATGatewayTest(ctx context
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradeNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+func staticExternalMasqueradeNATGatewayTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.staticExtName == "" {
 		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
 	}
@@ -805,7 +805,7 @@ func (testCtx *VPCPeeringTestCtx) testIperfToExternal(ctx context.Context, vpc *
 //	          - Protocol: TCP
 //	            Port: 5201
 //	            As: 15201
-func (testCtx *VPCPeeringTestCtx) staticExternalPortForwardNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+func staticExternalPortForwardNATGatewayTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.staticExtName == "" {
 		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
 	}
@@ -909,7 +909,7 @@ func (testCtx *VPCPeeringTestCtx) staticExternalPortForwardNATGatewayTest(ctx co
 //	    Expose:
 //	      Ips:
 //	        Cidr:  0.0.0.0/0
-func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradePortForwardNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+func staticExternalMasqueradePortForwardNATGatewayTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.staticExtName == "" {
 		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
 	}
@@ -971,11 +971,11 @@ func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradePortForwardNATGatewayT
 }
 
 // getExternalNATTestCases returns the external NAT test cases
-func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
+func getExternalNATTestCases() []JUnitTestCase {
 	return []JUnitTestCase{
 		{
 			Name: "Gateway Peering BGP External No NAT",
-			F:    testCtx.bgpExternalNoNatTest,
+			F:    bgpExternalNoNatTest,
 			SkipFlags: SkipFlags{
 				NoGateway:      true,
 				NoBGPExternals: true,
@@ -983,7 +983,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering BGP External Static NAT",
-			F:    testCtx.bgpExternalStaticNATTest,
+			F:    bgpExternalStaticNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway:      true,
 				NoBGPExternals: true,
@@ -991,7 +991,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering BGP External Masquerade NAT",
-			F:    testCtx.bgpExternalMasqueradeNATTest,
+			F:    bgpExternalMasqueradeNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway:      true,
 				NoBGPExternals: true,
@@ -999,7 +999,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering BGP External Port Forward NAT",
-			F:    testCtx.bgpExternalPortForwardNATTest,
+			F:    bgpExternalPortForwardNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway:      true,
 				NoBGPExternals: true,
@@ -1007,7 +1007,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering BGP External Masquerade and Port Forward NAT",
-			F:    testCtx.bgpExternalMasqueradePortForwardNATTest,
+			F:    bgpExternalMasqueradePortForwardNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway:      true,
 				NoBGPExternals: true,
@@ -1015,7 +1015,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering Static External No NAT",
-			F:    testCtx.staticExternalNoNATGatewayTest,
+			F:    staticExternalNoNATGatewayTest,
 			SkipFlags: SkipFlags{
 				NoGateway:         true,
 				NoStaticExternals: true,
@@ -1023,7 +1023,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering Static External Static NAT",
-			F:    testCtx.staticExternalStaticNATGatewayTest,
+			F:    staticExternalStaticNATGatewayTest,
 			SkipFlags: SkipFlags{
 				NoGateway:         true,
 				NoStaticExternals: true,
@@ -1031,7 +1031,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering Static External Masquerade NAT",
-			F:    testCtx.staticExternalMasqueradeNATGatewayTest,
+			F:    staticExternalMasqueradeNATGatewayTest,
 			SkipFlags: SkipFlags{
 				NoGateway:         true,
 				NoStaticExternals: true,
@@ -1039,7 +1039,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering Static External Port Forward NAT",
-			F:    testCtx.staticExternalPortForwardNATGatewayTest,
+			F:    staticExternalPortForwardNATGatewayTest,
 			SkipFlags: SkipFlags{
 				NoGateway:         true,
 				NoStaticExternals: true,
@@ -1047,7 +1047,7 @@ func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		},
 		{
 			Name: "Gateway Peering Static External Masquerade and Port Forward NAT",
-			F:    testCtx.staticExternalMasqueradePortForwardNATGatewayTest,
+			F:    staticExternalMasqueradePortForwardNATGatewayTest,
 			SkipFlags: SkipFlags{
 				NoGateway:         true,
 				NoStaticExternals: true,

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -329,7 +329,7 @@ func (testCtx *VPCPeeringTestCtx) testNATGatewayConnectivity(
 //		          Cidr:  10.50.2.0/24
 //
 // NOTE: Masquerade NAT on both sides of a peering is not supported (see dataplane#1248)
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringMasqueradeSourceNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringMasqueradeSourceNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -397,7 +397,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringMasqueradeSourceNATTest(ctx cont
 //	    Expose:
 //	      Ips:
 //	        Cidr:  10.50.2.0/24
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringStaticSourceNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringStaticSourceNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -465,7 +465,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringStaticSourceNATTest(ctx context.
 //	        Cidr:  10.50.2.0/24
 //	      Nat:
 //	        Static:
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringBidirectionalStaticNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringBidirectionalStaticNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -537,7 +537,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringBidirectionalStaticNATTest(ctx c
 //	        Cidr:  10.50.1.0/24
 //	      Nat:
 //	        Static:
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringOverlapNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringOverlapNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	const (
 		overlapNSName  = "overlap-ns"  // max 11 chars for IPv4Namespace name
 		overlapVPCName = "vpc-overlap" // max 11 chars for VPC name (VRF interface limit)
@@ -1013,7 +1013,7 @@ func (testCtx *VPCPeeringTestCtx) testPortForwardInboundConnectivity(
 //	    Expose:
 //	      Ips:
 //	        Cidr:  10.50.2.0/24
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringPortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringPortForwardNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -1089,7 +1089,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringPortForwardNATTest(ctx context.C
 //	    Expose:
 //	      Ips:
 //	        Cidr:  10.50.2.0/24
-func (testCtx *VPCPeeringTestCtx) gatewayPeeringMasqueradePortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayPeeringMasqueradePortForwardNATTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
 		return false, nil, fmt.Errorf("listing VPCs: %w", err)
@@ -1144,46 +1144,46 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringMasqueradePortForwardNATTest(ctx
 }
 
 // getNATTestCases returns the NAT test cases to be added to the multi-VPC single-subnet suite
-func getNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
+func getNATTestCases() []JUnitTestCase {
 	return []JUnitTestCase{
 		{
 			Name: "Gateway Peering Masquerade Source NAT",
-			F:    testCtx.gatewayPeeringMasqueradeSourceNATTest,
+			F:    gatewayPeeringMasqueradeSourceNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 			},
 		},
 		{
 			Name: "Gateway Peering Static Source NAT",
-			F:    testCtx.gatewayPeeringStaticSourceNATTest,
+			F:    gatewayPeeringStaticSourceNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 			},
 		},
 		{
 			Name: "Gateway Peering Bidirectional Static NAT",
-			F:    testCtx.gatewayPeeringBidirectionalStaticNATTest,
+			F:    gatewayPeeringBidirectionalStaticNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 			},
 		},
 		{
 			Name: "Gateway Peering Overlap NAT",
-			F:    testCtx.gatewayPeeringOverlapNATTest,
+			F:    gatewayPeeringOverlapNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 			},
 		},
 		{
 			Name: "Gateway Peering Port Forward NAT",
-			F:    testCtx.gatewayPeeringPortForwardNATTest,
+			F:    gatewayPeeringPortForwardNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 			},
 		},
 		{
 			Name: "Gateway Peering Masquerade and Port Forward NAT",
-			F:    testCtx.gatewayPeeringMasqueradePortForwardNATTest,
+			F:    gatewayPeeringMasqueradePortForwardNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 			},

--- a/pkg/hhfab/rt_no_vpc_suite.go
+++ b/pkg/hhfab/rt_no_vpc_suite.go
@@ -41,28 +41,28 @@ type prometheusQueryResponse struct {
 	} `json:"data"`
 }
 
-func makeNoVpcsSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
+func makeNoVpcsSuite() *JUnitTestSuite {
 	suite := &JUnitTestSuite{
 		Name: "No VPCs Suite",
 	}
 	suite.TestCases = []JUnitTestCase{
 		{
 			Name: "Breakout ports",
-			F:    testCtx.breakoutTest,
+			F:    breakoutTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 			},
 		},
 		{
 			Name: "Loki Observability",
-			F:    testCtx.lokiObservabilityTest,
+			F:    lokiObservabilityTest,
 			SkipFlags: SkipFlags{
 				NoLoki: true,
 			},
 		},
 		{
 			Name: "Prometheus Observability",
-			F:    testCtx.prometheusObservabilityTest,
+			F:    prometheusObservabilityTest,
 			SkipFlags: SkipFlags{
 				NoProm: true,
 			},
@@ -78,7 +78,7 @@ func makeNoVpcsSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 // 2. change breakout to some non default mode
 // 3. wait for all switches to be ready for 1 minute
 // 4. check that all agents report the breakout to be completed and that the port is in the expected mode
-func (testCtx *VPCPeeringTestCtx) breakoutTest(ctx context.Context) (bool, []RevertFunc, error) {
+func breakoutTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// get all agents in the fabric
 	agents := &agentapi.AgentList{}
 	if err := testCtx.kube.List(ctx, agents); err != nil {
@@ -311,7 +311,7 @@ const (
 	AlloyCtrlComponent = "alloy-ctrl"
 )
 
-func (testCtx *VPCPeeringTestCtx) lokiObservabilityTest(ctx context.Context) (bool, []RevertFunc, error) {
+func lokiObservabilityTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	lokiEndpoint, _, env, err := getObservabilityQueryURLs(ctx, testCtx.kube)
 	if err != nil {
 		return true, nil, fmt.Errorf("error getting observability endpoints: %w", err)
@@ -588,7 +588,7 @@ func (testCtx *VPCPeeringTestCtx) lokiObservabilityTest(ctx context.Context) (bo
 	return false, nil, nil
 }
 
-func (testCtx *VPCPeeringTestCtx) prometheusObservabilityTest(ctx context.Context) (bool, []RevertFunc, error) {
+func prometheusObservabilityTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	_, prometheusEndpoint, env, err := getObservabilityQueryURLs(ctx, testCtx.kube)
 	if err != nil {
 		return true, nil, fmt.Errorf("error getting observability endpoints: %w", err)

--- a/pkg/hhfab/rt_on_ready_suite.go
+++ b/pkg/hhfab/rt_on_ready_suite.go
@@ -1,0 +1,751 @@
+// Copyright 2024 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	gwapi "go.githedgehog.com/fabric/api/gateway/v1alpha1"
+	"go.githedgehog.com/fabric/api/meta"
+	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/hhfctl"
+	"golang.org/x/sync/errgroup"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func makeOnReadyTestSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
+	suite := &JUnitTestSuite{
+		Name: "OnReady Suite",
+	}
+	suite.TestCases = []JUnitTestCase{
+		{
+			Name:      "New VLAB OnReady Test",
+			F:         testCtx.newOnReadyTest,
+			SkipFlags: SkipFlags{},
+		},
+	}
+	suite.Tests = len(suite.TestCases)
+
+	return suite
+}
+
+// ortServerInfo holds information about a server and its connection for the on-ready test.
+type ortServerInfo struct {
+	name        string
+	conn        wiringapi.Connection
+	switches    []string
+	isUnbundled bool
+	isMclag     bool
+}
+
+// Test to get as much coverage as possible for Fabric while being short and compact
+// Unlike the other tests, here we create ad-hoc VPCs and attach them to servers to
+// maximize feature coverage. Specifically we want:
+// - 1 VPC with two subnets, 1 server per subnet
+// - 1 VPC with a single host bgp subnet and a server
+// - 1 VPC with a single subnet and 2 servers attached to two different switches
+// - as many VPCs with a single regular subnet and a single server as there are remaining servers (at least 2)
+// in terms of peering, we want to cover:
+// - 1 single-server VPC peered to the bgp external
+// - 1 single-server VPC peered to the static external without proxy
+// - the 2-servers VPC peered with the proxied static external via the gateway, using masquerade NAT
+// - the host bgp VPC peered with a regular VPC
+// the test should fail if this target setup cannot be achieved, with the only exception of gateway
+// not being enabled, in which case we skip gateway peerings
+// Note that there are more things that we could test but are not supported by virtual switches,
+// such as restricted/isolated flags, multiple peerings to the same external etc.
+// At the end of the test, we clean up all VPCs and peerings to leave a clean slate.
+//
+//nolint:cyclop
+func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []RevertFunc, error) {
+	slog.Info("Starting new on-ready test: discovering resources")
+
+	kube := testCtx.kube
+	reverts := make([]RevertFunc, 0)
+
+	// ── Phase 1: Discover switches and classify MCLAG ────────────────────
+	swList := &wiringapi.SwitchList{}
+	if err := kube.List(ctx, swList); err != nil {
+		return false, nil, fmt.Errorf("listing switches: %w", err)
+	}
+	mclagSwitches := map[string]bool{}
+	for _, sw := range swList.Items {
+		if sw.Spec.Redundancy.Type == meta.RedundancyTypeMCLAG {
+			mclagSwitches[sw.Name] = true
+		}
+	}
+
+	// ── Phase 2: Discover servers and their connections ───────────────────
+	servers := &wiringapi.ServerList{}
+	if err := kube.List(ctx, servers); err != nil {
+		return false, nil, fmt.Errorf("listing servers: %w", err)
+	}
+	// Sort servers by their numeric ID for deterministic allocation
+	serverIDs := map[string]uint64{}
+	for _, server := range servers.Items {
+		if !strings.HasPrefix(server.Name, ServerNamePrefix) {
+			continue
+		}
+
+		serverID, err := strconv.ParseUint(server.Name[len(ServerNamePrefix):], 10, 64)
+		if err != nil {
+			continue
+		}
+		serverIDs[server.Name] = serverID
+	}
+	slices.SortFunc(servers.Items, func(a, b wiringapi.Server) int {
+		return int(serverIDs[a.Name]) - int(serverIDs[b.Name]) //nolint:gosec
+	})
+
+	available := make([]ortServerInfo, 0, len(servers.Items))
+	for _, server := range servers.Items {
+		if _, ok := serverIDs[server.Name]; !ok {
+			continue
+		}
+
+		conns := &wiringapi.ConnectionList{}
+		if err := kube.List(ctx, conns, wiringapi.MatchingLabelsForListLabelServer(server.Name)); err != nil {
+			return false, nil, fmt.Errorf("listing connections for server %q: %w", server.Name, err)
+		}
+		if len(conns.Items) != 1 {
+			slog.Debug("Skipping server with unexpected connection count", "server", server.Name, "conns", len(conns.Items))
+
+			continue
+		}
+		conn := conns.Items[0]
+
+		// Skip ESLAG servers in non-L2VNI mode (they need special handling)
+		if conn.Spec.ESLAG != nil && testCtx.setupOpts.VPCMode != vpcapi.VPCModeL2VNI {
+			slog.Debug("Skipping ESLAG server", "server", server.Name)
+
+			continue
+		}
+
+		switches, _, _, _, err := conn.Spec.Endpoints()
+		if err != nil {
+			slog.Debug("Skipping server with endpoint error", "server", server.Name, "err", err)
+
+			continue
+		}
+		isMclag := false
+		for _, sw := range switches {
+			if mclagSwitches[sw] {
+				isMclag = true
+
+				break
+			}
+		}
+		available = append(available, ortServerInfo{
+			name:        server.Name,
+			conn:        conn,
+			switches:    switches,
+			isUnbundled: conn.Spec.Unbundled != nil,
+			isMclag:     isMclag,
+		})
+	}
+	slog.Info("Discovered available servers", "count", len(available))
+
+	// ── Phase 3: Discover externals ──────────────────────────────────────
+	extList := &vpcapi.ExternalList{}
+	if err := kube.List(ctx, extList); err != nil {
+		return false, nil, fmt.Errorf("listing externals: %w", err)
+	}
+	extAttachList := &vpcapi.ExternalAttachmentList{}
+	if err := kube.List(ctx, extAttachList); err != nil {
+		return false, nil, fmt.Errorf("listing external attachments: %w", err)
+	}
+
+	var bgpExtName, staticExtNonProxyName, staticExtProxyName string
+	// var staticExtProxyRemoteIP string
+	for _, ext := range extList.Items {
+		if ext.Spec.Static == nil {
+			// BGP external
+			if bgpExtName == "" {
+				// Verify it has at least one attachment
+				for _, att := range extAttachList.Items {
+					if att.Spec.External == ext.Name {
+						bgpExtName = ext.Name
+
+						break
+					}
+				}
+			}
+		} else {
+			// Static external – classify by attachment proxy flag
+			for _, att := range extAttachList.Items {
+				if att.Spec.External != ext.Name || att.Spec.Static == nil {
+					continue
+				}
+				if att.Spec.Static.Proxy && staticExtProxyName == "" {
+					staticExtProxyName = ext.Name
+					// staticExtProxyRemoteIP = att.Spec.Static.RemoteIP
+				} else if !att.Spec.Static.Proxy && staticExtNonProxyName == "" {
+					staticExtNonProxyName = ext.Name
+				}
+			}
+		}
+	}
+	slog.Info("Discovered externals",
+		"bgp", bgpExtName, "staticNonProxy", staticExtNonProxyName, "staticProxy", staticExtProxyName)
+
+	// ── Phase 4: Validate preconditions ──────────────────────────────────
+	if bgpExtName == "" {
+		return false, nil, fmt.Errorf("no BGP external found, cannot run on-ready test") //nolint:goerr113
+	}
+	if staticExtNonProxyName == "" {
+		return false, nil, fmt.Errorf("no static external without proxy found, cannot run on-ready test") //nolint:goerr113
+	}
+	if staticExtProxyName == "" {
+		slog.Warn("no proxied static external found, but we are currently skipping its testing")
+	}
+	const minServers = 7
+	if len(available) < minServers {
+		return false, nil, fmt.Errorf("not enough servers: need at least %d, found %d", minServers, len(available)) //nolint:goerr113
+	}
+
+	// ── Phase 5: Allocate servers to VPC roles ───────────────────────────
+	// We consume servers from the `available` slice as we assign them.
+	used := map[string]bool{}
+	take := func(pred func(s ortServerInfo) bool) (ortServerInfo, bool) {
+		for _, s := range available {
+			if used[s.name] {
+				continue
+			}
+
+			if pred(s) {
+				used[s.name] = true
+
+				return s, true
+			}
+		}
+
+		return ortServerInfo{}, false
+	}
+
+	// VPC B: 1 hostBGP subnet – needs unbundled, non-MCLAG
+	hostBGPServer, ok := take(func(s ortServerInfo) bool {
+		return s.isUnbundled && !s.isMclag
+	})
+	if !ok {
+		return false, nil, fmt.Errorf("no unbundled non-MCLAG server available for hostBGP VPC") //nolint:goerr113
+	}
+
+	// VPC C: 1 subnet, 2 servers on different non mclag switches
+	vpcCServer1, ok := take(func(s ortServerInfo) bool { return !s.isMclag })
+	if !ok {
+		return false, nil, fmt.Errorf("not enough servers for multi-switch VPC") //nolint:goerr113
+	}
+	vpcCServer2, ok := take(func(s ortServerInfo) bool {
+		if s.isMclag {
+			return false
+		}
+		// Must be on a different switch than vpcCServer1
+		for _, sw := range s.switches {
+			for _, sw1 := range vpcCServer1.switches {
+				if sw == sw1 {
+					return false
+				}
+			}
+		}
+
+		return true
+	})
+	if !ok {
+		return false, nil, fmt.Errorf("no server on a different switch found for multi-switch VPC") //nolint:goerr113
+	}
+
+	// VPC A: 2 subnets, 1 server per subnet
+	vpcAServer1, ok := take(func(s ortServerInfo) bool { return true })
+	if !ok {
+		return false, nil, fmt.Errorf("not enough servers for dual-subnet VPC (server 1)") //nolint:goerr113
+	}
+	vpcAServer2, ok := take(func(s ortServerInfo) bool { return true })
+	if !ok {
+		return false, nil, fmt.Errorf("not enough servers for dual-subnet VPC (server 2)") //nolint:goerr113
+	}
+
+	// VPC D+: remaining servers, need at least 2 for BGP external + static external peerings
+	singleServers := make([]ortServerInfo, 0)
+	for _, s := range available {
+		if used[s.name] {
+			continue
+		}
+		used[s.name] = true
+		singleServers = append(singleServers, s)
+	}
+	if len(singleServers) < 2 {
+		return false, nil, fmt.Errorf("not enough remaining servers for single-server VPCs: need at least 2, got %d", len(singleServers)) //nolint:goerr113
+	}
+	slog.Info("Server allocation complete",
+		"vpcA", []string{vpcAServer1.name, vpcAServer2.name},
+		"vpcB_hostBGP", hostBGPServer.name,
+		"vpcC_multiSwitch", []string{vpcCServer1.name, vpcCServer2.name},
+		"singleServerVPCs", len(singleServers))
+
+	// ── Phase 6: Allocate VLANs and subnets ──────────────────────────────
+	vlanNS := &wiringapi.VLANNamespace{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Name: testCtx.setupOpts.VLANNamespace, Namespace: kmetav1.NamespaceDefault}, vlanNS); err != nil {
+		return false, nil, fmt.Errorf("getting VLAN namespace %s: %w", testCtx.setupOpts.VLANNamespace, err)
+	}
+	nextVLAN, stopVLAN := iter.Pull(VLANsFrom(vlanNS.Spec.Ranges...))
+	defer stopVLAN()
+
+	ipNS := &vpcapi.IPv4Namespace{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Name: testCtx.setupOpts.IPv4Namespace, Namespace: kmetav1.NamespaceDefault}, ipNS); err != nil {
+		return false, nil, fmt.Errorf("getting IPv4 namespace %s: %w", testCtx.setupOpts.IPv4Namespace, err)
+	}
+	prefixes := make([]netip.Prefix, 0)
+	for _, p := range ipNS.Spec.Subnets {
+		parsed, err := netip.ParsePrefix(p)
+		if err != nil {
+			return false, nil, fmt.Errorf("parsing IPv4 namespace prefix %q: %w", p, err)
+		}
+		prefixes = append(prefixes, parsed)
+	}
+	nextPrefix, stopPrefix := iter.Pull(SubPrefixesFrom(24, prefixes...))
+	defer stopPrefix()
+
+	allocVLAN := func() (uint16, error) {
+		v, ok := nextVLAN()
+		if !ok {
+			return 0, fmt.Errorf("no more VLANs available") //nolint:goerr113
+		}
+
+		return v, nil
+	}
+	allocSubnet := func() (string, error) {
+		p, ok := nextPrefix()
+		if !ok {
+			return "", fmt.Errorf("no more subnets available") //nolint:goerr113
+		}
+
+		return p.String(), nil
+	}
+
+	vpcMode := testCtx.setupOpts.VPCMode
+	hashPolicy := testCtx.setupOpts.HashPolicy
+
+	// ── Phase 7: Build VPCs, attachments, and server netconf commands ────
+	type vpcPlan struct {
+		vpc      *vpcapi.VPC
+		attaches []*vpcapi.VPCAttachment
+		// map server name → netconf command (for hhnet) or hostBGP arguments
+		netconfs map[string]string
+		hostBGP  map[string]bool
+	}
+	plans := make([]vpcPlan, 0)
+
+	makeRegularSubnet := func() (*vpcapi.VPCSubnet, error) {
+		cidr, err := allocSubnet()
+		if err != nil {
+			return nil, err
+		}
+		vlan, err := allocVLAN()
+		if err != nil {
+			return nil, err
+		}
+
+		return &vpcapi.VPCSubnet{
+			Subnet: cidr,
+			VLAN:   vlan,
+			DHCP:   vpcapi.VPCDHCP{Enable: true},
+		}, nil
+	}
+
+	makeAttach := func(connName, vpcName, subnetName string) *vpcapi.VPCAttachment {
+		attachName := fmt.Sprintf("%s--%s--%s", connName, vpcName, subnetName)
+
+		return &vpcapi.VPCAttachment{
+			ObjectMeta: kmetav1.ObjectMeta{
+				Name:      attachName,
+				Namespace: kmetav1.NamespaceDefault,
+			},
+			Spec: vpcapi.VPCAttachmentSpec{
+				Connection: connName,
+				Subnet:     fmt.Sprintf("%s/%s", vpcName, subnetName),
+			},
+		}
+	}
+
+	serverNetconf := func(s ortServerInfo, vlan uint16, hashPolicy string) (string, error) {
+		return GetServerNetconfCmd(&s.conn, ServerNetconfOpts{VLAN: vlan, HashPolicy: hashPolicy})
+	}
+
+	// ── VPC A: 2 subnets, 1 server per subnet ───────────────────────────
+	const vpcAName = "ort-a"
+	{
+		sub1, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC A subnet-01: %w", err)
+		}
+		sub2, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC A subnet-02: %w", err)
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcAName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub1,
+					"subnet-02": sub2,
+				},
+			},
+		}
+		att1 := makeAttach(vpcAServer1.conn.Name, vpcAName, "subnet-01")
+		att2 := makeAttach(vpcAServer2.conn.Name, vpcAName, "subnet-02")
+		nc1, err := serverNetconf(vpcAServer1, sub1.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcAServer1.name, err)
+		}
+		nc2, err := serverNetconf(vpcAServer2, sub2.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcAServer2.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att1, att2},
+			netconfs: map[string]string{vpcAServer1.name: nc1, vpcAServer2.name: nc2},
+			hostBGP:  map[string]bool{},
+		})
+	}
+
+	// ── VPC B: 1 hostBGP subnet, 1 server ────────────────────────────────
+	const vpcBName = "ort-b"
+	{
+		subCIDR, err := allocSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC B subnet: %w", err)
+		}
+		vlan, err := allocVLAN()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC B VLAN: %w", err)
+		}
+		sub := &vpcapi.VPCSubnet{
+			Subnet:  subCIDR,
+			HostBGP: true,
+			VLAN:    vlan,
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcBName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub,
+				},
+			},
+		}
+		att := makeAttach(hostBGPServer.conn.Name, vpcBName, "subnet-01")
+		subPrefix, err := netip.ParsePrefix(subCIDR)
+		if err != nil {
+			return false, nil, fmt.Errorf("parsing VPC B subnet: %w", err)
+		}
+		hostBGPCmd, err := getServerHostBGPCmd(&hostBGPServer.conn, vlan, subPrefix, 1)
+		if err != nil {
+			return false, nil, fmt.Errorf("hostBGP cmd for %s: %w", hostBGPServer.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att},
+			netconfs: map[string]string{hostBGPServer.name: hostBGPCmd},
+			hostBGP:  map[string]bool{hostBGPServer.name: true},
+		})
+	}
+
+	// ── VPC C: 1 subnet, 2 servers on different switches ─────────────────
+	const vpcCName = "ort-c"
+	{
+		sub, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC C subnet: %w", err)
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcCName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub,
+				},
+			},
+		}
+		att1 := makeAttach(vpcCServer1.conn.Name, vpcCName, "subnet-01")
+		att2 := makeAttach(vpcCServer2.conn.Name, vpcCName, "subnet-01")
+		nc1, err := serverNetconf(vpcCServer1, sub.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcCServer1.name, err)
+		}
+		nc2, err := serverNetconf(vpcCServer2, sub.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcCServer2.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att1, att2},
+			netconfs: map[string]string{vpcCServer1.name: nc1, vpcCServer2.name: nc2},
+			hostBGP:  map[string]bool{},
+		})
+	}
+
+	// ── VPC D+: 1 regular subnet + 1 server each, for remaining servers ──
+	singleServerVPCs := make(map[string]*vpcapi.VPC, len(singleServers))
+	for i, s := range singleServers {
+		vpcName := fmt.Sprintf("ort-d%d", i+1)
+		sub, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating %s subnet: %w", vpcName, err)
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub,
+				},
+			},
+		}
+		singleServerVPCs[s.name] = vpc
+		att := makeAttach(s.conn.Name, vpcName, "subnet-01")
+		nc, err := serverNetconf(s, sub.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", s.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att},
+			netconfs: map[string]string{s.name: nc},
+			hostBGP:  map[string]bool{},
+		})
+	}
+
+	// ── Phase 8: Create VPCs and attachments in Kubernetes ────────────────
+	slog.Info("Creating VPCs and attachments", "vpcs", len(plans))
+
+	// Register a cleanup revert that removes everything we created
+	reverts = append(reverts, func(ctx context.Context) error {
+		slog.Info("Cleaning up on-ready test VPCs and peerings")
+		if err := hhfctl.VPCWipeWithClient(ctx, kube); err != nil {
+			slog.Warn("failed to wipe VPCs and peerings", "error", err)
+		}
+		// Clean up server networking
+		for _, plan := range plans {
+			for serverName := range plan.netconfs {
+				ssh, err := testCtx.getSSH(ctx, serverName)
+				if err != nil {
+					slog.Warn("Failed to get SSH for cleanup", "server", serverName, "err", err)
+
+					continue
+				}
+				if plan.hostBGP[serverName] {
+					_, _, _ = ssh.Run(ctx, "docker stop -t 1 hostbgp")
+				}
+
+				if _, stderr, err := ssh.Run(ctx, "/opt/bin/hhnet cleanup"); err != nil {
+					slog.Warn("hhnet cleanup failed", "server", serverName, "err", err, "stderr", stderr)
+				}
+			}
+		}
+
+		return nil
+	})
+
+	for _, plan := range plans {
+		if _, err := CreateOrUpdateVpc(ctx, kube, plan.vpc); err != nil {
+			return false, reverts, fmt.Errorf("creating VPC %s: %w", plan.vpc.Name, err)
+		}
+	}
+
+	for _, plan := range plans {
+		for _, att := range plan.attaches {
+			if err := kube.Create(ctx, att); err != nil {
+				return false, reverts, fmt.Errorf("creating attachment %s: %w", att.Name, err)
+			}
+		}
+	}
+
+	// Wait for switches to pick up the new VPCs/attachments
+	time.Sleep(15 * time.Second)
+	if err := WaitReady(ctx, kube, testCtx.wrOpts); err != nil {
+		return false, reverts, fmt.Errorf("waiting for ready after creating VPCs: %w", err)
+	}
+
+	// ── Phase 9: Configure server networking ─────────────────────────────
+	slog.Info("Configuring server networking")
+
+	g := &errgroup.Group{}
+	for _, plan := range plans {
+		for serverName, cmd := range plan.netconfs {
+			g.Go(func() error {
+				ssh, err := testCtx.getSSH(ctx, serverName)
+				if err != nil {
+					return fmt.Errorf("getting SSH for %s: %w", serverName, err)
+				}
+				// Cleanup any previous config
+				if _, _, err := ssh.Run(ctx, "docker stop -t 1 hostbgp"); err != nil {
+					// Ignore – container may not be running
+					_ = err
+				}
+				if _, stderr, err := ssh.Run(ctx, "/opt/bin/hhnet cleanup"); err != nil {
+					return fmt.Errorf("hhnet cleanup on %s: %w: %s", serverName, err, stderr)
+				}
+
+				if plan.hostBGP[serverName] {
+					slog.Debug("Starting hostBGP container", "server", serverName, "args", cmd)
+					_, stderr, err := ssh.Run(ctx, "docker run --network=host --privileged --rm --detach --name hostbgp ghcr.io/githedgehog/host-bgp "+cmd)
+					if err != nil {
+						return fmt.Errorf("starting hostbgp on %s: %w: %s", serverName, err, stderr)
+					}
+					// Wait for hostBGP to acquire a VIP
+					acquired := false
+					for attempt := range 10 {
+						time.Sleep(2 * time.Second)
+						stdout, _, err := ssh.Run(ctx, "/opt/bin/hhnet getvips")
+						if err != nil {
+							continue
+						}
+						for line := range strings.Lines(stdout) {
+							line = strings.TrimSpace(line)
+							if _, parseErr := netip.ParsePrefix(line); parseErr == nil {
+								acquired = true
+								slog.Debug("HostBGP VIP acquired", "server", serverName, "vip", line, "attempt", attempt+1)
+
+								break
+							}
+						}
+						if acquired {
+							break
+						}
+					}
+					if !acquired {
+						return fmt.Errorf("hostBGP on %s did not acquire VIP in time", serverName) //nolint:goerr113
+					}
+				} else {
+					slog.Debug("Configuring server networking", "server", serverName, "cmd", cmd)
+					stdout, stderr, err := ssh.Run(ctx, "/opt/bin/hhnet "+cmd)
+					if err != nil {
+						return fmt.Errorf("hhnet on %s: %w: %s", serverName, err, stderr)
+					}
+					addr := strings.TrimSpace(stdout)
+					if _, parseErr := netip.ParsePrefix(addr); parseErr != nil {
+						return fmt.Errorf("unexpected hhnet output on %s: %q", serverName, addr) //nolint:goerr113
+					}
+					slog.Debug("Server configured", "server", serverName, "addr", addr)
+				}
+
+				return nil
+			})
+		}
+	}
+
+	if err := g.Wait(); err != nil {
+		return false, reverts, fmt.Errorf("configuring server networking: %w", err)
+	}
+
+	// In L3VNI mode, give extra time for routes to propagate
+	if vpcMode == vpcapi.VPCModeL3VNI || vpcMode == vpcapi.VPCModeL3Flat {
+		time.Sleep(10 * time.Second)
+	}
+
+	// ── Phase 10: Build and apply peerings ───────────────────────────────
+	slog.Info("Setting up peerings")
+
+	// We need the created VPCs (with defaults applied) to build gateway peering specs.
+	// Re-fetch VPC C to get full subnet CIDRs after defaults.
+	vpcC := &vpcapi.VPC{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Name: vpcCName, Namespace: kmetav1.NamespaceDefault}, vpcC); err != nil {
+		return false, reverts, fmt.Errorf("getting VPC %s: %w", vpcCName, err)
+	}
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	extPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	// Peering 1: first single-server VPC peered to the BGP external
+	bgpPeerVPC := singleServerVPCs[singleServers[0].name]
+	appendExtPeeringSpecByName(extPeerings, bgpPeerVPC.Name, bgpExtName, []string{"subnet-01"}, AllZeroPrefix)
+	slog.Debug("Added BGP external peering", "server", singleServers[0].name, "vpc", bgpPeerVPC.Name, "external", bgpExtName)
+
+	// Peering 2: second single-server VPC peered to the static external without proxy
+	staticPeerVPC := singleServerVPCs[singleServers[1].name]
+	appendExtPeeringSpecByName(extPeerings, staticPeerVPC.Name, staticExtNonProxyName, []string{"subnet-01"}, AllZeroPrefix)
+	slog.Debug("Added static (non-proxy) external peering", "server", singleServers[1].name, "vpc", staticPeerVPC.Name, "external", staticExtNonProxyName)
+
+	// Peering 3: VPC C (2-server, multi-switch) peered with the proxied static external via gateway, masquerade NAT
+	// commented out as test-connectivity does not support NAT currently
+	// if testCtx.gwSupported {
+	// 	entryName := fmt.Sprintf("%s--ext.%s", vpcCName, staticExtProxyName)
+	// 	// Expose VPC C's subnet with masquerade NAT
+	// 	vpcCSubnets := make([]gwapi.PeeringEntryIP, 0)
+	// 	for _, sub := range vpcC.Spec.Subnets {
+	// 		vpcCSubnets = append(vpcCSubnets, gwapi.PeeringEntryIP{CIDR: sub.Subnet})
+	// 	}
+	// 	extIP, err := netip.ParseAddr(staticExtProxyRemoteIP)
+	// 	if err != nil {
+	// 		return false, reverts, fmt.Errorf("parsing static external proxy remote IP %q: %w", staticExtProxyRemoteIP, err)
+	// 	}
+	// 	masqPrefix, err := extIP.Next().Prefix(32)
+	// 	if err != nil {
+	// 		return false, reverts, fmt.Errorf("creating masquerade prefix from %q: %w", extIP.Next(), err)
+	// 	}
+	// 	gwPeerings[entryName] = &gwapi.PeeringSpec{
+	// 		Peering: map[string]*gwapi.PeeringEntry{
+	// 			vpcCName: {
+	// 				Expose: []gwapi.PeeringEntryExpose{
+	// 					{
+	// 						IPs: vpcCSubnets,
+	// 						As:  []gwapi.PeeringEntryAs{{CIDR: masqPrefix.String()}},
+	// 						NAT: &gwapi.PeeringNAT{Masquerade: &gwapi.PeeringNATMasquerade{}},
+	// 					},
+	// 				},
+	// 			},
+	// 			"ext." + staticExtProxyName: {
+	// 				Expose: []gwapi.PeeringEntryExpose{
+	// 					{DefaultDestination: true},
+	// 				},
+	// 			},
+	// 		},
+	// 	}
+	// 	slog.Debug("Added gateway masquerade peering", "vpc", vpcCName, "external", staticExtProxyName)
+	// }
+
+	// Peering 4: hostBGP VPC (B) peered with VPC A (a regular VPC)
+	appendVpcPeeringSpecByName(vpcPeerings, vpcBName, vpcAName, "", []string{}, []string{})
+	slog.Debug("Added VPC peering", "vpc1", vpcBName, "vpc2", vpcAName)
+
+	// Extra gateway peerings to increase coverage. TODO: add NAT once test-connectivity supports it.
+	// Note that we skip peering between the first two servers as they are respectively peered to the BGP external
+	// and the static non-proxy one, and by peering them the bgp VRF would get a LPM route to the second server
+	// compared to the flat ipv4 namespace route the static external vrf has in the virtual external
+	if !testCtx.skipFlags.NoGateway {
+		for i := 1; i <= len(singleServers)-2; i++ {
+			if err := appendGwPeeringSpec(gwPeerings, singleServerVPCs[singleServers[i].name], singleServerVPCs[singleServers[i+1].name], nil); err != nil {
+				return false, reverts, fmt.Errorf("setting up gateway peering: %w", err)
+			}
+		}
+	}
+
+	if err := DoSetupPeerings(ctx, kube, vpcPeerings, extPeerings, gwPeerings, true); err != nil {
+		return false, reverts, fmt.Errorf("setting up peerings: %w", err)
+	}
+
+	// ── Phase 11: Test connectivity ──────────────────────────────────────
+	slog.Info("Running connectivity test")
+
+	if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		return false, reverts, fmt.Errorf("connectivity test failed: %w", err)
+	}
+
+	slog.Info("On-ready test completed successfully")
+
+	return false, reverts, nil
+}

--- a/pkg/hhfab/rt_on_ready_suite.go
+++ b/pkg/hhfab/rt_on_ready_suite.go
@@ -166,7 +166,7 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 		return false, nil, fmt.Errorf("listing external attachments: %w", err)
 	}
 
-	var bgpExtName, staticExtNonProxyName, staticExtProxyName string
+	var bgpExtName, staticExtNonProxyName string
 	// var staticExtProxyRemoteIP string
 	for _, ext := range extList.Items {
 		if ext.Spec.Static == nil {
@@ -187,17 +187,14 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 				if att.Spec.External != ext.Name || att.Spec.Static == nil {
 					continue
 				}
-				if att.Spec.Static.Proxy && staticExtProxyName == "" {
-					staticExtProxyName = ext.Name
-					// staticExtProxyRemoteIP = att.Spec.Static.RemoteIP
-				} else if !att.Spec.Static.Proxy && staticExtNonProxyName == "" {
+				if !att.Spec.Static.Proxy && staticExtNonProxyName == "" {
 					staticExtNonProxyName = ext.Name
 				}
 			}
 		}
 	}
 	slog.Info("Discovered externals",
-		"bgp", bgpExtName, "staticNonProxy", staticExtNonProxyName, "staticProxy", staticExtProxyName)
+		"bgp", bgpExtName, "staticNonProxy", staticExtNonProxyName)
 
 	// ── Phase 4: Validate preconditions ──────────────────────────────────
 	if bgpExtName == "" {
@@ -205,9 +202,6 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 	}
 	if staticExtNonProxyName == "" {
 		return false, nil, fmt.Errorf("no static external without proxy found, cannot run on-ready test") //nolint:goerr113
-	}
-	if staticExtProxyName == "" {
-		slog.Warn("no proxied static external found, but we are currently skipping its testing")
 	}
 	const minServers = 7
 	if len(available) < minServers {
@@ -659,13 +653,6 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 	// ── Phase 10: Build and apply peerings ───────────────────────────────
 	slog.Info("Setting up peerings")
 
-	// We need the created VPCs (with defaults applied) to build gateway peering specs.
-	// Re-fetch VPC C to get full subnet CIDRs after defaults.
-	vpcC := &vpcapi.VPC{}
-	if err := kube.Get(ctx, kclient.ObjectKey{Name: vpcCName, Namespace: kmetav1.NamespaceDefault}, vpcC); err != nil {
-		return false, reverts, fmt.Errorf("getting VPC %s: %w", vpcCName, err)
-	}
-
 	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
 	extPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
 	gwPeerings := make(map[string]*gwapi.PeeringSpec)
@@ -679,44 +666,6 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 	staticPeerVPC := singleServerVPCs[singleServers[1].name]
 	appendExtPeeringSpecByName(extPeerings, staticPeerVPC.Name, staticExtNonProxyName, []string{"subnet-01"}, AllZeroPrefix)
 	slog.Debug("Added static (non-proxy) external peering", "server", singleServers[1].name, "vpc", staticPeerVPC.Name, "external", staticExtNonProxyName)
-
-	// Peering 3: VPC C (2-server, multi-switch) peered with the proxied static external via gateway, masquerade NAT
-	// commented out as test-connectivity does not support NAT currently
-	// if testCtx.gwSupported {
-	// 	entryName := fmt.Sprintf("%s--ext.%s", vpcCName, staticExtProxyName)
-	// 	// Expose VPC C's subnet with masquerade NAT
-	// 	vpcCSubnets := make([]gwapi.PeeringEntryIP, 0)
-	// 	for _, sub := range vpcC.Spec.Subnets {
-	// 		vpcCSubnets = append(vpcCSubnets, gwapi.PeeringEntryIP{CIDR: sub.Subnet})
-	// 	}
-	// 	extIP, err := netip.ParseAddr(staticExtProxyRemoteIP)
-	// 	if err != nil {
-	// 		return false, reverts, fmt.Errorf("parsing static external proxy remote IP %q: %w", staticExtProxyRemoteIP, err)
-	// 	}
-	// 	masqPrefix, err := extIP.Next().Prefix(32)
-	// 	if err != nil {
-	// 		return false, reverts, fmt.Errorf("creating masquerade prefix from %q: %w", extIP.Next(), err)
-	// 	}
-	// 	gwPeerings[entryName] = &gwapi.PeeringSpec{
-	// 		Peering: map[string]*gwapi.PeeringEntry{
-	// 			vpcCName: {
-	// 				Expose: []gwapi.PeeringEntryExpose{
-	// 					{
-	// 						IPs: vpcCSubnets,
-	// 						As:  []gwapi.PeeringEntryAs{{CIDR: masqPrefix.String()}},
-	// 						NAT: &gwapi.PeeringNAT{Masquerade: &gwapi.PeeringNATMasquerade{}},
-	// 					},
-	// 				},
-	// 			},
-	// 			"ext." + staticExtProxyName: {
-	// 				Expose: []gwapi.PeeringEntryExpose{
-	// 					{DefaultDestination: true},
-	// 				},
-	// 			},
-	// 		},
-	// 	}
-	// 	slog.Debug("Added gateway masquerade peering", "vpc", vpcCName, "external", staticExtProxyName)
-	// }
 
 	// Peering 4: hostBGP VPC (B) peered with VPC A (a regular VPC)
 	appendVpcPeeringSpecByName(vpcPeerings, vpcBName, vpcAName, "", []string{}, []string{})

--- a/pkg/hhfab/rt_on_ready_suite.go
+++ b/pkg/hhfab/rt_on_ready_suite.go
@@ -60,7 +60,6 @@ type ortServerInfo struct {
 // in terms of peering, we want to cover:
 // - 1 single-server VPC peered to the bgp external
 // - 1 single-server VPC peered to the static external without proxy
-// - the 2-servers VPC peered with the proxied static external via the gateway, using masquerade NAT
 // - the host bgp VPC peered with a regular VPC
 // the test should fail if this target setup cannot be achieved, with the only exception of gateway
 // not being enabled, in which case we skip gateway peerings
@@ -167,7 +166,7 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 		return false, nil, fmt.Errorf("listing external attachments: %w", err)
 	}
 
-	var bgpExtName, staticExtNonProxyName, staticExtProxyName string
+	var bgpExtName, staticExtNonProxyName string
 	// var staticExtProxyRemoteIP string
 	for _, ext := range extList.Items {
 		if ext.Spec.Static == nil {
@@ -188,17 +187,14 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 				if att.Spec.External != ext.Name || att.Spec.Static == nil {
 					continue
 				}
-				if att.Spec.Static.Proxy && staticExtProxyName == "" {
-					staticExtProxyName = ext.Name
-					// staticExtProxyRemoteIP = att.Spec.Static.RemoteIP
-				} else if !att.Spec.Static.Proxy && staticExtNonProxyName == "" {
+				if !att.Spec.Static.Proxy && staticExtNonProxyName == "" {
 					staticExtNonProxyName = ext.Name
 				}
 			}
 		}
 	}
 	slog.Info("Discovered externals",
-		"bgp", bgpExtName, "staticNonProxy", staticExtNonProxyName, "staticProxy", staticExtProxyName)
+		"bgp", bgpExtName, "staticNonProxy", staticExtNonProxyName)
 
 	// ── Phase 4: Validate preconditions ──────────────────────────────────
 	if bgpExtName == "" {
@@ -206,9 +202,6 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 	}
 	if staticExtNonProxyName == "" {
 		return false, nil, fmt.Errorf("no static external without proxy found, cannot run on-ready test") //nolint:goerr113
-	}
-	if staticExtProxyName == "" {
-		slog.Warn("no proxied static external found, but we are currently skipping its testing")
 	}
 	const minServers = 7
 	if len(available) < minServers {
@@ -661,13 +654,6 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 	// ── Phase 10: Build and apply peerings ───────────────────────────────
 	slog.Info("Setting up peerings")
 
-	// We need the created VPCs (with defaults applied) to build gateway peering specs.
-	// Re-fetch VPC C to get full subnet CIDRs after defaults.
-	vpcC := &vpcapi.VPC{}
-	if err := kube.Get(ctx, kclient.ObjectKey{Name: vpcCName, Namespace: kmetav1.NamespaceDefault}, vpcC); err != nil {
-		return false, reverts, fmt.Errorf("getting VPC %s: %w", vpcCName, err)
-	}
-
 	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
 	extPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
 	gwPeerings := make(map[string]*gwapi.PeeringSpec)
@@ -681,44 +667,6 @@ func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []R
 	staticPeerVPC := singleServerVPCs[singleServers[1].name]
 	appendExtPeeringSpecByName(extPeerings, staticPeerVPC.Name, staticExtNonProxyName, []string{"subnet-01"}, AllZeroPrefix)
 	slog.Debug("Added static (non-proxy) external peering", "server", singleServers[1].name, "vpc", staticPeerVPC.Name, "external", staticExtNonProxyName)
-
-	// Peering 3: VPC C (2-server, multi-switch) peered with the proxied static external via gateway, masquerade NAT
-	// commented out as test-connectivity does not support NAT currently
-	// if testCtx.gwSupported {
-	// 	entryName := fmt.Sprintf("%s--ext.%s", vpcCName, staticExtProxyName)
-	// 	// Expose VPC C's subnet with masquerade NAT
-	// 	vpcCSubnets := make([]gwapi.PeeringEntryIP, 0)
-	// 	for _, sub := range vpcC.Spec.Subnets {
-	// 		vpcCSubnets = append(vpcCSubnets, gwapi.PeeringEntryIP{CIDR: sub.Subnet})
-	// 	}
-	// 	extIP, err := netip.ParseAddr(staticExtProxyRemoteIP)
-	// 	if err != nil {
-	// 		return false, reverts, fmt.Errorf("parsing static external proxy remote IP %q: %w", staticExtProxyRemoteIP, err)
-	// 	}
-	// 	masqPrefix, err := extIP.Next().Prefix(32)
-	// 	if err != nil {
-	// 		return false, reverts, fmt.Errorf("creating masquerade prefix from %q: %w", extIP.Next(), err)
-	// 	}
-	// 	gwPeerings[entryName] = &gwapi.PeeringSpec{
-	// 		Peering: map[string]*gwapi.PeeringEntry{
-	// 			vpcCName: {
-	// 				Expose: []gwapi.PeeringEntryExpose{
-	// 					{
-	// 						IPs: vpcCSubnets,
-	// 						As:  []gwapi.PeeringEntryAs{{CIDR: masqPrefix.String()}},
-	// 						NAT: &gwapi.PeeringNAT{Masquerade: &gwapi.PeeringNATMasquerade{}},
-	// 					},
-	// 				},
-	// 			},
-	// 			"ext." + staticExtProxyName: {
-	// 				Expose: []gwapi.PeeringEntryExpose{
-	// 					{DefaultDestination: true},
-	// 				},
-	// 			},
-	// 		},
-	// 	}
-	// 	slog.Debug("Added gateway masquerade peering", "vpc", vpcCName, "external", staticExtProxyName)
-	// }
 
 	// Peering 4: hostBGP VPC (B) peered with VPC A (a regular VPC)
 	appendVpcPeeringSpecByName(vpcPeerings, vpcBName, vpcAName, "", []string{}, []string{})

--- a/pkg/hhfab/rt_on_ready_suite.go
+++ b/pkg/hhfab/rt_on_ready_suite.go
@@ -25,14 +25,14 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func makeOnReadyTestSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
+func makeOnReadyTestSuite() *JUnitTestSuite {
 	suite := &JUnitTestSuite{
 		Name: "OnReady Suite",
 	}
 	suite.TestCases = []JUnitTestCase{
 		{
 			Name:      "New VLAB OnReady Test",
-			F:         testCtx.newOnReadyTest,
+			F:         newOnReadyTest,
 			SkipFlags: SkipFlags{},
 		},
 	}
@@ -68,7 +68,7 @@ type ortServerInfo struct {
 // At the end of the test, we clean up all VPCs and peerings to leave a clean slate.
 //
 //nolint:cyclop
-func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []RevertFunc, error) {
+func newOnReadyTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	slog.Info("Starting new on-ready test: discovering resources")
 
 	kube := testCtx.kube

--- a/pkg/hhfab/rt_on_ready_suite.go
+++ b/pkg/hhfab/rt_on_ready_suite.go
@@ -1,0 +1,753 @@
+// Copyright 2024 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	gwapi "go.githedgehog.com/fabric/api/gateway/v1alpha1"
+	"go.githedgehog.com/fabric/api/meta"
+	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/hhfctl"
+	"golang.org/x/sync/errgroup"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func makeOnReadyTestSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
+	suite := &JUnitTestSuite{
+		Name: "OnReady Suite",
+	}
+	suite.TestCases = []JUnitTestCase{
+		{
+			Name:      "New VLAB OnReady Test",
+			F:         testCtx.newOnReadyTest,
+			SkipFlags: SkipFlags{},
+		},
+	}
+	suite.Tests = len(suite.TestCases)
+
+	return suite
+}
+
+// ortServerInfo holds information about a server and its connection for the on-ready test.
+type ortServerInfo struct {
+	name        string
+	conn        wiringapi.Connection
+	switches    []string
+	isUnbundled bool
+	isMclag     bool
+}
+
+// Test to get as much coverage as possible for Fabric while being short and compact
+// Unlike the other tests, here we create ad-hoc VPCs and attach them to servers to
+// maximize feature coverage. Specifically we want:
+// - 1 VPC with two subnets, 1 server per subnet
+// - 1 VPC with a single host bgp subnet and a server
+// - 1 VPC with a single subnet and 2 servers attached to two different switches
+// - as many VPCs with a single regular subnet and a single server as there are remaining servers (at least 2)
+// in terms of peering, we want to cover:
+// - 1 single-server VPC peered to the bgp external
+// - 1 single-server VPC peered to the static external without proxy
+// - the 2-servers VPC peered with the proxied static external via the gateway, using masquerade NAT
+// - the host bgp VPC peered with a regular VPC
+// the test should fail if this target setup cannot be achieved, with the only exception of gateway
+// not being enabled, in which case we skip gateway peerings
+// Note that there are more things that we could test but are not supported by virtual switches,
+// such as restricted/isolated flags, multiple peerings to the same external etc.
+// At the end of the test, we clean up all VPCs and peerings to leave a clean slate.
+//
+//nolint:cyclop
+func (testCtx *VPCPeeringTestCtx) newOnReadyTest(ctx context.Context) (bool, []RevertFunc, error) {
+	slog.Info("Starting new on-ready test: discovering resources")
+
+	kube := testCtx.kube
+	reverts := make([]RevertFunc, 0)
+
+	// ── Phase 1: Discover switches and classify MCLAG ────────────────────
+	swList := &wiringapi.SwitchList{}
+	if err := kube.List(ctx, swList); err != nil {
+		return false, nil, fmt.Errorf("listing switches: %w", err)
+	}
+	mclagSwitches := map[string]bool{}
+	for _, sw := range swList.Items {
+		if sw.Spec.Redundancy.Type == meta.RedundancyTypeMCLAG {
+			mclagSwitches[sw.Name] = true
+		}
+	}
+
+	// ── Phase 2: Discover servers and their connections ───────────────────
+	servers := &wiringapi.ServerList{}
+	if err := kube.List(ctx, servers); err != nil {
+		return false, nil, fmt.Errorf("listing servers: %w", err)
+	}
+	// Sort servers by their numeric ID for deterministic allocation
+	serverIDs := map[string]uint64{}
+	for _, server := range servers.Items {
+		if !strings.HasPrefix(server.Name, ServerNamePrefix) {
+			continue
+		}
+
+		serverID, err := strconv.ParseUint(server.Name[len(ServerNamePrefix):], 10, 64)
+		if err != nil {
+			continue
+		}
+		serverIDs[server.Name] = serverID
+	}
+	slices.SortFunc(servers.Items, func(a, b wiringapi.Server) int {
+		return int(serverIDs[a.Name]) - int(serverIDs[b.Name]) //nolint:gosec
+	})
+
+	available := make([]ortServerInfo, 0, len(servers.Items))
+	for _, server := range servers.Items {
+		if _, ok := serverIDs[server.Name]; !ok {
+			continue
+		}
+
+		conns := &wiringapi.ConnectionList{}
+		if err := kube.List(ctx, conns, wiringapi.MatchingLabelsForListLabelServer(server.Name)); err != nil {
+			return false, nil, fmt.Errorf("listing connections for server %q: %w", server.Name, err)
+		}
+		if len(conns.Items) != 1 {
+			slog.Debug("Skipping server with unexpected connection count", "server", server.Name, "conns", len(conns.Items))
+
+			continue
+		}
+		conn := conns.Items[0]
+
+		// Skip ESLAG servers in non-L2VNI mode (they need special handling)
+		if conn.Spec.ESLAG != nil && testCtx.setupOpts.VPCMode != vpcapi.VPCModeL2VNI {
+			slog.Debug("Skipping ESLAG server", "server", server.Name)
+
+			continue
+		}
+
+		switches, _, _, _, err := conn.Spec.Endpoints()
+		if err != nil {
+			slog.Debug("Skipping server with endpoint error", "server", server.Name, "err", err)
+
+			continue
+		}
+		isMclag := false
+		for _, sw := range switches {
+			if mclagSwitches[sw] {
+				isMclag = true
+
+				break
+			}
+		}
+		available = append(available, ortServerInfo{
+			name:        server.Name,
+			conn:        conn,
+			switches:    switches,
+			isUnbundled: conn.Spec.Unbundled != nil,
+			isMclag:     isMclag,
+		})
+	}
+	slog.Info("Discovered available servers", "count", len(available))
+
+	// ── Phase 3: Discover externals ──────────────────────────────────────
+	extList := &vpcapi.ExternalList{}
+	if err := kube.List(ctx, extList); err != nil {
+		return false, nil, fmt.Errorf("listing externals: %w", err)
+	}
+	extAttachList := &vpcapi.ExternalAttachmentList{}
+	if err := kube.List(ctx, extAttachList); err != nil {
+		return false, nil, fmt.Errorf("listing external attachments: %w", err)
+	}
+
+	var bgpExtName, staticExtNonProxyName, staticExtProxyName string
+	// var staticExtProxyRemoteIP string
+	for _, ext := range extList.Items {
+		if ext.Spec.Static == nil {
+			// BGP external
+			if bgpExtName == "" {
+				// Verify it has at least one attachment
+				for _, att := range extAttachList.Items {
+					if att.Spec.External == ext.Name {
+						bgpExtName = ext.Name
+
+						break
+					}
+				}
+			}
+		} else {
+			// Static external – classify by attachment proxy flag
+			for _, att := range extAttachList.Items {
+				if att.Spec.External != ext.Name || att.Spec.Static == nil {
+					continue
+				}
+				if att.Spec.Static.Proxy && staticExtProxyName == "" {
+					staticExtProxyName = ext.Name
+					// staticExtProxyRemoteIP = att.Spec.Static.RemoteIP
+				} else if !att.Spec.Static.Proxy && staticExtNonProxyName == "" {
+					staticExtNonProxyName = ext.Name
+				}
+			}
+		}
+	}
+	slog.Info("Discovered externals",
+		"bgp", bgpExtName, "staticNonProxy", staticExtNonProxyName, "staticProxy", staticExtProxyName)
+
+	// ── Phase 4: Validate preconditions ──────────────────────────────────
+	if bgpExtName == "" {
+		return false, nil, fmt.Errorf("no BGP external found, cannot run on-ready test") //nolint:goerr113
+	}
+	if staticExtNonProxyName == "" {
+		return false, nil, fmt.Errorf("no static external without proxy found, cannot run on-ready test") //nolint:goerr113
+	}
+	if staticExtProxyName == "" {
+		slog.Warn("no proxied static external found, but we are currently skipping its testing")
+	}
+	const minServers = 7
+	if len(available) < minServers {
+		return false, nil, fmt.Errorf("not enough servers: need at least %d, found %d", minServers, len(available)) //nolint:goerr113
+	}
+
+	// ── Phase 5: Allocate servers to VPC roles ───────────────────────────
+	// We consume servers from the `available` slice as we assign them.
+	used := map[string]bool{}
+	take := func(pred func(s ortServerInfo) bool) (ortServerInfo, bool) {
+		for _, s := range available {
+			if used[s.name] {
+				continue
+			}
+
+			if pred(s) {
+				used[s.name] = true
+
+				return s, true
+			}
+		}
+
+		return ortServerInfo{}, false
+	}
+
+	// VPC B: 1 hostBGP subnet – needs unbundled, non-MCLAG
+	hostBGPServer, ok := take(func(s ortServerInfo) bool {
+		return s.isUnbundled && !s.isMclag
+	})
+	if !ok {
+		return false, nil, fmt.Errorf("no unbundled non-MCLAG server available for hostBGP VPC") //nolint:goerr113
+	}
+
+	// VPC C: 1 subnet, 2 servers on different non mclag switches
+	vpcCServer1, ok := take(func(s ortServerInfo) bool { return !s.isMclag })
+	if !ok {
+		return false, nil, fmt.Errorf("not enough servers for multi-switch VPC") //nolint:goerr113
+	}
+	vpcCServer2, ok := take(func(s ortServerInfo) bool {
+		if s.isMclag {
+			return false
+		}
+		// Must be on a different switch than vpcCServer1
+		for _, sw := range s.switches {
+			for _, sw1 := range vpcCServer1.switches {
+				if sw == sw1 {
+					return false
+				}
+			}
+		}
+
+		return true
+	})
+	if !ok {
+		return false, nil, fmt.Errorf("no server on a different switch found for multi-switch VPC") //nolint:goerr113
+	}
+
+	// VPC A: 2 subnets, 1 server per subnet
+	vpcAServer1, ok := take(func(s ortServerInfo) bool { return true })
+	if !ok {
+		return false, nil, fmt.Errorf("not enough servers for dual-subnet VPC (server 1)") //nolint:goerr113
+	}
+	vpcAServer2, ok := take(func(s ortServerInfo) bool { return true })
+	if !ok {
+		return false, nil, fmt.Errorf("not enough servers for dual-subnet VPC (server 2)") //nolint:goerr113
+	}
+
+	// VPC D+: remaining servers, need at least 2 for BGP external + static external peerings
+	singleServers := make([]ortServerInfo, 0)
+	for _, s := range available {
+		if used[s.name] {
+			continue
+		}
+		used[s.name] = true
+		singleServers = append(singleServers, s)
+	}
+	if len(singleServers) < 2 {
+		return false, nil, fmt.Errorf("not enough remaining servers for single-server VPCs: need at least 2, got %d", len(singleServers)) //nolint:goerr113
+	}
+	slog.Info("Server allocation complete",
+		"vpcA", []string{vpcAServer1.name, vpcAServer2.name},
+		"vpcB_hostBGP", hostBGPServer.name,
+		"vpcC_multiSwitch", []string{vpcCServer1.name, vpcCServer2.name},
+		"singleServerVPCs", len(singleServers))
+
+	// ── Phase 6: Allocate VLANs and subnets ──────────────────────────────
+	vlanNS := &wiringapi.VLANNamespace{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Name: testCtx.setupOpts.VLANNamespace, Namespace: kmetav1.NamespaceDefault}, vlanNS); err != nil {
+		return false, nil, fmt.Errorf("getting VLAN namespace %s: %w", testCtx.setupOpts.VLANNamespace, err)
+	}
+	nextVLAN, stopVLAN := iter.Pull(VLANsFrom(vlanNS.Spec.Ranges...))
+	defer stopVLAN()
+
+	ipNS := &vpcapi.IPv4Namespace{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Name: testCtx.setupOpts.IPv4Namespace, Namespace: kmetav1.NamespaceDefault}, ipNS); err != nil {
+		return false, nil, fmt.Errorf("getting IPv4 namespace %s: %w", testCtx.setupOpts.IPv4Namespace, err)
+	}
+	prefixes := make([]netip.Prefix, 0)
+	for _, p := range ipNS.Spec.Subnets {
+		parsed, err := netip.ParsePrefix(p)
+		if err != nil {
+			return false, nil, fmt.Errorf("parsing IPv4 namespace prefix %q: %w", p, err)
+		}
+		prefixes = append(prefixes, parsed)
+	}
+	nextPrefix, stopPrefix := iter.Pull(SubPrefixesFrom(24, prefixes...))
+	defer stopPrefix()
+
+	allocVLAN := func() (uint16, error) {
+		v, ok := nextVLAN()
+		if !ok {
+			return 0, fmt.Errorf("no more VLANs available") //nolint:goerr113
+		}
+
+		return v, nil
+	}
+	allocSubnet := func() (string, error) {
+		p, ok := nextPrefix()
+		if !ok {
+			return "", fmt.Errorf("no more subnets available") //nolint:goerr113
+		}
+
+		return p.String(), nil
+	}
+
+	vpcMode := testCtx.setupOpts.VPCMode
+	hashPolicy := testCtx.setupOpts.HashPolicy
+
+	// ── Phase 7: Build VPCs, attachments, and server netconf commands ────
+	type vpcPlan struct {
+		vpc      *vpcapi.VPC
+		attaches []*vpcapi.VPCAttachment
+		// map server name → netconf command (for hhnet) or hostBGP arguments
+		netconfs map[string]string
+		hostBGP  map[string]bool
+	}
+	plans := make([]vpcPlan, 0)
+
+	makeRegularSubnet := func() (*vpcapi.VPCSubnet, error) {
+		cidr, err := allocSubnet()
+		if err != nil {
+			return nil, err
+		}
+		vlan, err := allocVLAN()
+		if err != nil {
+			return nil, err
+		}
+
+		return &vpcapi.VPCSubnet{
+			Subnet: cidr,
+			VLAN:   vlan,
+			DHCP:   vpcapi.VPCDHCP{Enable: true},
+		}, nil
+	}
+
+	makeAttach := func(connName, vpcName, subnetName string) *vpcapi.VPCAttachment {
+		attachName := fmt.Sprintf("%s--%s--%s", connName, vpcName, subnetName)
+
+		return &vpcapi.VPCAttachment{
+			ObjectMeta: kmetav1.ObjectMeta{
+				Name:      attachName,
+				Namespace: kmetav1.NamespaceDefault,
+			},
+			Spec: vpcapi.VPCAttachmentSpec{
+				Connection: connName,
+				Subnet:     fmt.Sprintf("%s/%s", vpcName, subnetName),
+			},
+		}
+	}
+
+	serverNetconf := func(s ortServerInfo, vlan uint16, hashPolicy string) (string, error) {
+		return GetServerNetconfCmd(&s.conn, ServerNetconfOpts{VLAN: vlan, HashPolicy: hashPolicy})
+	}
+
+	// ── VPC A: 2 subnets, 1 server per subnet ───────────────────────────
+	const vpcAName = "ort-a"
+	{
+		sub1, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC A subnet-01: %w", err)
+		}
+		sub2, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC A subnet-02: %w", err)
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcAName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub1,
+					"subnet-02": sub2,
+				},
+			},
+		}
+		att1 := makeAttach(vpcAServer1.conn.Name, vpcAName, "subnet-01")
+		att2 := makeAttach(vpcAServer2.conn.Name, vpcAName, "subnet-02")
+		nc1, err := serverNetconf(vpcAServer1, sub1.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcAServer1.name, err)
+		}
+		nc2, err := serverNetconf(vpcAServer2, sub2.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcAServer2.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att1, att2},
+			netconfs: map[string]string{vpcAServer1.name: nc1, vpcAServer2.name: nc2},
+			hostBGP:  map[string]bool{},
+		})
+	}
+
+	// ── VPC B: 1 hostBGP subnet, 1 server ────────────────────────────────
+	const vpcBName = "ort-b"
+	{
+		subCIDR, err := allocSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC B subnet: %w", err)
+		}
+		vlan, err := allocVLAN()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC B VLAN: %w", err)
+		}
+		sub := &vpcapi.VPCSubnet{
+			Subnet:  subCIDR,
+			HostBGP: true,
+			VLAN:    vlan,
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcBName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub,
+				},
+			},
+		}
+		att := makeAttach(hostBGPServer.conn.Name, vpcBName, "subnet-01")
+		subPrefix, err := netip.ParsePrefix(subCIDR)
+		if err != nil {
+			return false, nil, fmt.Errorf("parsing VPC B subnet: %w", err)
+		}
+		hostBGPCmd, err := getServerHostBGPCmd(&hostBGPServer.conn, vlan, subPrefix, 1)
+		if err != nil {
+			return false, nil, fmt.Errorf("hostBGP cmd for %s: %w", hostBGPServer.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att},
+			netconfs: map[string]string{hostBGPServer.name: hostBGPCmd},
+			hostBGP:  map[string]bool{hostBGPServer.name: true},
+		})
+	}
+
+	// ── VPC C: 1 subnet, 2 servers on different switches ─────────────────
+	const vpcCName = "ort-c"
+	{
+		sub, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating VPC C subnet: %w", err)
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcCName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub,
+				},
+			},
+		}
+		att1 := makeAttach(vpcCServer1.conn.Name, vpcCName, "subnet-01")
+		att2 := makeAttach(vpcCServer2.conn.Name, vpcCName, "subnet-01")
+		nc1, err := serverNetconf(vpcCServer1, sub.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcCServer1.name, err)
+		}
+		nc2, err := serverNetconf(vpcCServer2, sub.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", vpcCServer2.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att1, att2},
+			netconfs: map[string]string{vpcCServer1.name: nc1, vpcCServer2.name: nc2},
+			hostBGP:  map[string]bool{},
+		})
+	}
+
+	// ── VPC D+: 1 regular subnet + 1 server each, for remaining servers ──
+	singleServerVPCs := make(map[string]*vpcapi.VPC, len(singleServers))
+	for i, s := range singleServers {
+		vpcName := fmt.Sprintf("ort-d%d", i+1)
+		sub, err := makeRegularSubnet()
+		if err != nil {
+			return false, nil, fmt.Errorf("allocating %s subnet: %w", vpcName, err)
+		}
+		vpc := &vpcapi.VPC{
+			ObjectMeta: kmetav1.ObjectMeta{Name: vpcName, Namespace: kmetav1.NamespaceDefault},
+			Spec: vpcapi.VPCSpec{
+				Mode: vpcMode,
+				Subnets: map[string]*vpcapi.VPCSubnet{
+					"subnet-01": sub,
+				},
+			},
+		}
+		singleServerVPCs[s.name] = vpc
+		att := makeAttach(s.conn.Name, vpcName, "subnet-01")
+		nc, err := serverNetconf(s, sub.VLAN, hashPolicy)
+		if err != nil {
+			return false, nil, fmt.Errorf("netconf for %s: %w", s.name, err)
+		}
+		plans = append(plans, vpcPlan{
+			vpc:      vpc,
+			attaches: []*vpcapi.VPCAttachment{att},
+			netconfs: map[string]string{s.name: nc},
+			hostBGP:  map[string]bool{},
+		})
+	}
+
+	// ── Phase 8: Create VPCs and attachments in Kubernetes ────────────────
+	slog.Info("Creating VPCs and attachments", "vpcs", len(plans))
+
+	// Register a cleanup revert that removes everything we created
+	reverts = append(reverts, func(ctx context.Context) error {
+		slog.Info("Cleaning up on-ready test VPCs and peerings")
+		var cleanupErr error
+		if err := hhfctl.VPCWipeWithClient(ctx, kube); err != nil {
+			cleanupErr = fmt.Errorf("failed to wipe VPCs and peerings: %w", err)
+		}
+		// Clean up server networking
+		for _, plan := range plans {
+			for serverName := range plan.netconfs {
+				ssh, err := testCtx.getSSH(ctx, serverName)
+				if err != nil {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to get SSH for cleanup: %w", err))
+
+					continue
+				}
+				if plan.hostBGP[serverName] {
+					_, _, _ = ssh.Run(ctx, "docker stop -t 1 hostbgp")
+				}
+
+				if _, _, err := ssh.Run(ctx, "/opt/bin/hhnet cleanup"); err != nil {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("hhnet cleanup failed: %w", err))
+				}
+			}
+		}
+
+		return cleanupErr
+	})
+
+	for _, plan := range plans {
+		if _, err := CreateOrUpdateVpc(ctx, kube, plan.vpc); err != nil {
+			return false, reverts, fmt.Errorf("creating VPC %s: %w", plan.vpc.Name, err)
+		}
+	}
+
+	for _, plan := range plans {
+		for _, att := range plan.attaches {
+			if err := kube.Create(ctx, att); err != nil {
+				return false, reverts, fmt.Errorf("creating attachment %s: %w", att.Name, err)
+			}
+		}
+	}
+
+	// Wait for switches to pick up the new VPCs/attachments
+	time.Sleep(15 * time.Second)
+	if err := WaitReady(ctx, kube, testCtx.wrOpts); err != nil {
+		return false, reverts, fmt.Errorf("waiting for ready after creating VPCs: %w", err)
+	}
+
+	// ── Phase 9: Configure server networking ─────────────────────────────
+	slog.Info("Configuring server networking")
+
+	g := &errgroup.Group{}
+	for _, plan := range plans {
+		for serverName, cmd := range plan.netconfs {
+			g.Go(func() error {
+				ssh, err := testCtx.getSSH(ctx, serverName)
+				if err != nil {
+					return fmt.Errorf("getting SSH for %s: %w", serverName, err)
+				}
+				// Cleanup any previous config
+				if _, _, err := ssh.Run(ctx, "docker stop -t 1 hostbgp"); err != nil {
+					// Ignore – container may not be running
+					_ = err
+				}
+				if _, stderr, err := ssh.Run(ctx, "/opt/bin/hhnet cleanup"); err != nil {
+					return fmt.Errorf("hhnet cleanup on %s: %w: %s", serverName, err, stderr)
+				}
+
+				if plan.hostBGP[serverName] {
+					slog.Debug("Starting hostBGP container", "server", serverName, "args", cmd)
+					_, stderr, err := ssh.Run(ctx, "docker run --network=host --privileged --rm --detach --name hostbgp ghcr.io/githedgehog/host-bgp "+cmd)
+					if err != nil {
+						return fmt.Errorf("starting hostbgp on %s: %w: %s", serverName, err, stderr)
+					}
+					// Wait for hostBGP to acquire a VIP
+					acquired := false
+					for attempt := range 10 {
+						time.Sleep(2 * time.Second)
+						stdout, _, err := ssh.Run(ctx, "/opt/bin/hhnet getvips")
+						if err != nil {
+							continue
+						}
+						for line := range strings.Lines(stdout) {
+							line = strings.TrimSpace(line)
+							if _, parseErr := netip.ParsePrefix(line); parseErr == nil {
+								acquired = true
+								slog.Debug("HostBGP VIP acquired", "server", serverName, "vip", line, "attempt", attempt+1)
+
+								break
+							}
+						}
+						if acquired {
+							break
+						}
+					}
+					if !acquired {
+						return fmt.Errorf("hostBGP on %s did not acquire VIP in time", serverName) //nolint:goerr113
+					}
+				} else {
+					slog.Debug("Configuring server networking", "server", serverName, "cmd", cmd)
+					stdout, stderr, err := ssh.Run(ctx, "/opt/bin/hhnet "+cmd)
+					if err != nil {
+						return fmt.Errorf("hhnet on %s: %w: %s", serverName, err, stderr)
+					}
+					addr := strings.TrimSpace(stdout)
+					if _, parseErr := netip.ParsePrefix(addr); parseErr != nil {
+						return fmt.Errorf("unexpected hhnet output on %s: %q", serverName, addr) //nolint:goerr113
+					}
+					slog.Debug("Server configured", "server", serverName, "addr", addr)
+				}
+
+				return nil
+			})
+		}
+	}
+
+	if err := g.Wait(); err != nil {
+		return false, reverts, fmt.Errorf("configuring server networking: %w", err)
+	}
+
+	// In L3VNI mode, give extra time for routes to propagate
+	if vpcMode == vpcapi.VPCModeL3VNI || vpcMode == vpcapi.VPCModeL3Flat {
+		time.Sleep(10 * time.Second)
+	}
+
+	// ── Phase 10: Build and apply peerings ───────────────────────────────
+	slog.Info("Setting up peerings")
+
+	// We need the created VPCs (with defaults applied) to build gateway peering specs.
+	// Re-fetch VPC C to get full subnet CIDRs after defaults.
+	vpcC := &vpcapi.VPC{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Name: vpcCName, Namespace: kmetav1.NamespaceDefault}, vpcC); err != nil {
+		return false, reverts, fmt.Errorf("getting VPC %s: %w", vpcCName, err)
+	}
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	extPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	// Peering 1: first single-server VPC peered to the BGP external
+	bgpPeerVPC := singleServerVPCs[singleServers[0].name]
+	appendExtPeeringSpecByName(extPeerings, bgpPeerVPC.Name, bgpExtName, []string{"subnet-01"}, AllZeroPrefix)
+	slog.Debug("Added BGP external peering", "server", singleServers[0].name, "vpc", bgpPeerVPC.Name, "external", bgpExtName)
+
+	// Peering 2: second single-server VPC peered to the static external without proxy
+	staticPeerVPC := singleServerVPCs[singleServers[1].name]
+	appendExtPeeringSpecByName(extPeerings, staticPeerVPC.Name, staticExtNonProxyName, []string{"subnet-01"}, AllZeroPrefix)
+	slog.Debug("Added static (non-proxy) external peering", "server", singleServers[1].name, "vpc", staticPeerVPC.Name, "external", staticExtNonProxyName)
+
+	// Peering 3: VPC C (2-server, multi-switch) peered with the proxied static external via gateway, masquerade NAT
+	// commented out as test-connectivity does not support NAT currently
+	// if testCtx.gwSupported {
+	// 	entryName := fmt.Sprintf("%s--ext.%s", vpcCName, staticExtProxyName)
+	// 	// Expose VPC C's subnet with masquerade NAT
+	// 	vpcCSubnets := make([]gwapi.PeeringEntryIP, 0)
+	// 	for _, sub := range vpcC.Spec.Subnets {
+	// 		vpcCSubnets = append(vpcCSubnets, gwapi.PeeringEntryIP{CIDR: sub.Subnet})
+	// 	}
+	// 	extIP, err := netip.ParseAddr(staticExtProxyRemoteIP)
+	// 	if err != nil {
+	// 		return false, reverts, fmt.Errorf("parsing static external proxy remote IP %q: %w", staticExtProxyRemoteIP, err)
+	// 	}
+	// 	masqPrefix, err := extIP.Next().Prefix(32)
+	// 	if err != nil {
+	// 		return false, reverts, fmt.Errorf("creating masquerade prefix from %q: %w", extIP.Next(), err)
+	// 	}
+	// 	gwPeerings[entryName] = &gwapi.PeeringSpec{
+	// 		Peering: map[string]*gwapi.PeeringEntry{
+	// 			vpcCName: {
+	// 				Expose: []gwapi.PeeringEntryExpose{
+	// 					{
+	// 						IPs: vpcCSubnets,
+	// 						As:  []gwapi.PeeringEntryAs{{CIDR: masqPrefix.String()}},
+	// 						NAT: &gwapi.PeeringNAT{Masquerade: &gwapi.PeeringNATMasquerade{}},
+	// 					},
+	// 				},
+	// 			},
+	// 			"ext." + staticExtProxyName: {
+	// 				Expose: []gwapi.PeeringEntryExpose{
+	// 					{DefaultDestination: true},
+	// 				},
+	// 			},
+	// 		},
+	// 	}
+	// 	slog.Debug("Added gateway masquerade peering", "vpc", vpcCName, "external", staticExtProxyName)
+	// }
+
+	// Peering 4: hostBGP VPC (B) peered with VPC A (a regular VPC)
+	appendVpcPeeringSpecByName(vpcPeerings, vpcBName, vpcAName, "", []string{}, []string{})
+	slog.Debug("Added VPC peering", "vpc1", vpcBName, "vpc2", vpcAName)
+
+	// Extra gateway peerings to increase coverage. TODO: add NAT once test-connectivity supports it.
+	// Note that we skip peering between the first two servers as they are respectively peered to the BGP external
+	// and the static non-proxy one, and by peering them the bgp VRF would get a LPM route to the second server
+	// compared to the flat ipv4 namespace route the static external vrf has in the virtual external
+	if !testCtx.skipFlags.NoGateway {
+		for i := 1; i <= len(singleServers)-2; i++ {
+			if err := appendGwPeeringSpec(gwPeerings, singleServerVPCs[singleServers[i].name], singleServerVPCs[singleServers[i+1].name], nil); err != nil {
+				return false, reverts, fmt.Errorf("setting up gateway peering: %w", err)
+			}
+		}
+	}
+
+	if err := DoSetupPeerings(ctx, kube, vpcPeerings, extPeerings, gwPeerings, true); err != nil {
+		return false, reverts, fmt.Errorf("setting up peerings: %w", err)
+	}
+
+	// ── Phase 11: Test connectivity ──────────────────────────────────────
+	slog.Info("Running connectivity test")
+
+	if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		return false, reverts, fmt.Errorf("connectivity test failed: %w", err)
+	}
+
+	slog.Info("On-ready test completed successfully")
+
+	return false, reverts, nil
+}

--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -27,21 +27,21 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
+func makeSingleVPCSuite() *JUnitTestSuite {
 	suite := &JUnitTestSuite{
 		Name: "Single VPC Suite",
 	}
 	suite.TestCases = []JUnitTestCase{
 		{
 			Name: "No restrictions",
-			F:    testCtx.noRestrictionsTest,
+			F:    noRestrictionsTest,
 			SkipFlags: SkipFlags{
 				NoServers: true,
 			},
 		},
 		{
 			Name: "Single VPC with restrictions",
-			F:    testCtx.singleVPCWithRestrictionsTest,
+			F:    singleVPCWithRestrictionsTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoServers:     true,
@@ -49,19 +49,19 @@ func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "DNS/NTP/MTU/DHCP lease",
-			F:    testCtx.dnsNtpMtuTest,
+			F:    dnsNtpMtuTest,
 		},
 		{
 			Name: "DHCP renewal",
-			F:    testCtx.dhcpRenewalTest,
+			F:    dhcpRenewalTest,
 		},
 		{
 			Name: "DHCP static lease",
-			F:    testCtx.dhcpStaticLeaseTest,
+			F:    dhcpStaticLeaseTest,
 		},
 		{
 			Name: "MCLAG Failover",
-			F:    testCtx.mclagTest,
+			F:    mclagTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoServers:     true,
@@ -69,7 +69,7 @@ func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "ESLAG Failover",
-			F:    testCtx.eslagTest,
+			F:    eslagTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoServers:     true,
@@ -77,7 +77,7 @@ func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Bundled Failover",
-			F:    testCtx.bundledFailoverTest,
+			F:    bundledFailoverTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoServers:     true,
@@ -85,7 +85,7 @@ func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Spine Failover",
-			F:    testCtx.spineFailoverTest,
+			F:    spineFailoverTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoFabricLink:  true,
@@ -94,7 +94,7 @@ func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "Mesh Failover",
-			F:    testCtx.meshFailoverTest,
+			F:    meshFailoverTest,
 			SkipFlags: SkipFlags{
 				VirtualSwitch: true,
 				NoMeshLink:    true,
@@ -103,7 +103,7 @@ func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 		},
 		{
 			Name: "RoCE flag and basic traffic marking",
-			F:    testCtx.roceBasicTest,
+			F:    roceBasicTest,
 			SkipFlags: SkipFlags{
 				RoCE:      true,
 				NoServers: true,
@@ -118,7 +118,7 @@ func makeSingleVPCSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 // Basic test for mclag failover.
 // For each mclag connection, set one of the links down by shutting down the port on the switch,
 // then test connectivity. Repeat for the other link.
-func (testCtx *VPCPeeringTestCtx) mclagTest(ctx context.Context) (bool, []RevertFunc, error) {
+func mclagTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// list connections in the fabric, filter by MC-LAG connection type
 	conns := &wiringapi.ConnectionList{}
 	if err := testCtx.kube.List(ctx, conns, kclient.MatchingLabels{wiringapi.LabelConnectionType: wiringapi.ConnectionTypeMCLAG}); err != nil {
@@ -153,7 +153,7 @@ func (testCtx *VPCPeeringTestCtx) mclagTest(ctx context.Context) (bool, []Revert
 // Basic test for eslag failover.
 // For each eslag connection, set one of the links down by shutting down the port on the switch,
 // then test connectivity. Repeat for the other link.
-func (testCtx *VPCPeeringTestCtx) eslagTest(ctx context.Context) (bool, []RevertFunc, error) {
+func eslagTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// l3vni mode is not compatible with ESLAG, so there will be no servers attached to ESLAG connections
 	if testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3VNI {
 		return true, nil, fmt.Errorf("L3VNI mode is not compatible with ESLAG") //nolint:goerr113
@@ -192,7 +192,7 @@ func (testCtx *VPCPeeringTestCtx) eslagTest(ctx context.Context) (bool, []Revert
 // Basic test for bundled connection failover.
 // For each bundled connection, set one of the links down by shutting down the port on the switch,
 // then test connectivity. Repeat for the other link(s).
-func (testCtx *VPCPeeringTestCtx) bundledFailoverTest(ctx context.Context) (bool, []RevertFunc, error) {
+func bundledFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// list connections in the fabric, filter by bundled connection type
 	conns := &wiringapi.ConnectionList{}
 	if err := testCtx.kube.List(ctx, conns, kclient.MatchingLabels{wiringapi.LabelConnectionType: wiringapi.ConnectionTypeBundled}); err != nil {
@@ -227,7 +227,7 @@ func (testCtx *VPCPeeringTestCtx) bundledFailoverTest(ctx context.Context) (bool
 // Basic test for spine failover.
 // Iterate over the spine switches (skip the first one), and shut down all links towards them.
 // Test connectivity, then re-enable the links.
-func (testCtx *VPCPeeringTestCtx) spineFailoverTest(ctx context.Context) (bool, []RevertFunc, error) {
+func spineFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	var returnErr error
 
 	// list spines, unfortunately we cannot filter by role
@@ -358,7 +358,7 @@ outer:
 // that group, then shuts down all spine ports connected to the primary gateway.
 // After restoring, tests connectivity again.
 // Requires at least 2 gateways and 2 VPCs.
-func (testCtx *VPCPeeringTestCtx) gatewayFailoverTest(ctx context.Context) (bool, []RevertFunc, error) {
+func gatewayFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	var returnErr error
 
 	// list gateways
@@ -671,7 +671,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayFailoverTest(ctx context.Context) (bool
 // Basic test for mesh failover.
 // Iterate over leaf switches, shutdown all mesh links except for one, test connectivity
 // as soon as we manage to test this on a leaf, return and renable all agents as part of the revert
-func (testCtx *VPCPeeringTestCtx) meshFailoverTest(ctx context.Context) (bool, []RevertFunc, error) {
+func meshFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// list leaves, unfortunately we cannot filter by role
 	switches := &wiringapi.SwitchList{}
 	if err := testCtx.kube.List(ctx, switches); err != nil {
@@ -805,7 +805,7 @@ func (testCtx *VPCPeeringTestCtx) meshFailoverTest(ctx context.Context) (bool, [
 }
 
 // Vanilla test for VPC peering, just test connectivity without any further restriction
-func (testCtx *VPCPeeringTestCtx) noRestrictionsTest(ctx context.Context) (bool, []RevertFunc, error) {
+func noRestrictionsTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
 		return false, nil, fmt.Errorf("waiting for readiness: %w", err)
 	}
@@ -823,7 +823,7 @@ func (testCtx *VPCPeeringTestCtx) noRestrictionsTest(ctx context.Context) (bool,
 // 3. Set both isolated and restricted flags in the third subnet, test connectivity
 // 4. Override isolation with explicit permit list, test connectivity
 // 5. Remove all restrictions
-func (testCtx *VPCPeeringTestCtx) singleVPCWithRestrictionsTest(ctx context.Context) (bool, []RevertFunc, error) {
+func singleVPCWithRestrictionsTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	var returnErr error
 
 	vpcs := &vpcapi.VPCList{}
@@ -958,7 +958,7 @@ outer:
 // for NTP, we check the output of timedatectl show-timesync;
 // for MTU, we check the output of "ip link" on the vlan interface;
 // for DHCP Lease, we check the output of "ip addr" on the server.
-func (testCtx *VPCPeeringTestCtx) dnsNtpMtuTest(ctx context.Context) (bool, []RevertFunc, error) {
+func dnsNtpMtuTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	vpcAttaches := &vpcapi.VPCAttachmentList{}
 	if err := testCtx.kube.List(ctx, vpcAttaches); err != nil {
 		return false, nil, fmt.Errorf("listing VPCAttachments: %w", err)
@@ -1141,7 +1141,7 @@ func (testCtx *VPCPeeringTestCtx) dnsNtpMtuTest(ctx context.Context) (bool, []Re
 // Uses 1 server by default, all servers in extended mode
 // Sets VPC DHCPOptions to a shorter lease and reconfigures servers via networkctl
 // Waits for DHCP renewal and checks lease time
-func (testCtx *VPCPeeringTestCtx) dhcpRenewalTest(ctx context.Context) (bool, []RevertFunc, error) {
+func dhcpRenewalTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// Find VPC with at least one server attached that has DHCP enabled
 	vpcAttaches := &vpcapi.VPCAttachmentList{}
 	if err := testCtx.kube.List(ctx, vpcAttaches); err != nil {
@@ -1415,7 +1415,7 @@ func (testCtx *VPCPeeringTestCtx) testStaticIPAssignment(ctx context.Context, vp
 // Verifies that static IP assignments work correctly both within and outside the dynamic range.
 // The test finds any server on any subnet, saves the existing DHCP config (if any),
 // forces a hardcoded DHCP config, runs tests, and restores the original config.
-func (testCtx *VPCPeeringTestCtx) dhcpStaticLeaseTest(ctx context.Context) (bool, []RevertFunc, error) {
+func dhcpStaticLeaseTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// 1. Find any server attached to any VPC subnet (regardless of DHCP config)
 	serverInfo, err := findAnyAttachedServer(ctx, testCtx.kube)
 	if errors.Is(err, errNoAttachedServers) {
@@ -1525,7 +1525,7 @@ func (testCtx *VPCPeeringTestCtx) dhcpStaticLeaseTest(ctx context.Context) (bool
 
 // Test RoCE functionality and DSCP traffic marking by enabling RoCE on a leaf switch
 // with servers, generating DSCP 24 marked traffic, and verifying UC3 queue counters.
-func (testCtx *VPCPeeringTestCtx) roceBasicTest(ctx context.Context) (bool, []RevertFunc, error) {
+func roceBasicTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	// this should never fail
 	if len(testCtx.roceLeaves) == 0 {
 		slog.Error("RoCE leaves not specified, skipping RoCE basic test")

--- a/pkg/hhfab/rt_static_external.go
+++ b/pkg/hhfab/rt_static_external.go
@@ -22,7 +22,7 @@ var (
 // staticExternalPeeringTest tests static external connectivity using the External API
 // with spec.static (non-BGP mode). This test requires a static External with an ExternalAttachment
 // it creates the ExternalPeering dynamically to test VPC-to-External connectivity.
-func (testCtx *VPCPeeringTestCtx) staticExternalPeeringTest(ctx context.Context) (bool, []RevertFunc, error) {
+func staticExternalPeeringTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
 	if testCtx.staticExtName == "" {
 		return true, nil, errNoStaticExternalWithAttachment
 	}

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -440,11 +440,13 @@ func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (st
 	return netconfCmd, nil
 }
 
-func getServerHostBGPCmd(conn *wiringapi.Connection, subnet netip.Prefix, serversInSubnet int) (string, error) {
+// TODO: multi subnet support once test-connectivity supports it
+func getServerHostBGPCmd(conn *wiringapi.Connection, vlan uint16, subnet netip.Prefix, serversInSubnet int) (string, error) {
 	if conn == nil {
 		return "", fmt.Errorf("connection is nil")
 	}
 
+	cmd := fmt.Sprintf("vpc:v=%d:i=", vlan)
 	interfaces := []string{}
 	switch {
 	case conn.Spec.Unbundled != nil:
@@ -465,7 +467,7 @@ func getServerHostBGPCmd(conn *wiringapi.Connection, subnet netip.Prefix, server
 		return "", fmt.Errorf("unexpected connection type for conn %q", conn.Name)
 	}
 
-	cmd := strings.Join(interfaces, ",")
+	cmd += strings.Join(interfaces, ":i=")
 	addr := subnet.Addr()
 	for range serversInSubnet {
 		addr = addr.Next()
@@ -473,7 +475,7 @@ func getServerHostBGPCmd(conn *wiringapi.Connection, subnet netip.Prefix, server
 	if !addr.IsValid() {
 		return "", fmt.Errorf("failed to get IP address from subnet %s", subnet.String())
 	}
-	cmd += " " + addr.String() + "/32"
+	cmd += ":a=" + addr.String() + "/32"
 
 	return cmd, nil
 }
@@ -839,18 +841,14 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 				}
 			}
 
-			var vlan uint16
+			vlan, ok := nextVLAN()
+			if !ok {
+				return fmt.Errorf("no more vlans available")
+			}
 			dhcp := vpcapi.VPCDHCP{}
-			if !hostBGP {
-				if !opts.P2P {
-					dhcp.Enable = true
-					dhcp.Options = dhcpOpts
-				}
-
-				vlan, ok = nextVLAN()
-				if !ok {
-					return fmt.Errorf("no more vlans available")
-				}
+			if !hostBGP && !opts.P2P {
+				dhcp.Enable = true
+				dhcp.Options = dhcpOpts
 			}
 
 			vpc.Spec.Subnets[subnetName] = &vpcapi.VPCSubnet{
@@ -918,7 +916,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		var confErr error
 
 		if hostBGP {
-			confCmd, confErr = getServerHostBGPCmd(&conn, expectedSubnet, serverInSubnet)
+			confCmd, confErr = getServerHostBGPCmd(&conn, vlan, expectedSubnet, serverInSubnet)
 		} else if opts.P2P {
 			confCmd, confErr = GetServerNetconfCmd(&conn, ServerNetconfOpts{
 				P2P: p2p.String(),

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3421,6 +3421,7 @@ type ReleaseTestOpts struct {
 	VPCMode        vpcapi.VPCMode
 	ListTests      bool
 	ShowTechDump   bool
+	OnReadyTest    bool
 }
 
 func (c *Config) ReleaseTest(ctx context.Context, vlab *VLAB, opts ReleaseTestOpts) error {

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3480,6 +3480,7 @@ type ReleaseTestOpts struct {
 	ListTests      bool
 	ShowTechDump   bool
 	IPerfsMinSpeed float64
+	OnReadyTest    bool
 }
 
 func (c *Config) ReleaseTest(ctx context.Context, vlab *VLAB, opts ReleaseTestOpts) error {

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -430,11 +430,13 @@ func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (st
 	return netconfCmd, nil
 }
 
-func getServerHostBGPCmd(conn *wiringapi.Connection, subnet netip.Prefix, serversInSubnet int) (string, error) {
+// TODO: multi subnet support once test-connectivity supports it
+func getServerHostBGPCmd(conn *wiringapi.Connection, vlan uint16, subnet netip.Prefix, serversInSubnet int) (string, error) {
 	if conn == nil {
 		return "", fmt.Errorf("connection is nil")
 	}
 
+	cmd := fmt.Sprintf("vpc:v=%d:i=", vlan)
 	interfaces := []string{}
 	switch {
 	case conn.Spec.Unbundled != nil:
@@ -455,7 +457,7 @@ func getServerHostBGPCmd(conn *wiringapi.Connection, subnet netip.Prefix, server
 		return "", fmt.Errorf("unexpected connection type for conn %q", conn.Name)
 	}
 
-	cmd := strings.Join(interfaces, ",")
+	cmd += strings.Join(interfaces, ":i=")
 	addr := subnet.Addr()
 	for range serversInSubnet {
 		addr = addr.Next()
@@ -463,7 +465,7 @@ func getServerHostBGPCmd(conn *wiringapi.Connection, subnet netip.Prefix, server
 	if !addr.IsValid() {
 		return "", fmt.Errorf("failed to get IP address from subnet %s", subnet.String())
 	}
-	cmd += " " + addr.String() + "/32"
+	cmd += ":a=" + addr.String() + "/32"
 
 	return cmd, nil
 }
@@ -829,18 +831,14 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 				}
 			}
 
-			var vlan uint16
+			vlan, ok := nextVLAN()
+			if !ok {
+				return fmt.Errorf("no more vlans available")
+			}
 			dhcp := vpcapi.VPCDHCP{}
-			if !hostBGP {
-				if !opts.P2P {
-					dhcp.Enable = true
-					dhcp.Options = dhcpOpts
-				}
-
-				vlan, ok = nextVLAN()
-				if !ok {
-					return fmt.Errorf("no more vlans available")
-				}
+			if !hostBGP && !opts.P2P {
+				dhcp.Enable = true
+				dhcp.Options = dhcpOpts
 			}
 
 			vpc.Spec.Subnets[subnetName] = &vpcapi.VPCSubnet{
@@ -908,7 +906,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		var confErr error
 
 		if hostBGP {
-			confCmd, confErr = getServerHostBGPCmd(&conn, expectedSubnet, serverInSubnet)
+			confCmd, confErr = getServerHostBGPCmd(&conn, vlan, expectedSubnet, serverInSubnet)
 		} else if opts.P2P {
 			confCmd, confErr = GetServerNetconfCmd(&conn, ServerNetconfOpts{
 				P2P: p2p.String(),

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3483,7 +3483,7 @@ type ReleaseTestOpts struct {
 	OnReadyTest    bool
 }
 
-func (c *Config) ReleaseTest(ctx context.Context, vlab *VLAB, opts ReleaseTestOpts) error {
+func ReleaseTest(ctx context.Context, c *Config, vlab *VLAB, opts ReleaseTestOpts) error {
 	if !slices.Contains(HashPolicies, opts.HashPolicy) {
 		return fmt.Errorf("invalid hash policy %q, must be one of %v", opts.HashPolicy, HashPolicies)
 	} else if opts.HashPolicy != HashPolicyL2 && opts.HashPolicy != HashPolicyL2And3 {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -108,6 +108,7 @@ type VLABRunOpts struct {
 	PauseOnFailure           bool
 	ReleaseTestRegexes       []string
 	ReleaseTestRegexesInvert bool
+	ReleaseTestOnReadyOnly   bool
 	InterfaceMTU             uint16
 }
 
@@ -760,6 +761,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						Regexes:        opts.ReleaseTestRegexes,
 						InvertRegex:    opts.ReleaseTestRegexesInvert,
 						ShowTechDump:   true,
+						OnReadyTest:    opts.ReleaseTestOnReadyOnly,
 					}
 					slog.Debug("Running release-test", "opts", releaseTestOpts)
 					if err := c.ReleaseTest(ctx, vlab, releaseTestOpts); err != nil {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -108,6 +108,7 @@ type VLABRunOpts struct {
 	PauseOnFailure           bool
 	ReleaseTestRegexes       []string
 	ReleaseTestRegexesInvert bool
+	ReleaseTestOnReadyOnly   bool
 	InterfaceMTU             uint16
 }
 
@@ -761,6 +762,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						InvertRegex:    opts.ReleaseTestRegexesInvert,
 						ShowTechDump:   true,
 						IPerfsMinSpeed: 8200,
+						OnReadyTest:    opts.ReleaseTestOnReadyOnly,
 					}
 					slog.Debug("Running release-test", "opts", releaseTestOpts)
 					if err := c.ReleaseTest(ctx, vlab, releaseTestOpts); err != nil {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -765,7 +765,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						OnReadyTest:    opts.ReleaseTestOnReadyOnly,
 					}
 					slog.Debug("Running release-test", "opts", releaseTestOpts)
-					if err := c.ReleaseTest(ctx, vlab, releaseTestOpts); err != nil {
+					if err := ReleaseTest(ctx, c, vlab, releaseTestOpts); err != nil {
 						if c.Shutdown.Load() == int32(ShutdownTypeGraceful) {
 							return nil
 						}


### PR DESCRIPTION
Fix #1139 
Fix #1360 
Fix #1362 
Fix #1363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR replaces the legacy on-ready workflow steps (`setup-vpcs`, `setup-peerings`, `test-connectivity`) with a new minimal "OnReady Suite" test that provides comprehensive Fabric coverage while running in approximately the same time as the original three steps. The new suite runs by default in normal VLAB CI runs and serves as a lightweight alternative to the full release test matrix.

## Key Changes

### New OnReady Test Suite (`pkg/hhfab/rt_on_ready_suite.go`)
- Introduced `makeOnReadyTestSuite()` with a single test case ("New VLAB OnReady Test") that orchestrates a complete environment setup
- Discovers MCLAG-capable switches and enumerates candidate servers (filtered by naming prefix, numeric ID, and topology compatibility)
- Deterministically allocates 7+ servers across multiple VPCs:
  - VPC-A with two subnets (one server per subnet)
  - VPC-B with host-BGP single subnet (on unbundled/non-MCLAG server)
  - VPC-C with single subnet and two servers on different non-MCLAG switches
  - VPC-D+ (one-server-per-VPC for remaining servers)
- Discovers BGP and static externals with proper validation (static external requires proxy disabled)
- Allocates VLAN IDs and IPv4 subnets, creates VPC objects in Kubernetes
- Configures per-server networking via SSH (using `hhnet` or `hostbgp`)
- Sets up VPC peerings including conditional gateway peerings
- Runs VLAB connectivity test, cleans up all resources in revert functions

### Test Framework Refactoring
- Changed `TestFunc` signature from `func(context.Context)` to `func(context.Context, *VPCPeeringTestCtx)`, threading test context into all test functions
- Added `skipFlags SkipFlags` field to `VPCPeeringTestCtx` to allow topology-detected skip behavior
- Converted all receiver-based test methods on `*VPCPeeringTestCtx` to standalone package-level functions across multiple suite files (`rt_multi_vpc_single_subnet_suite.go`, `rt_multi_vpc_multi_subnet_suite.go`, `rt_nat_tests.go`, `rt_nat_external_tests.go`, `rt_single_vpc_suite.go`, `rt_no_vpc_suite.go`, `rt_static_external.go`)
- Refactored suite builders to no longer require `*VPCPeeringTestCtx` at construction time
- Updated `RunReleaseTestSuites` to support `OnReadyTest` option: when enabled, runs only the on-ready suite; otherwise runs full suite sequence

### CLI and Public API Changes
- Added `--release-test-on-ready-only` flag (alias `--rt-or`) to `vlab up` command
- Added `--on-ready-only` flag (aliases `--on-ready`, `-o`) to `vlab release-test` command
- Converted `ReleaseTest` from a method `(*Config).ReleaseTest()` to a standalone function `ReleaseTest(ctx, c, vlab, opts)`
- Added `OnReadyTest bool` field to `ReleaseTestOpts`
- Added `ReleaseTestOnReadyOnly bool` field to `VLABRunOpts`

### Workflow and Configuration Changes
- Updated `run-vlab.yaml` to refactor ready/test selection logic into `HHFAB_TEST_ARGS` array:
  - Default (normal CI): `--release-test --release-test-on-ready-only` (runs OnReady Suite)
  - When `releasetest=true`: `--release-test` with optional `--release-test-regexes` and `--release-test-regexes-invert`
  - When `upgradefrom` is set: Falls back to legacy `--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity`
- Updated VLAB generation logic in `run-vlab.yaml` to compute topology parameters (MCLAG leaves, ESLAG groups, orphan leaves, mesh links, unbundled servers) based on `vpcmode` and `mesh` inputs with explicit defaults
- Added `.github/workflows/ci-normal-run-test-coverage.md` documenting CI behavior: explicit description of OnReady Suite execution for normal runs, expected topology counts, VPC/subnet/server layout, peerings applied, and how CI inputs control test behavior

### Other Updates
- Refined external selection logic in `findExternals`: stricter `hasStaticAttachments` validation for static externals, rejecting unsupported proxy/non-proxy attachment mixes
- Updated `getServerHostBGPCmd` to accept explicit `vlan` parameter and generate new colon-delimited command format (`:vpc=`, `:i=`, `:a=`)
- VLAN allocation now occurs whenever a subnet is created; DHCP is enabled only for non-hostBGP, non-P2P subnets

## Benefits

- Enables External[t=Static] and virtual external testing in VLAB CI without full Release Test overhead
- Provides minimal but comprehensive coverage equivalent to release tests
- Maintains same infrastructure as regular release tests
- Supports gateway peering validation (when gateway is enabled) and backward compatibility with upgrade flows
- Reduces CI latency for normal runs by running lightweight OnReady Suite instead of full test matrix

<!-- end of auto-generated comment: release notes by coderabbit.ai -->