### PR TITLE
chore: remove deprecated fields from l2 externals

### DIFF
--- a/pkg/hhfab/vlabbuilder.go
+++ b/pkg/hhfab/vlabbuilder.go
@@ -915,10 +915,8 @@ func (b *VLABBuilder) Build(ctx context.Context, l *apiutil.Loader, fabricMode m
 			}
 			if ext.Spec.L2 != nil {
 				extAttachSpec.L2 = &vpcapi.ExternalAttachmentL2{
-					IP:           fmt.Sprintf("100.%d.%d.6", connOctet, vlanID),
-					VLAN:         vlanID,
-					GatewayIPs:   []string{fmt.Sprintf("100.%d.%d.1/24", connOctet, vlanID)},
-					FabricEdgeIP: fmt.Sprintf("192.168.%d.1/31", connOctet),
+					IP:   fmt.Sprintf("100.%d.%d.1", connOctet, vlanID),
+					VLAN: vlanID,
 				}
 			} else {
 				extAttachSpec.Switch = vpcapi.ExternalAttachmentSwitch{

--- a/pkg/hhfab/vlabconfig.go
+++ b/pkg/hhfab/vlabconfig.go
@@ -768,9 +768,11 @@ func createVLABConfig(ctx context.Context, controls []fabapi.ControlNode, nodes 
 				}
 				if extVrf.IsL2 {
 					// update VRF config with some attachment specs that are handy to keep there for the template
-					// TODO: transform gateway IPs into /32 for the purpose of installing static routes in the external?
-					// it would be more accurate, although this should work just fine
-					extVrf.L2Cfg.GatewayIPs = extAttach.Spec.L2.GatewayIPs
+					l2IP, err := netip.ParsePrefix(extAttach.Spec.L2.IP + "/24")
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse L2 external IP %q: %w", extAttach.Spec.L2.IP, err)
+					}
+					extVrf.L2Cfg.GatewayIPs = []string{l2IP.Masked().String()}
 					// add vlan to the interface name for the static route
 					if extAttach.Spec.L2.VLAN != 0 {
 						extVrf.L2Cfg.NICName = fmt.Sprintf("%s.%d", nicName, extAttach.Spec.L2.VLAN)


### PR DESCRIPTION
in preparation to remove them from fabric, since otherwise fabric CI will fail as they are used in fabricator