### PR TITLE
chore(vlab): fix IPerfsMinSpeed 0

### DIFF
--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -689,6 +689,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						WaitSwitchesReady: true,
 						PingsCount:        5,
 						IPerfsSeconds:     5,
+						IPerfsMinSpeed:    8200, // Match the CLI default
 						CurlsCount:        3,
 					}
 					slog.Debug("Running test-connectivity", "opts", testConnOpts)


### PR DESCRIPTION
Fixes https://github.com/githedgehog/fabricator/issues/1454

Also shows on-ready command options to provide more clarity on what is run:
```
2026-02-12T23:14:13.1846997Z 23:14:13 DBG Running test-connectivity opts="{WaitSwitchesReady:true PingsCount:5 PingsParallel:0 IPerfsSeconds:5 IPerfsMinSpeed:8200 IPerfsParallel:0 IPerfsDSCP:0 IPerfsTOS:0 CurlsCount:3 CurlsParallel:0 Sources:[] Destinations:[] RequireAllServers:false}"
```