### PR TITLE
ci: do not fail on artifact upload error

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -338,6 +338,7 @@ jobs:
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v6
         if: ${{ always() }}
+        continue-on-error: true
         with:
           name: fab-${{ github.run_id }}-${{ env.slug }}
           path: fab-${{ github.run_id }}-${{ env.slug }}


### PR DESCRIPTION
this is uncommon, but with GitHub experiencing quite a few incidents lately we have observed it a couple of times, and the fix is simple.