### PR TITLE
chore(hhfab): use new default flag for expose

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1214,8 +1214,9 @@ func Run(ctx context.Context) error {
 								default subnet and any route from external
 							1~:subnets=default@prefixes=0.0.0.0/0 -- external peering for vpc-1 with auth external with default vpc subnet and
 								default route from external permitted
-							1~as5835:subnets=default,other:prefixes=0.0.0.0/0_le32_ge32,22.22.22.0/24 -- same but with more details
-							1~as5835:s=default,other:p=0.0.0.0/0_le32_ge32,22.22.22.0/24 -- same as above
+							1~as5835:s=default:p=default:gw -- same as above but via the gateway
+							1~as5835:s=default,other:p=1.0.0.1/32_le32_ge32,22.22.22.0/24 -- two explicit prefixes allowed from the external,
+								provided the external it is advertising them they will be imported and exposed to the VPC
 						`, "							", "")),
 						Flags: flatten(defaultFlags, accessNameFlags, []cli.Flag{
 							&cli.BoolFlag{

--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -573,11 +573,7 @@ func appendGwExtPeeringSpec(gwPeerings map[string]*gwapi.PeeringSpec, vpc1 *vpca
 		vpc1Expose.IPs = append(vpc1Expose.IPs, gwapi.PeeringEntryIP{CIDR: subnet})
 	}
 	extExpose := gwapi.PeeringEntryExpose{
-		IPs: []gwapi.PeeringEntryIP{
-			{
-				CIDR: "0.0.0.0/0",
-			},
-		},
+		DefaultDestination: true,
 	}
 
 	gwPeerings[entryName] = &gwapi.PeeringSpec{


### PR DESCRIPTION
instead of using the all zero prefix, according to the new API that was implemented in the gateway

note that this will not work until the dataplane side implements the new behavior, but it is still needed to fix release tests and manual testing

Fix #1313 