### PR TITLE
ci: change CI workflow dispatch behavior

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,14 +26,14 @@ on:
     - cron: "0 10 * * *" # ~2am PST
   workflow_dispatch:
     inputs:
-      releasetest_vlab:
+      releasetest:
         type: boolean
-        description: "Run release tests in vlab"
+        description: "Run release tests"
         required: false
         default: false
-      releasetest_hlab:
+      hlab:
         type: boolean
-        description: "Run release tests in hlab"
+        description: "Run hlab"
         required: false
         default: false
       debug_enabled:
@@ -230,13 +230,13 @@ jobs:
           fi
 
   vlab:
-    name: "${{ matrix.hybrid && 'h' || 'v' }}-${{ matrix.upgradefrom && 'up' || '' }}${{ matrix.upgradefrom }}${{ matrix.upgradefrom && '-' || '' }}${{ matrix.mesh && 'mesh-' || '' }}${{ matrix.gateway && 'gw-' || '' }}${{ matrix.includeonie && 'onie-' || '' }}${{ matrix.buildmode }}-${{ matrix.vpcmode }}${{ ((matrix.hybrid && (inputs.releasetest_hlab == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *')) || (!matrix.hybrid && (inputs.releasetest_vlab == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *'))) && '-rt' || '' }}"
+    name: "${{ matrix.hybrid && 'h' || 'v' }}-${{ matrix.upgradefrom && 'up' || '' }}${{ matrix.upgradefrom }}${{ matrix.upgradefrom && '-' || '' }}${{ matrix.mesh && 'mesh-' || '' }}${{ matrix.gateway && 'gw-' || '' }}${{ matrix.includeonie && 'onie-' || '' }}${{ matrix.buildmode }}-${{ matrix.vpcmode }}${{ (inputs.releasetest == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *') && '-rt' || '' }}"
     needs:
       - test-build
     uses: ./.github/workflows/run-vlab.yaml
     with:
-      # if pull_request: skip hlab if not ci:+hlab and skip vlab if ci:-vlab
-      # if workflow_dispatch: skip hlab if only vlab release tests requested and skip vlab if only hlab release tests requested
+      # if pull_request: skip hlab if not ci:+hlab, skip vlab if ci:-vlab, skip upgrade if ci:-upgrade
+      # if workflow_dispatch: skip hlab if hlab input is false
       skip: >-
         ${{
           github.event_name == 'pull_request'
@@ -246,11 +246,7 @@ jobs:
             || matrix.upgradefrom != '' && contains(github.event.pull_request.labels.*.name, 'ci:-upgrade')
           )
           || github.event_name == 'workflow_dispatch'
-          && (inputs.releasetest_vlab == true || inputs.releasetest_hlab == true)
-          && (
-            matrix.hybrid && inputs.releasetest_hlab != true
-            || !matrix.hybrid && inputs.releasetest_vlab != true
-          )
+          && matrix.hybrid && inputs.hlab != true
         }}
       fabricatorref: ${{ github.ref }}
       fabricmode: spine-leaf
@@ -259,7 +255,7 @@ jobs:
       includeonie: ${{ matrix.includeonie }}
       buildmode: ${{ matrix.buildmode }}
       vpcmode: ${{ matrix.vpcmode }}
-      releasetest: ${{ (matrix.hybrid && (inputs.releasetest_hlab == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *')) || (!matrix.hybrid && (inputs.releasetest_vlab == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *')) }}
+      releasetest: ${{ inputs.releasetest == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *' }}
       hybrid: ${{ matrix.hybrid }}
       upgradefrom: ${{ matrix.upgradefrom }}
 
@@ -380,7 +376,7 @@ jobs:
           fi
 
   publish-test-results:
-    if: ${{ (inputs.releasetest_vlab == true || inputs.releasetest_hlab == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *') && !cancelled() }}
+    if: ${{ (inputs.releasetest == true || contains(github.event.pull_request.labels.*.name, 'ci:+release') || github.event.schedule == '0 6 * * *') && !cancelled() }}
     runs-on: lab
     needs:
       - vlabs


### PR DESCRIPTION
This tries to be a DX improvement.

Adds toogle for release tests and hlab, this way it doesn't run hlab unless requested: <img width="386" height="461" alt="image" src="https://github.com/user-attachments/assets/c042fd94-ce69-49ae-b8a3-e1e79f8b557b" />

Instead of:
<img width="386" height="461" alt="image" src="https://github.com/user-attachments/assets/5aa67b17-6473-4ba5-a1da-743399cf23a5" />

I am fail-proofing some branches to reduce CI flakiness and having hlab run by default is slowing down everything

push and PR triggers are unaffected