### PR TITLE
chore: update frr ref

### DIFF
--- a/hack/arch.sh
+++ b/hack/arch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2024 Hedgehog
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/os.sh
+++ b/hack/os.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2024 Hedgehog
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/fab/comp/gateway/gateway.go
+++ b/pkg/fab/comp/gateway/gateway.go
@@ -28,7 +28,7 @@ const (
 	CtrlChartRef         = "gateway/charts/gateway"
 	APIChartRef          = "gateway/charts/gateway-api"
 	DataplaneRef         = "dataplane"
-	FRRRef               = "dpdk-sys/frr"
+	FRRRef               = "dataplane/frr"
 	DataplaneMetricsPort = 9442
 	FRRMetricsPort       = 9342
 )

--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -18,7 +18,7 @@ var (
 	FabricVersion     = meta.Version("v0.110.0")
 	GatewayVersion    = meta.Version("v0.43.4")
 	DataplaneVersion  = meta.Version("v0.13.0")
-	FRRVersion        = meta.Version("v0.6.0")
+	FRRVersion        = meta.Version("v0.13.0-79-g7eee0f46-debug")
 	BCMSONiCVersion   = meta.Version("v4.5.0")
 	CLSSONiCVersion   = meta.Version("v4.2.1")
 	CumulusVersion    = meta.Version("v5.15.1")


### PR DESCRIPTION
The reference for the container image has changed now that FRR is being built by the updated build system in the dataplane repo.