### PR TITLE
ci: source lab-ci env in vlab up step

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -261,6 +261,10 @@ jobs:
       # TODO: make controls restricted again when we figure out how to get NTP upstream working for isolated VMs
       - name: ${{ inputs.upgradefrom != '' && 'Upgrade' || 'Run' }} and test ${{ inputs.hybrid && 'hybrid ' || '' }}VLAB
         run: |
+          if [[ "${{ inputs.hybrid }}" == "true" ]]; then
+            source "./lab-ci/envs/$KUBE_NODE/source.sh"
+          fi
+
           export HHFAB_JOIN_TOKEN=$(openssl rand -base64 24)
           bin/hhfab vlab up -v \
             --build-mode="${{ inputs.buildmode }}" \


### PR DESCRIPTION
Originally used to test a GW VM with bigger RAM. Repurposed to load env on the `vlab up` step, which was missing to set variables that can influence VLAB VM parameters