### PR TITLE
ci: update golangci-lint-action and oras

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
           just --timestamp lint-gha gen _lint
 
       - name: More Go lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           # keep in sync with hack/tools.just
           version: v1.64.8
@@ -167,7 +167,7 @@ jobs:
           brew install --formula docker
 
       - name: Setup oras
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@v1.2.4
 
       - name: Setup local registry
         env:


### PR DESCRIPTION
Part of https://github.com/githedgehog/fabricator/issues/1561

Notes:
- oras-project/setup-oras@v1.2.4 still uses node20 (node24 PR is in-flight upstream)
- extractions/setup-just@v3 setup-crate which is node20 and hasn't been updated


