### PR TITLE
chore(ci): disable test conns on old hhfab

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -197,7 +197,7 @@ jobs:
           old/hhfab diagram --format=mermaid
 
       # TODO: make controls restricted again when we figure out how to get NTP upstream working for isolated VMs
-      - name: (${{ inputs.upgradefrom }}) Run and test ${{ inputs.hybrid && 'hybrid ' || '' }}VLAB
+      - name: (${{ inputs.upgradefrom }}) Run ${{ inputs.hybrid && 'hybrid ' || '' }}VLAB
         if: ${{ inputs.upgradefrom != '' }}
         run: |
           export HHFAB_JOIN_TOKEN=$(openssl rand -base64 24)
@@ -209,7 +209,6 @@ jobs:
             --ready=inspect \
             --ready=setup-vpcs \
             ${{ inputs.upgradefrom != '25.03' && '--ready=setup-peerings' || '' }} \
-            --ready=test-connectivity \
             --ready=exit
 
       - name: (${{ inputs.upgradefrom }}) Prepare debug artifacts


### PR DESCRIPTION
in upgrade jobs, when on the old version hhfab, just bring the VLAB up and run inspect instead of the usual test connectivity routine. we do not want to fail the CI due to bugs in the old version, especially in the testing harness, which might have been fixed since.

Related to the discussion in https://github.com/githedgehog/fabricator/issues/1291