### PR TITLE
chore(vlab): disable remaining control VM offloads

### DIFF
--- a/pkg/fab/recipe/control_butane.tmpl.yaml
+++ b/pkg/fab/recipe/control_butane.tmpl.yaml
@@ -33,7 +33,7 @@ systemd:
         [Service]
         Type=oneshot
         ExecCondition=/bin/sh -c '[ "$(basename $(readlink /sys/class/net/{{ .ExtInterface }}/device/driver))" = "e1000" ]'
-        ExecStart=/usr/sbin/ethtool -K {{ .ExtInterface }} tso off gso off gro off tx off rx off sg off
+        ExecStart=/usr/sbin/ethtool -K {{ .ExtInterface }} tso off gso off gro off tx off rx off sg off rxvlan off txvlan off rx-checksumming off tx-checksumming off
         RemainAfterExit=yes
 
         [Install]

--- a/pkg/hhfab/show-tech/control.sh
+++ b/pkg/hhfab/show-tech/control.sh
@@ -32,10 +32,12 @@ KUBECTL="/opt/bin/kubectl"
     ip neigh show
     ip link show
 
-    echo -e "\n=== NIC Offload Settings ==="
+    echo -e "\n=== NIC Statistics and Offload Settings ==="
     for iface in $(ls /sys/class/net/ | grep -v '^lo$'); do
-        echo "--- $iface ---"
-        ethtool -k "$iface" 2>/dev/null | grep -E 'offload|segmentation' || echo "ethtool not available"
+        echo "--- $iface Statistics---"
+        ethtool -S "$iface" 2>/dev/null
+        echo "--- $iface Offload Settings---"
+        ethtool -k "$iface" 2>/dev/null | grep -E 'offload|segmentation'
     done
 
     echo -e "\n=== Switch connectivity from control node ==="


### PR DESCRIPTION
Fixes https://github.com/githedgehog/fabricator/issues/1239

Occurrence has decreased dramatically since https://github.com/githedgehog/fabricator/pull/1443

With this I hope we get rid completely of the e1000 TX hangs:
```
core@control-1 ~ $ ethtool -k enp2s1 2>/dev/null | grep -E 'offload|segmentation'
tcp-segmentation-offload: off
        tx-tcp-segmentation: off
        tx-tcp-ecn-segmentation: off [fixed]
        tx-tcp-mangleid-segmentation: off
        tx-tcp6-segmentation: off [fixed]
generic-segmentation-offload: off
generic-receive-offload: off
large-receive-offload: off [fixed]
rx-vlan-offload: off
tx-vlan-offload: off [fixed]
tx-fcoe-segmentation: off [fixed]
tx-gre-segmentation: off [fixed]
tx-gre-csum-segmentation: off [fixed]
tx-ipxip4-segmentation: off [fixed]
tx-ipxip6-segmentation: off [fixed]
tx-udp_tnl-segmentation: off [fixed]
tx-udp_tnl-csum-segmentation: off [fixed]
tx-tunnel-remcsum-segmentation: off [fixed]
tx-sctp-segmentation: off [fixed]
tx-esp-segmentation: off [fixed]
tx-udp-segmentation: off [fixed]
l2-fwd-offload: off [fixed]
hw-tc-offload: off [fixed]
esp-hw-offload: off [fixed]
esp-tx-csum-hw-offload: off [fixed]
rx-udp_tunnel-port-offload: off [fixed]
tls-hw-tx-offload: off [fixed]
tls-hw-rx-offload: off [fixed]
macsec-hw-offload: off [fixed]
hsr-tag-ins-offload: off [fixed]
hsr-tag-rm-offload: off [fixed]
hsr-fwd-offload: off [fixed]
hsr-dup-offload: off [fixed]
core@control-1 ~ $ 
```