### PR TITLE
ci: increase upgrade job timeout

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -102,7 +102,7 @@ jobs:
   run:
     if: ${{ !inputs.skip }}
     runs-on: ${{ inputs.hybrid && 'hlab' || 'vlab' }}
-    timeout-minutes: "${{ inputs.pause_on_failure && (inputs.releasetest && (inputs.hybrid && 320 || 220) || 130) || (inputs.releasetest && (inputs.hybrid && 250 || 150) || 60) }}"
+    timeout-minutes: "${{ inputs.pause_on_failure && (inputs.releasetest && (inputs.hybrid && 320 || 220) || 130) || (inputs.releasetest && (inputs.hybrid && 250 || (inputs.upgradefrom != '' && 180 || 150)) || (inputs.upgradefrom != '' && 90 || 60)) }}"
 
     steps:
       - name: Runner host


### PR DESCRIPTION
This was used in a previous branch to diagnose upgrade job failures as early job cancellation was preventing the gathering of show-tech

We need it again (at least temporarily) to properly investigate issue https://github.com/githedgehog/fabricator/issues/1239 , because we can hit it during the upgrade step and the job will time out, leaving us without proper diagnostic data