### PR TITLE
chore(vlab): add configurable server VM mtu and use 9036 for HLAB

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1135,6 +1135,12 @@ func Run(ctx context.Context) error {
 								Name:  FlagNameVPCMode,
 								Usage: "VPC mode to be used for on-ready commands: empty is default (l2vni), l3vni, etc.",
 							},
+							&cli.UintFlag{
+								Name:    "interface-mtu",
+								Aliases: []string{"mtu"},
+								Usage:   "interface MTU for server interfaces and VPCs advertised by DHCP when using on-ready commands (0 = auto: 9036 for non-VS, disabled for SONiC VS)",
+								EnvVars: []string{"HHFAB_INTERFACE_MTU"},
+							},
 							&cli.StringSliceFlag{
 								Name:    FlagReleaseTestRegexes,
 								Aliases: []string{"rt-regex"},
@@ -1212,6 +1218,11 @@ func Run(ctx context.Context) error {
 								onReady = append(onReady, ready)
 							}
 
+							ifMTU, err := parseInterfaceMTU(c)
+							if err != nil {
+								return err
+							}
+
 							if err := hhfab.VLABUp(ctx, workDir, cacheDir, hhfab.VLABUpOpts{
 								HydrateMode:          hhfab.HydrateMode(hydrateMode),
 								ReCreate:             c.Bool(FlagNameReCreate),
@@ -1250,6 +1261,7 @@ func Run(ctx context.Context) error {
 									VPCMode:                  vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
 									ReleaseTestRegexes:       c.StringSlice(FlagReleaseTestRegexes),
 									ReleaseTestRegexesInvert: c.Bool(FlagReleaseTestRegexesInvert),
+									InterfaceMTU:             ifMTU,
 								},
 							}); err != nil {
 								return fmt.Errorf("running VLAB: %w", err)
@@ -1427,6 +1439,11 @@ func Run(ctx context.Context) error {
 						}),
 						Before: before(false),
 						Action: func(c *cli.Context) error {
+							ifMTU, err := parseInterfaceMTU(c)
+							if err != nil {
+								return err
+							}
+
 							if err := hhfab.DoVLABSetupVPCs(ctx, workDir, cacheDir, hhfab.SetupVPCsOpts{
 								WaitSwitchesReady: c.Bool("wait-switches-ready"),
 								ForceCleanup:      c.Bool("force-cleanup"),
@@ -1436,7 +1453,7 @@ func Run(ctx context.Context) error {
 								SubnetsPerVPC:     c.Int("subnets-per-vpc"),
 								DNSServers:        c.StringSlice("dns-servers"),
 								TimeServers:       c.StringSlice("time-servers"),
-								InterfaceMTU:      uint16(c.Uint("interface-mtu")), //nolint:gosec
+								InterfaceMTU:      ifMTU,
 								HashPolicy:        c.String(FlagHashPolicy),
 								VPCMode:           vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
 								KeepPeerings:      c.Bool("keep-peerings"),
@@ -1954,6 +1971,20 @@ func Run(ctx context.Context) error {
 
 func flatten[T any, Slice ~[]T](collection ...Slice) Slice {
 	return lo.Flatten(collection)
+}
+
+func parseInterfaceMTU(c *cli.Context) (uint16, error) {
+	const minMTU = 96   // matches the DHCP API lower bound
+	const maxMTU = 9036 // matches the DHCP API upper bound
+	mtu := c.Uint("interface-mtu")
+	if mtu != 0 && mtu < minMTU {
+		return 0, fmt.Errorf("interface-mtu %d is below minimum allowed value of %d", mtu, minMTU) //nolint:err113
+	}
+	if mtu > maxMTU {
+		return 0, fmt.Errorf("interface-mtu %d exceeds maximum allowed value of %d", mtu, maxMTU) //nolint:err113
+	}
+
+	return uint16(mtu), nil
 }
 
 func handleL2VNI(in string) string {

--- a/pkg/hhfab/hhnet.sh
+++ b/pkg/hhfab/hhnet.sh
@@ -35,10 +35,15 @@ function restart_networkd() {
 function setup_bond() {
     local bond_name=$1
     local hash_policy=$2
+    local mtu=$3
 
     sudo ip l a "$bond_name" type bond miimon 100 mode 802.3ad xmit_hash_policy "$hash_policy"
 
-    for iface in "${@:3}"; do
+    if [ -n "$mtu" ]; then
+        sudo ip l s "$bond_name" mtu "$mtu"
+    fi
+
+    for iface in "${@:4}"; do
         # cannot enslave interface if it is up
         sudo ip l s "$iface" down 2> /dev/null || echo "warning: could not bring down $iface" >&2
         sudo ip l s "$iface" master "$bond_name"
@@ -50,6 +55,11 @@ function setup_bond() {
 function setup_vlan() {
     local iface_name=$1
     local vlan_id=$2
+    local mtu=$3
+
+    if [ -n "$mtu" ]; then
+        sudo ip l s "$iface_name" mtu "$mtu"
+    fi
 
     sudo ip l s "$iface_name" up
     sudo ip l a link "$iface_name" name "$iface_name.$vlan_id" type vlan id "$vlan_id"
@@ -119,24 +129,46 @@ elif [ "$1" == "cleanup" ]; then
     exit 0
 elif [ "$1" == "bond" ]; then
     if [ "$#" -lt 4 ]; then
-        echo "Usage: $0 bond <vlan_id> <hash_policy> <iface1> [<iface2> ...]" >&2
+        echo "Usage: $0 bond <vlan_id> <hash_policy> <iface1> [<iface2> ...] [--mtu=<value>]" >&2
         exit 1
     fi
 
-    setup_bond bond0 "${@:3}"
+    mtu=""
+    ifaces=()
+    for arg in "${@:4}"; do
+        case "$arg" in
+            --mtu=*) mtu="${arg#--mtu=}" ;;
+            *) ifaces+=("$arg") ;;
+        esac
+    done
+
+    if [ "${#ifaces[@]}" -eq 0 ]; then
+        echo "Error: at least one interface required for bond" >&2
+        exit 1
+    fi
+
+    setup_bond bond0 "$3" "$mtu" "${ifaces[@]}"
     sleep 1
     setup_vlan bond0 "$2"
     get_ip bond0."$2"
 
     exit 0
 elif [ "$1" == "vlan" ]; then
-    if [ "$#" -ne 3 ]; then
-        echo "Usage: $0 vlan <vlan_id> <iface1>" >&2
+    if [ "$#" -lt 3 ]; then
+        echo "Usage: $0 vlan <vlan_id> <iface1> [--mtu=<value>]" >&2
         exit 1
     fi
 
-    setup_vlan "$3" "$2"
-    get_ip "$3"."$2"
+    mtu=""
+    iface="$3"
+    for arg in "${@:4}"; do
+        case "$arg" in
+            --mtu=*) mtu="${arg#--mtu=}" ;;
+        esac
+    done
+
+    setup_vlan "$iface" "$2" "$mtu"
+    get_ip "$iface"."$2"
 
     exit 0
 elif [ "$1" == "p2p" ]; then

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -34,6 +34,7 @@ import (
 	"go.githedgehog.com/fabric/pkg/util/kubeutil"
 	fabapi "go.githedgehog.com/fabricator/api/fabricator/v1beta1"
 	"go.githedgehog.com/fabricator/pkg/fab"
+	fabcomp "go.githedgehog.com/fabricator/pkg/fab/comp/fabric"
 	"go.githedgehog.com/fabricator/pkg/util/sshutil"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
@@ -372,6 +373,7 @@ type ServerNetconfOpts struct {
 	VLAN       uint16
 	HashPolicy string
 	P2P        string
+	MTU        uint16
 }
 
 func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (string, error) {
@@ -382,6 +384,9 @@ func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (st
 	if opts.P2P != "" {
 		if opts.VLAN != 0 || opts.HashPolicy != "" {
 			return "", fmt.Errorf("p2p option cannot be used with VLAN or HashPolicy")
+		}
+		if opts.MTU != 0 {
+			return "", fmt.Errorf("p2p option does not support MTU configuration")
 		}
 		if conn.Spec.Unbundled == nil {
 			return "", fmt.Errorf("p2p option cannot be used with connections other than unbundled")
@@ -405,6 +410,9 @@ func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (st
 		netconfCmd = fmt.Sprintf("p2p %s %s %s", conn.Spec.Unbundled.Link.Server.LocalPortName(), localIP, remoteIP)
 	case conn.Spec.Unbundled != nil:
 		netconfCmd = fmt.Sprintf("vlan %d %s", opts.VLAN, conn.Spec.Unbundled.Link.Server.LocalPortName())
+		if opts.MTU > 0 {
+			netconfCmd += fmt.Sprintf(" --mtu=%d", opts.MTU)
+		}
 	default:
 		netconfCmd = fmt.Sprintf("bond %d %s", opts.VLAN, opts.HashPolicy)
 
@@ -422,6 +430,10 @@ func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (st
 			}
 		} else {
 			return "", fmt.Errorf("unexpected connection type for conn %q", conn.Name)
+		}
+
+		if opts.MTU > 0 {
+			netconfCmd += fmt.Sprintf(" --mtu=%d", opts.MTU)
 		}
 	}
 
@@ -574,6 +586,34 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	if !opts.P2P && allCumulus {
 		opts.P2P = true
 		slog.Warn("Forcing P2P mode since all switches are cumulus")
+	}
+
+	// Auto-configure server interface MTU when not explicitly set (0 = auto).
+	// For non-VS environments, we use jumbo frames (9036) matching the fabric server-facing MTU.
+	// For SONiC VS, jumbo frames are not supported. When DNS/NTP options are configured, DHCP options
+	// will be created and the VPC API defaults InterfaceMTU to 9036 if left at 0 — so we explicitly
+	// set 1500 to prevent advertising jumbo MTU via DHCP. When no DNS/NTP options are configured,
+	// no DHCP options object is created, the API default doesn't apply, and no MTU is advertised.
+	if opts.InterfaceMTU == 0 {
+		hasSonicVS := false
+		for _, sw := range switchList.Items {
+			if sw.Spec.Profile == meta.SwitchProfileVS || sw.Spec.Profile == meta.SwitchProfileVSCLSP {
+				hasSonicVS = true
+
+				break
+			}
+		}
+		if hasSonicVS {
+			if len(opts.DNSServers) > 0 || len(opts.TimeServers) > 0 {
+				opts.InterfaceMTU = 1500
+				slog.Info("SONiC VS switches detected, using standard MTU to prevent DHCP jumbo frame advertisement", "mtu", opts.InterfaceMTU)
+			} else {
+				slog.Info("SONiC VS switches detected, skipping jumbo frame MTU auto-configuration")
+			}
+		} else {
+			opts.InterfaceMTU = uint16(fabcomp.ServerFacingMTU) //nolint:gosec
+			slog.Info("Auto-configuring server interface MTU", "mtu", opts.InterfaceMTU)
+		}
 	}
 
 	{
@@ -864,6 +904,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 			confCmd, confErr = GetServerNetconfCmd(&conn, ServerNetconfOpts{
 				VLAN:       vlan,
 				HashPolicy: opts.HashPolicy,
+				MTU:        opts.InterfaceMTU,
 			})
 		}
 		if confErr != nil {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -108,6 +108,7 @@ type VLABRunOpts struct {
 	PauseOnFailure           bool
 	ReleaseTestRegexes       []string
 	ReleaseTestRegexesInvert bool
+	InterfaceMTU             uint16
 }
 
 type OnReady string
@@ -678,7 +679,6 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						return c.handleShutdownWithPause(ctx, vlab, opts, fmt.Errorf("reinstalling switches: %w", err))
 					}
 				case OnReadySetupVPCs:
-					// TODO make it configurable
 					setupVPCsOpts := SetupVPCsOpts{
 						WaitSwitchesReady: true,
 						VLANNamespace:     "default",
@@ -689,6 +689,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						TimeServers:       []string{"219.239.35.0"},
 						HashPolicy:        HashPolicyL2And3,
 						VPCMode:           opts.VPCMode,
+						InterfaceMTU:      opts.InterfaceMTU,
 					}
 					slog.Debug("Running setup-vpcs", "opts", setupVPCsOpts)
 					if err := c.SetupVPCs(ctx, vlab, setupVPCsOpts); err != nil {


### PR DESCRIPTION
## Before this PR

There is a `--interface-mtu` flag on `setup-vpcs` that lets users manually set an MTU value. Its default is 0, meaning "don't set any MTU."

Before this PR, when `setup-vpcs` ran with MTU=0 (the default), two things could happen depending on whether DNS/NTP servers were configured:

Without DNS/NTP: no DHCP options object created. DHCP hands out IP addresses but advertises no MTU. Servers use their OS default (1500).

With DNS/NTP (e.g. `--dns-servers 8.8.8.8`): a DHCP options object is created to carry the DNS servers. The VPC API sees MTU=0 in that object and auto-fills it to 9036. DHCP now advertises 9036 jumbo MTU to all servers, including SONiC VS where jumbo frames crash the VS. There was no protection against this.

Server interfaces themselves were never configured with any MTU either. They just used the OS default (1500). So even if DHCP advertised 9036, the server interfaces weren't set up for it.

Bottom line: MTU was not actively managed. It was either not advertised, or silently wrong (9036 advertised via DHCP on VS environments that can't handle it).

## What this PR changes

### Auto-configure MTU based on environment

When `--interface-mtu` is not explicitly set (defaults to 0), the code now detects what kind of switches are running and picks the right value:

Non-VS (HLAB/production): sets MTU to 9036. Jumbo frames work here, this is the correct value.

SONiC VS with DNS/NTP configured: sets MTU to 1500. This prevents the API from auto-filling 9036 into the DHCP options object that must exist to carry the DNS/NTP servers.

SONiC VS without DNS/NTP: leaves MTU at 0. No DHCP options object is created, so the API never fills in 9036. No MTU advertised. Servers use default 1500.

### Configure server interfaces

The MTU value is now passed to `hhnet.sh` via `--mtu=<value>` when configuring bonds and VLANs on server VMs. Before, server interfaces were never told what MTU to use. Now they match what DHCP advertises.

### CLI validation

The `--interface-mtu` flag now validates that the value is between 96 and 9036 (matching the VPC API limits), and is available on `vlab up` in addition to `setup-vpcs`.

## Why we cannot always leave MTU at 0 for SONiC VS

The ideal behavior for SONiC VS is "do nothing with MTU" -- don't advertise jumbo frames, let servers use their default 1500. Leaving `InterfaceMTU` at 0 achieves this, but only when no DHCP options object is created. The problem is that we cannot always avoid creating one.

When the user configures DNS or NTP servers, the code must create a `VPCDHCPOptions` object to carry those values (`pkg/hhfab/testing.go:804-811`):

```go
var dhcpOpts *vpcapi.VPCDHCPOptions
if len(opts.DNSServers) > 0 || len(opts.TimeServers) > 0 || opts.InterfaceMTU > 0 {
	dhcpOpts = &vpcapi.VPCDHCPOptions{
		DNSServers:   opts.DNSServers,
		TimeServers:  opts.TimeServers,
		InterfaceMTU: opts.InterfaceMTU,
	}
}
```

Once that object exists, the VPC API defaulting webhook sees `InterfaceMTU == 0` and sets it to 9036 (`vendor/go.githedgehog.com/fabric/api/vpc/v1beta1/vpc_types.go:306-317`):

```go
if subnet.DHCP.Options != nil {
	if subnet.DHCP.Options.InterfaceMTU == 0 {
		subnet.DHCP.Options.InterfaceMTU = 9036
	}
}
```

There is no way to create a DHCP options object with DNS servers without also triggering the MTU default. So the code explicitly sets 1500 to fill the slot before the API can inject 9036 (`pkg/hhfab/testing.go:607-608`):

```go
if len(opts.DNSServers) > 0 || len(opts.TimeServers) > 0 {
	opts.InterfaceMTU = 1500
}
```

When no DNS/NTP are configured, all three conditions in the `if` on line 805 are false, `dhcpOpts` stays `nil`, the API webhook never fires, and no MTU is advertised. Leaving `InterfaceMTU` at 0 is safe in this case.

Part of https://github.com/githedgehog/internal/issues/338