### PR TITLE
chore(test): add gateway peering NAT tests for all cases in 26.01

### DIFF
--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -132,6 +132,89 @@ func makeTestCtx(ctx context.Context, kube kclient.Client, setupOpts SetupVPCsOp
 	return testCtx
 }
 
+// findExternals finds a viable BGP external and a viable static external, returning (bgpExtName, staticExtName).
+// Two passes ensure hardware externals always win regardless of API response order: pass 1 selects
+// hardware externals, pass 2 accepts virtual externals whose attachments all go through hardware
+// connections (same data path, only the peer device is emulated).
+func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.ExternalList, extAttachList *vpcapi.ExternalAttachmentList) (string, string) {
+	bgpExt, staticExt := "", ""
+
+	hasAttachment := func(extName string) bool {
+		for _, attach := range extAttachList.Items {
+			if attach.Spec.External == extName {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// hasStaticAttachment checks that at least one attachment for the external has
+	// Spec.Static configured, which is required for static external tests to work.
+	hasStaticAttachment := func(extName string) bool {
+		for _, attach := range extAttachList.Items {
+			if attach.Spec.External == extName && attach.Spec.Static != nil {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	allAttachmentsHW := func(extName string) bool {
+		for _, attach := range extAttachList.Items {
+			if attach.Spec.External != extName {
+				continue
+			}
+			conn := &wiringapi.Connection{}
+			if err := kube.Get(ctx, kclient.ObjectKey{Namespace: "default", Name: attach.Spec.Connection}, conn); err != nil {
+				return false
+			}
+			if !isHardware(conn) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	// First pass: prefer hardware externals
+	for _, ext := range extList.Items {
+		if !isHardware(&ext) || !hasAttachment(ext.Name) {
+			continue
+		}
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+			staticExt = ext.Name
+			slog.Info("Using hardware static external", "external", staticExt)
+		} else if ext.Spec.Static == nil && bgpExt == "" {
+			bgpExt = ext.Name
+			slog.Info("Using hardware BGP external", "external", bgpExt)
+		}
+		if bgpExt != "" && staticExt != "" {
+			return bgpExt, staticExt
+		}
+	}
+
+	// Second pass: virtual externals with all-hardware attachments
+	for _, ext := range extList.Items {
+		if !hasAttachment(ext.Name) || !allAttachmentsHW(ext.Name) {
+			continue
+		}
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+			staticExt = ext.Name
+			slog.Info("Using virtual static external (hw-attached)", "external", staticExt)
+		} else if ext.Spec.Static == nil && bgpExt == "" {
+			bgpExt = ext.Name
+			slog.Info("Using virtual BGP external (hw-attached)", "external", bgpExt)
+		}
+		if bgpExt != "" && staticExt != "" {
+			return bgpExt, staticExt
+		}
+	}
+
+	return bgpExt, staticExt
+}
+
 type JUnitReport struct {
 	XMLName xml.Name         `xml:"testsuites"`
 	Suites  []JUnitTestSuite `xml:"testsuite"`
@@ -150,8 +233,8 @@ type JUnitTestSuite struct {
 
 type SkipFlags struct {
 	VirtualSwitch     bool `xml:"-"` // skip if there's any virtual switch in the vlab
-	NoExternals       bool `xml:"-"` // skip if there are no externals
-	NoStaticExternals bool `xml:"-"` // skip if there are no static externals (new API)
+	NoBGPExternals    bool `xml:"-"` // skip if there are no viable BGP externals
+	NoStaticExternals bool `xml:"-"` // skip if there are no viable static externals
 	ExtendedOnly      bool `xml:"-"` // skip if extended tests are not enabled
 	RoCE              bool `xml:"-"` // skip if RoCE is not supported by any of the leaf switches
 	SubInterfaces     bool `xml:"-"` // skip if subinterfaces are not supported by some of the switches
@@ -174,8 +257,8 @@ func (sf *SkipFlags) PrettyPrint() string {
 	if sf.VirtualSwitch {
 		parts = append(parts, "VS")
 	}
-	if sf.NoExternals {
-		parts = append(parts, "NoExt")
+	if sf.NoBGPExternals {
+		parts = append(parts, "NoBGPExt")
 	}
 	if sf.NoStaticExternals {
 		parts = append(parts, "NoStaticExt")
@@ -524,9 +607,17 @@ func selectAndRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, suite *J
 
 			continue
 		}
-		if test.SkipFlags.NoExternals && skipFlags.NoExternals {
+		if test.SkipFlags.NoBGPExternals && skipFlags.NoBGPExternals {
 			suite.TestCases[i].Skipped = &Skipped{
 				Message: "There are no viable externals",
+			}
+			suite.Skipped++
+
+			continue
+		}
+		if test.SkipFlags.NoStaticExternals && skipFlags.NoStaticExternals {
+			suite.TestCases[i].Skipped = &Skipped{
+				Message: "There are no viable static externals",
 			}
 			suite.Skipped++
 
@@ -780,68 +871,17 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 	}
 	if len(extList.Items) == 0 || len(extAttachList.Items) == 0 {
 		slog.Warn("No viable externals found, some tests will be skipped")
-		skipFlags.NoExternals = true
+		skipFlags.NoBGPExternals = true
+		skipFlags.NoStaticExternals = true
 	} else {
-		testCtx.extName = ""
-		// look first for hardware externals with at least one attachment
-		for _, ext := range extList.Items {
-			if !isHardware(&ext) {
-				slog.Debug("Skipping non-hardware external", "external", ext.Name)
-
-				continue
-			}
-			for _, extAttach := range extAttachList.Items {
-				if extAttach.Spec.External != ext.Name {
-					continue
-				}
-				testCtx.extName = ext.Name
-
-				break
-			}
-			if testCtx.extName == "" {
-				slog.Debug("No external attachments found for hardware external, skipping it", "external", ext.Name)
-
-				continue
-			}
-			slog.Info("Using hardware external as the \"default\"", "external", testCtx.extName)
-
-			break
-		}
+		testCtx.extName, testCtx.staticExtName = findExternals(ctx, kube, extList, extAttachList)
 		if testCtx.extName == "" {
-			slog.Debug("No viable hardware externals found, checking for virtual externals attached to hw switches")
-			for _, ext := range extList.Items {
-				extAttach := &vpcapi.ExternalAttachmentList{}
-				if err := kube.List(ctx, extAttach, kclient.MatchingLabels{wiringapi.LabelName("external"): ext.Name}); err != nil {
-					return fmt.Errorf("listing external attachments for %s: %w", ext.Name, err)
-				}
-				if len(extAttach.Items) == 0 {
-					continue
-				}
-				// check if all of the attachments are via hardware connections
-				someNotHW := false
-				for _, attach := range extAttach.Items {
-					conn := &wiringapi.Connection{}
-					if err := kube.Get(ctx, kclient.ObjectKey{Namespace: "default", Name: attach.Spec.Connection}, conn); err != nil {
-						return fmt.Errorf("getting connection %s: %w", attach.Spec.Connection, err)
-					}
-					if !isHardware(conn) {
-						slog.Debug("Skipping virtual external due to non-hardware attachment", "external", ext.Name, "connection", conn.Name)
-						someNotHW = true
-
-						break
-					}
-				}
-				if !someNotHW {
-					testCtx.extName = ext.Name
-					slog.Info("Using virtual external as the \"default\"", "external", testCtx.extName)
-
-					break
-				}
-			}
-			if testCtx.extName == "" {
-				slog.Warn("No viable external found, some tests will be skipped")
-				skipFlags.NoExternals = true
-			}
+			slog.Warn("No viable BGP external found, BGP external tests will be skipped")
+			skipFlags.NoBGPExternals = true
+		}
+		if testCtx.staticExtName == "" {
+			slog.Warn("No viable static external found, static external tests will be skipped")
+			skipFlags.NoStaticExternals = true
 		}
 	}
 

--- a/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
@@ -22,18 +22,18 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 			Name: "Starter Test",
 			F:    testCtx.vpcPeeringsStarterTest,
 			SkipFlags: SkipFlags{
-				NoExternals:   true,
-				SubInterfaces: true,
-				NoServers:     true,
+				NoBGPExternals: true,
+				SubInterfaces:  true,
+				NoServers:      true,
 			},
 		},
 		{
 			Name: "Only Externals",
 			F:    testCtx.vpcPeeringsOnlyExternalsTest,
 			SkipFlags: SkipFlags{
-				NoExternals:   true,
-				SubInterfaces: true,
-				NoServers:     true,
+				NoBGPExternals: true,
+				SubInterfaces:  true,
+				NoServers:      true,
 			},
 		},
 		{
@@ -56,9 +56,9 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 			Name: "Sergei's Special Test",
 			F:    testCtx.vpcPeeringsSergeisSpecialTest,
 			SkipFlags: SkipFlags{
-				NoExternals:   true,
-				SubInterfaces: true,
-				NoServers:     true,
+				NoBGPExternals: true,
+				SubInterfaces:  true,
+				NoServers:      true,
 			},
 		},
 		{
@@ -97,9 +97,9 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 			Name: "Mixed Gateway and Fabric External Peering",
 			F:    testCtx.mixedGatewayAndFabricExternals,
 			SkipFlags: SkipFlags{
-				NoExternals: true,
-				NoGateway:   true,
-				NoServers:   true,
+				NoBGPExternals: true,
+				NoGateway:      true,
+				NoServers:      true,
 			},
 		},
 		{
@@ -115,6 +115,8 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 
 	// Add NAT test cases
 	suite.TestCases = append(suite.TestCases, getNATTestCases(testCtx)...)
+	// Add external NAT test cases
+	suite.TestCases = append(suite.TestCases, getExternalNATTestCases(testCtx)...)
 	suite.Tests = len(suite.TestCases)
 
 	return suite
@@ -307,7 +309,9 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringTest(ctx context.Context) (bool,
 	vpc2 := &vpcs.Items[1]
 
 	// Use all subnets from both VPCs by passing empty subnet lists
-	appendGwPeeringSpec(gwPeerings, vpc1, vpc2, nil)
+	if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, nil); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+	}
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
 		return false, nil, fmt.Errorf("setting up gateway peerings: %w", err)
@@ -346,7 +350,9 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringLoopTest(ctx context.Context) (b
 		vpc2 := &vpcs.Items[(i+1)%len(vpcs.Items)] // wrap around to create loop
 
 		// Use all subnets from both VPCs by passing empty subnet lists
-		appendGwPeeringSpec(gwPeerings, vpc1, vpc2, nil)
+		if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, nil); err != nil {
+			return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+		}
 	}
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
@@ -428,7 +434,9 @@ func (testCtx *VPCPeeringTestCtx) gatewayMixedPeeringLoopTest(ctx context.Contex
 		} else {
 			// Odd-indexed connections use Gateway peering
 			// Use all subnets from both VPCs by passing empty subnet lists
-			appendGwPeeringSpec(gwPeerings, vpc1, vpc2, nil)
+			if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, nil); err != nil {
+				return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+			}
 		}
 	}
 
@@ -484,7 +492,9 @@ func (testCtx *VPCPeeringTestCtx) mixedGatewayAndFabricExternals(ctx context.Con
 	// now peer some VPCs to make sure we are not blocking traffic via the filters
 	slog.Debug("Creating VPC peering between some VPCs to verify connectivity is not affected by mixed external peerings")
 	appendVpcPeeringSpecByName(vpcPeerings, vpcs.Items[0].Name, vpcs.Items[1].Name, "", []string{}, []string{})
-	appendGwPeeringSpec(gwPeerings, &vpcs.Items[2], &vpcs.Items[3], nil)
+	if err := appendGwPeeringSpec(gwPeerings, &vpcs.Items[2], &vpcs.Items[3], nil); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+	}
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
 		return false, nil, fmt.Errorf("setting up mixed peering loop: %w", err)
 	}

--- a/pkg/hhfab/rt_nat_external_tests.go
+++ b/pkg/hhfab/rt_nat_external_tests.go
@@ -35,7 +35,7 @@ const gwNATConvergenceInterval = 5 * time.Second
 // fabric switches are programmed, but the gateway still needs to advertise the NAT pool to DS2000
 // via BGP before return traffic can flow. Static externals have pre-configured routes so no wait
 // is needed.
-func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Context, vpc *vpcapi.VPC, waitForBGPConvergence bool) error {
+func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Context, vpc *vpcapi.VPC, extName string, waitForBGPConvergence bool) error {
 	servers := &wiringapi.ServerList{}
 	if err := testCtx.kube.List(ctx, servers); err != nil {
 		return fmt.Errorf("listing servers: %w", err)
@@ -88,6 +88,20 @@ func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Contex
 			}
 		} else if curlErr != nil {
 			return fmt.Errorf("NAT external connectivity check: %w", curlErr)
+		}
+
+		if remoteIP, err := getExternalRemoteIP(ctx, testCtx.kube, extName); err != nil {
+			return fmt.Errorf("getting external remote IP for ping: %w", err)
+		} else if remoteIP != "" {
+			remoteAddr, err := netip.ParseAddr(remoteIP)
+			if err != nil {
+				return fmt.Errorf("parsing external remote IP %s: %w", remoteIP, err)
+			}
+			slog.Debug("Testing NAT external connectivity stability via ping", "server", server.Name, "target", remoteIP)
+			pingSem := semaphore.NewWeighted(1)
+			if pingErr := checkPing(ctx, 10, pingSem, server.Name, remoteIP, sshCfg, remoteAddr, nil, true); pingErr != nil {
+				return fmt.Errorf("NAT external connectivity ping stability check: %w", pingErr)
+			}
 		}
 
 		tested++
@@ -216,7 +230,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalStaticNATTest(ctx context.Context) 
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, true); err != nil {
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName, true); err != nil {
 		return false, nil, fmt.Errorf("testing BGP external static NAT connectivity: %w", err)
 	}
 
@@ -287,7 +301,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradeNATTest(ctx context.Conte
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, true); err != nil {
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName, true); err != nil {
 		return false, nil, fmt.Errorf("testing BGP external masquerade NAT connectivity: %w", err)
 	}
 
@@ -470,7 +484,7 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradePortForwardNATTest(ctx co
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, true); err != nil {
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName, true); err != nil {
 		return false, nil, fmt.Errorf("testing BGP external masquerade+port-forward NAT connectivity: %w", err)
 	}
 
@@ -593,7 +607,7 @@ func (testCtx *VPCPeeringTestCtx) staticExternalStaticNATGatewayTest(ctx context
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, false); err != nil {
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName, false); err != nil {
 		return false, nil, fmt.Errorf("testing static external static NAT connectivity: %w", err)
 	}
 
@@ -664,7 +678,7 @@ func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradeNATGatewayTest(ctx con
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, false); err != nil {
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName, false); err != nil {
 		return false, nil, fmt.Errorf("testing static external masquerade NAT connectivity: %w", err)
 	}
 
@@ -916,7 +930,7 @@ func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradePortForwardNATGatewayT
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, false); err != nil {
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName, false); err != nil {
 		return false, nil, fmt.Errorf("testing static external masquerade+port-forward NAT connectivity: %w", err)
 	}
 

--- a/pkg/hhfab/rt_nat_external_tests.go
+++ b/pkg/hhfab/rt_nat_external_tests.go
@@ -1,0 +1,1010 @@
+// Copyright 2024 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"sort"
+	"strings"
+	"time"
+
+	gwapi "go.githedgehog.com/fabric/api/gateway/v1alpha1"
+	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/util/apiutil"
+	"golang.org/x/sync/semaphore"
+)
+
+// gwNATConvergenceTimeout is the maximum time to wait for the gateway NAT dataplane to
+// become active after a peering is established. WaitReady confirms the fabric switches are
+// ready, but the gateway still needs to program NAT rules (and, for BGP externals, advertise
+// routes to the upstream peer). Both take additional time that varies by environment.
+const gwNATConvergenceTimeout = 2 * time.Minute
+
+// gwNATConvergenceInterval is the polling interval between retries while waiting for the
+// gateway NAT dataplane to converge.
+const gwNATConvergenceInterval = 5 * time.Second
+
+// testNATExternalConnectivity tests outbound connectivity from a VPC through a NAT gateway peering
+// by curling 1.0.0.1 directly, bypassing the standard peering check that does not understand NAT
+// expose CIDRs. Pass waitForBGPConvergence=true for BGP externals: WaitReady only confirms the
+// fabric switches are programmed, but the gateway still needs to advertise the NAT pool to DS2000
+// via BGP before return traffic can flow. Static externals have pre-configured routes so no wait
+// is needed.
+func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Context, vpc *vpcapi.VPC, waitForBGPConvergence bool) error {
+	servers := &wiringapi.ServerList{}
+	if err := testCtx.kube.List(ctx, servers); err != nil {
+		return fmt.Errorf("listing servers: %w", err)
+	}
+
+	curlSem := semaphore.NewWeighted(1)
+
+	var tested int
+	for _, server := range servers.Items {
+		attachedSubnets, err := apiutil.GetAttachedSubnets(ctx, testCtx.kube, server.Name)
+		if err != nil {
+			continue
+		}
+
+		inVPC := false
+		for subnetName := range attachedSubnets {
+			if strings.HasPrefix(subnetName, vpc.Name+"/") {
+				inVPC = true
+
+				break
+			}
+		}
+		if !inVPC {
+			continue
+		}
+
+		sshCfg, err := testCtx.getSSH(ctx, server.Name)
+		if err != nil {
+			return fmt.Errorf("getting ssh config for %s: %w", server.Name, err)
+		}
+
+		slog.Debug("Testing NAT external connectivity via curl", "server", server.Name)
+		curlErr := checkCurl(ctx, testCtx.tcOpts, curlSem, server.Name, sshCfg, "1.0.0.1", true)
+		if curlErr != nil && waitForBGPConvergence {
+			deadline := time.Now().Add(gwNATConvergenceTimeout)
+			for curlErr != nil {
+				if time.Now().After(deadline) {
+					break
+				}
+				slog.Debug("BGP routes not yet propagated, retrying", "server", server.Name, "error", curlErr, "retryIn", gwNATConvergenceInterval)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(gwNATConvergenceInterval):
+				}
+				curlErr = checkCurl(ctx, testCtx.tcOpts, curlSem, server.Name, sshCfg, "1.0.0.1", true)
+			}
+			if curlErr != nil {
+				return fmt.Errorf("NAT external connectivity check (BGP not converged after %s): %w", gwNATConvergenceTimeout, curlErr)
+			}
+		} else if curlErr != nil {
+			return fmt.Errorf("NAT external connectivity check: %w", curlErr)
+		}
+
+		tested++
+	}
+
+	if tested == 0 {
+		return fmt.Errorf("no servers found in VPC %s for NAT external connectivity test", vpc.Name) //nolint:goerr113
+	}
+
+	return nil
+}
+
+// Test gateway external peering with no NAT (baseline)
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) bgpExternalNoNatTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.extName == "" {
+		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for external NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	appendGwExtPeeringSpec(gwPeerings, vpc, nil, testCtx.extName)
+
+	slog.Info("Testing BGP external peering with no NAT", "vpc", vpc.Name, "external", testCtx.extName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up BGP external peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		return false, nil, fmt.Errorf("testing BGP external connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway external peering with static NAT
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.81.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Static:
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) bgpExternalStaticNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.extName == "" {
+		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
+	}
+
+	bgpNATCIDR, err := getExternalBGPNATCIDR(ctx, testCtx.kube, testCtx.extName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting BGP NAT CIDR for external %s: %w", testCtx.extName, err)
+	}
+	if bgpNATCIDR == "" {
+		return true, nil, fmt.Errorf("no BGP NAT pool annotation (%s) on external %s", extBGPNATAnnotation, testCtx.extName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for external static NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	if err := appendGwExtPeeringSpecWithNAT(gwPeerings, vpc, testCtx.extName, &GwExtPeeringOptions{
+		VPCNATCIDR: []string{bgpNATCIDR},
+		VPCNATMode: NATModeStatic,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway external peering: %w", err)
+	}
+
+	slog.Info("Testing BGP external peering with static NAT", "vpc", vpc.Name, "external", testCtx.extName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up BGP external static NAT peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, true); err != nil {
+		return false, nil, fmt.Errorf("testing BGP external static NAT connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway external peering with masquerade NAT
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.81.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Masquerade:
+//	          Idle Timeout:  5m0s
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradeNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.extName == "" {
+		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
+	}
+
+	bgpNATCIDR, err := getExternalBGPNATCIDR(ctx, testCtx.kube, testCtx.extName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting BGP NAT CIDR for external %s: %w", testCtx.extName, err)
+	}
+	if bgpNATCIDR == "" {
+		return true, nil, fmt.Errorf("no BGP NAT pool annotation (%s) on external %s", extBGPNATAnnotation, testCtx.extName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for external masquerade NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	if err := appendGwExtPeeringSpecWithNAT(gwPeerings, vpc, testCtx.extName, &GwExtPeeringOptions{
+		VPCNATCIDR: []string{bgpNATCIDR},
+		VPCNATMode: NATModeMasquerade,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway external peering: %w", err)
+	}
+
+	slog.Info("Testing BGP external peering with masquerade NAT", "vpc", vpc.Name, "external", testCtx.extName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up BGP external masquerade NAT peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, true); err != nil {
+		return false, nil, fmt.Errorf("testing BGP external masquerade NAT connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway external peering with port-forward NAT (inverted: VPC→external).
+// The peering is set up with port-forward NAT on the external side, so the VPC can initiate
+// connections to the external device's iperf3 server through the gateway. The external's BGP
+// neighbor IP is NAT'd to .200/32 within the BGP NAT pool CIDR (from the extBGPNATAnnotation),
+// with port-forward 5201→15201. VPC connects to that IP:15201, gateway forwards to external:5201.
+//
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  10.50.1.0/24  (no NAT — VPC IPs visible)
+//	  ext-<name>:
+//	    Expose:
+//	      As:
+//	        Cidr:  <bgpNATCIDR .200>/32
+//	      Ips:
+//	        Cidr:  <ext neighbor IP>/32
+//	      Nat:
+//	        Port Forward:
+//	          Rules:
+//	          - Protocol: TCP
+//	            Port: 5201
+//	            As: 15201
+func (testCtx *VPCPeeringTestCtx) bgpExternalPortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.extName == "" {
+		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
+	}
+
+	bgpNATCIDR, err := getExternalBGPNATCIDR(ctx, testCtx.kube, testCtx.extName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting BGP NAT CIDR for external %s: %w", testCtx.extName, err)
+	}
+	if bgpNATCIDR == "" {
+		return true, nil, fmt.Errorf("no BGP NAT pool annotation (%s) on external %s", extBGPNATAnnotation, testCtx.extName) //nolint:goerr113
+	}
+
+	prefix, err := netip.ParsePrefix(bgpNATCIDR)
+	if err != nil {
+		return false, nil, fmt.Errorf("parsing BGP NAT CIDR %s: %w", bgpNATCIDR, err)
+	}
+	if prefix.Bits() != 24 {
+		return false, nil, fmt.Errorf("BGP NAT CIDR %s must be a /24 for the .200 inverted NAT address to be valid", bgpNATCIDR) //nolint:goerr113
+	}
+	// .200 within the NAT pool is the virtual IP representing the external device; traffic to it
+	// is port-forwarded to the real neighbor IP. Chosen to avoid VPC server IPs (low end of
+	// subnet) while staying within the /24 covered by the BGP advertisement.
+	b := prefix.Masked().Addr().As4()
+	b[3] = 200
+	bgpInvertedNATCIDR := netip.AddrFrom4(b).String() + "/32"
+
+	extRemoteIP, err := getExternalRemoteIP(ctx, testCtx.kube, testCtx.extName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting remote IP for external %s: %w", testCtx.extName, err)
+	}
+	if extRemoteIP == "" {
+		return true, nil, fmt.Errorf("no remote IP found in ExternalAttachment for %s", testCtx.extName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for BGP external port-forward NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	portForwardRules := []gwapi.PeeringNATPortForwardEntry{
+		{Protocol: gwapi.PeeringNATProtocolTCP, Port: "5201", As: "15201"},
+	}
+	appendGwExtInvertedPortForwardPeeringSpec(gwPeerings, vpc, testCtx.extName, extRemoteIP, bgpInvertedNATCIDR, portForwardRules)
+
+	slog.Info("Testing BGP external port-forward (inverted: VPC→ext)", "vpc", vpc.Name, "external", testCtx.extName, "extIP", extRemoteIP, "natCIDR", bgpInvertedNATCIDR)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up BGP external inverted port-forward peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testIperfToExternal(ctx, vpc, bgpInvertedNATCIDR, true); err != nil {
+		return false, nil, fmt.Errorf("testing BGP external port-forward via iperf3: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway external peering with combined masquerade and port-forward NAT
+// Masquerade enables outbound NAT from vpc to external; port-forward enables inbound on 15201→5201.
+// The outbound direction (vpc→external via masquerade) is tested with curl.
+// The inbound port-forward from external is not tested (no SSH access to external).
+//
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.81.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Masquerade:
+//	          Idle Timeout:  5m0s
+//	        Port Forward:
+//	          Rules:
+//	          - Protocol: TCP
+//	            Port: 5201
+//	            As: 15201
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradePortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.extName == "" {
+		return true, nil, fmt.Errorf("no BGP external available for testing") //nolint:goerr113
+	}
+
+	bgpNATCIDR, err := getExternalBGPNATCIDR(ctx, testCtx.kube, testCtx.extName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting BGP NAT CIDR for external %s: %w", testCtx.extName, err)
+	}
+	if bgpNATCIDR == "" {
+		return true, nil, fmt.Errorf("no BGP NAT pool annotation (%s) on external %s", extBGPNATAnnotation, testCtx.extName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for external masquerade+port-forward NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	portForwardRules := []gwapi.PeeringNATPortForwardEntry{
+		{Protocol: gwapi.PeeringNATProtocolTCP, Port: "5201", As: "15201"},
+	}
+	if err := appendGwExtPeeringSpecWithNAT(gwPeerings, vpc, testCtx.extName, &GwExtPeeringOptions{
+		VPCNATCIDR:          []string{bgpNATCIDR},
+		VPCNATMode:          NATModeMasqueradePortForward,
+		VPCPortForwardRules: portForwardRules,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway external peering: %w", err)
+	}
+
+	slog.Info("Testing BGP external peering with masquerade+port-forward NAT", "vpc", vpc.Name, "external", testCtx.extName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up BGP external masquerade+port-forward NAT peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, true); err != nil {
+		return false, nil, fmt.Errorf("testing BGP external masquerade+port-forward NAT connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway static external peering with no NAT
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) staticExternalNoNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.staticExtName == "" {
+		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for static external no NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	appendGwExtPeeringSpec(gwPeerings, vpc, nil, testCtx.staticExtName)
+
+	slog.Info("Testing static external peering with no NAT", "vpc", vpc.Name, "external", testCtx.staticExtName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up static external peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		return false, nil, fmt.Errorf("testing static external connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway static external peering with static NAT
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.81.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Static:
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) staticExternalStaticNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.staticExtName == "" {
+		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
+	}
+
+	staticNATCIDR, err := getExternalStaticNATCIDR(ctx, testCtx.kube, testCtx.staticExtName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting static NAT CIDR for external %s: %w", testCtx.staticExtName, err)
+	}
+	if staticNATCIDR == "" {
+		return true, nil, fmt.Errorf("no static NAT pool annotation (%s) on external %s", extStaticNATPoolAnnotation, testCtx.staticExtName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for static external static NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	if err := appendGwExtPeeringSpecWithNAT(gwPeerings, vpc, testCtx.staticExtName, &GwExtPeeringOptions{
+		VPCNATCIDR: []string{staticNATCIDR},
+		VPCNATMode: NATModeStatic,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway external peering: %w", err)
+	}
+
+	slog.Info("Testing static external peering with static NAT", "vpc", vpc.Name, "external", testCtx.staticExtName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up static external static NAT peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, false); err != nil {
+		return false, nil, fmt.Errorf("testing static external static NAT connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway static external peering with masquerade NAT
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.81.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Masquerade:
+//	          Idle Timeout:  5m0s
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradeNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.staticExtName == "" {
+		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
+	}
+
+	staticNATCIDR, err := getExternalStaticNATCIDR(ctx, testCtx.kube, testCtx.staticExtName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting static NAT CIDR for external %s: %w", testCtx.staticExtName, err)
+	}
+	if staticNATCIDR == "" {
+		return true, nil, fmt.Errorf("no static NAT pool annotation (%s) on external %s", extStaticNATPoolAnnotation, testCtx.staticExtName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for static external masquerade NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	if err := appendGwExtPeeringSpecWithNAT(gwPeerings, vpc, testCtx.staticExtName, &GwExtPeeringOptions{
+		VPCNATCIDR: []string{staticNATCIDR},
+		VPCNATMode: NATModeMasquerade,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway external peering: %w", err)
+	}
+
+	slog.Info("Testing static external peering with masquerade NAT", "vpc", vpc.Name, "external", testCtx.staticExtName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up static external masquerade NAT peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, false); err != nil {
+		return false, nil, fmt.Errorf("testing static external masquerade NAT connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// testIperfToExternal runs iperf3 from a VPC server to invertedNATCIDR:15201, testing
+// connectivity through the gateway's inverted port-forward NAT (external side has NAT).
+// One server in the VPC is sufficient.
+// waitForBGPConvergence should be true for BGP externals where the port-forward target IP is
+// reachable only after BGP route propagation; false for static externals with pre-configured routes.
+func (testCtx *VPCPeeringTestCtx) testIperfToExternal(ctx context.Context, vpc *vpcapi.VPC, invertedNATCIDR string, waitForBGPConvergence bool) error {
+	servers := &wiringapi.ServerList{}
+	if err := testCtx.kube.List(ctx, servers); err != nil {
+		return fmt.Errorf("listing servers: %w", err)
+	}
+
+	extNATIP := strings.SplitN(invertedNATCIDR, "/", 2)[0]
+	secs := testCtx.tcOpts.IPerfsSeconds
+	if secs <= 0 {
+		secs = 5
+	}
+
+	for _, server := range servers.Items {
+		attachedSubnets, err := apiutil.GetAttachedSubnets(ctx, testCtx.kube, server.Name)
+		if err != nil {
+			continue
+		}
+
+		inVPC := false
+		for subnetName := range attachedSubnets {
+			if strings.HasPrefix(subnetName, vpc.Name+"/") {
+				inVPC = true
+
+				break
+			}
+		}
+		if !inVPC {
+			continue
+		}
+
+		sshCfg, err := testCtx.getSSH(ctx, server.Name)
+		if err != nil {
+			return fmt.Errorf("getting ssh config for %s: %w", server.Name, err)
+		}
+
+		cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 -J -c %s -p 15201 -t %d",
+			secs+25, extNATIP, secs)
+		slog.Debug("Testing iperf3 through inverted port-forward NAT", "server", server.Name, "target", extNATIP+":15201")
+		_, _, iperfErr := retrySSHCmd(ctx, sshCfg, cmd, server.Name)
+		if iperfErr != nil && waitForBGPConvergence {
+			deadline := time.Now().Add(gwNATConvergenceTimeout)
+			for iperfErr != nil {
+				if time.Now().After(deadline) {
+					break
+				}
+				slog.Debug("BGP port-forward route not yet propagated, retrying", "server", server.Name, "error", iperfErr, "retryIn", gwNATConvergenceInterval)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(gwNATConvergenceInterval):
+				}
+				_, _, iperfErr = retrySSHCmd(ctx, sshCfg, cmd, server.Name)
+			}
+			if iperfErr != nil {
+				return fmt.Errorf("iperf3 from %s to %s:15201 (BGP not converged after %s): %w", server.Name, extNATIP, gwNATConvergenceTimeout, iperfErr)
+			}
+		} else if iperfErr != nil {
+			return fmt.Errorf("iperf3 from %s to %s:15201: %w", server.Name, extNATIP, iperfErr)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("no servers found in VPC %s for iperf3 test", vpc.Name) //nolint:goerr113
+}
+
+// Test gateway static external peering with port-forward NAT (inverted: VPC→external).
+// The peering is set up with port-forward NAT on the external side, so VPC can initiate
+// connections to the external device's iperf3 server through the gateway.
+//
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  10.50.1.0/24   (no NAT — VPC IPs visible; DS2000 has static return routes)
+//	  ext-<name>:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.81.200/32
+//	      Ips:
+//	        Cidr:  <DS2000 remoteIP>/32
+//	      Nat:
+//	        Port Forward:
+//	          Rules:
+//	          - Protocol: TCP
+//	            Port: 5201
+//	            As: 15201
+func (testCtx *VPCPeeringTestCtx) staticExternalPortForwardNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.staticExtName == "" {
+		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
+	}
+
+	staticNATCIDR, err := getExternalStaticNATCIDR(ctx, testCtx.kube, testCtx.staticExtName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting static NAT CIDR for external %s: %w", testCtx.staticExtName, err)
+	}
+	if staticNATCIDR == "" {
+		return true, nil, fmt.Errorf("no static NAT pool annotation (%s) on external %s", extStaticNATPoolAnnotation, testCtx.staticExtName) //nolint:goerr113
+	}
+
+	prefix, err := netip.ParsePrefix(staticNATCIDR)
+	if err != nil {
+		return false, nil, fmt.Errorf("parsing static NAT CIDR %s: %w", staticNATCIDR, err)
+	}
+	if prefix.Bits() != 24 {
+		return false, nil, fmt.Errorf("static NAT CIDR %s must be a /24 for the .200 inverted NAT address to be valid", staticNATCIDR) //nolint:goerr113
+	}
+	// .200 within the NAT pool is the virtual IP representing the external device; traffic to it
+	// is port-forwarded to the real remote IP. DS2000 has a static route for the whole /24 so
+	// any address in the pool is reachable. Chosen to avoid VPC server IPs (low end of subnet).
+	b := prefix.Masked().Addr().As4()
+	b[3] = 200
+	staticInvertedNATCIDR := netip.AddrFrom4(b).String() + "/32"
+
+	extRemoteIP, err := getExternalRemoteIP(ctx, testCtx.kube, testCtx.staticExtName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting remote IP for external %s: %w", testCtx.staticExtName, err)
+	}
+	if extRemoteIP == "" {
+		return true, nil, fmt.Errorf("no remote IP found in ExternalAttachment for %s", testCtx.staticExtName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for static external port-forward test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	portForwardRules := []gwapi.PeeringNATPortForwardEntry{
+		{Protocol: gwapi.PeeringNATProtocolTCP, Port: "5201", As: "15201"},
+	}
+	appendGwExtInvertedPortForwardPeeringSpec(gwPeerings, vpc, testCtx.staticExtName, extRemoteIP, staticInvertedNATCIDR, portForwardRules)
+
+	slog.Info("Testing static external port-forward (inverted: VPC→ext)", "vpc", vpc.Name, "external", testCtx.staticExtName, "extIP", extRemoteIP)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up inverted port-forward peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testIperfToExternal(ctx, vpc, staticInvertedNATCIDR, false); err != nil {
+		return false, nil, fmt.Errorf("testing static external port-forward via iperf3: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway static external peering with combined masquerade and port-forward NAT
+// Masquerade enables outbound NAT from vpc to external; port-forward enables inbound on 15201→5201.
+// The outbound direction (vpc→external via masquerade) is tested with curl.
+// The inbound port-forward from external is not tested (no SSH access to external).
+//
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.81.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Masquerade:
+//	          Idle Timeout:  5m0s
+//	        Port Forward:
+//	          Rules:
+//	          - Protocol: TCP
+//	            Port: 5201
+//	            As: 15201
+//	  ext-<name>:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  0.0.0.0/0
+func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradePortForwardNATGatewayTest(ctx context.Context) (bool, []RevertFunc, error) {
+	if testCtx.staticExtName == "" {
+		return true, nil, fmt.Errorf("no static external available for testing") //nolint:goerr113
+	}
+
+	staticNATCIDR, err := getExternalStaticNATCIDR(ctx, testCtx.kube, testCtx.staticExtName)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting static NAT CIDR for external %s: %w", testCtx.staticExtName, err)
+	}
+	if staticNATCIDR == "" {
+		return true, nil, fmt.Errorf("no static NAT pool annotation (%s) on external %s", extStaticNATPoolAnnotation, testCtx.staticExtName) //nolint:goerr113
+	}
+
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 1 {
+		return true, nil, fmt.Errorf("no VPCs available for static external masquerade+port-forward NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc := &vpcs.Items[0]
+	portForwardRules := []gwapi.PeeringNATPortForwardEntry{
+		{Protocol: gwapi.PeeringNATProtocolTCP, Port: "5201", As: "15201"},
+	}
+	if err := appendGwExtPeeringSpecWithNAT(gwPeerings, vpc, testCtx.staticExtName, &GwExtPeeringOptions{
+		VPCNATCIDR:          []string{staticNATCIDR},
+		VPCNATMode:          NATModeMasqueradePortForward,
+		VPCPortForwardRules: portForwardRules,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway external peering: %w", err)
+	}
+
+	slog.Info("Testing static external peering with masquerade+port-forward NAT", "vpc", vpc.Name, "external", testCtx.staticExtName)
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up static external masquerade+port-forward NAT peering: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, false); err != nil {
+		return false, nil, fmt.Errorf("testing static external masquerade+port-forward NAT connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// getExternalNATTestCases returns the external NAT test cases
+func getExternalNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
+	return []JUnitTestCase{
+		{
+			Name: "Gateway Peering BGP External No NAT",
+			F:    testCtx.bgpExternalNoNatTest,
+			SkipFlags: SkipFlags{
+				NoGateway:      true,
+				NoBGPExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering BGP External Static NAT",
+			F:    testCtx.bgpExternalStaticNATTest,
+			SkipFlags: SkipFlags{
+				NoGateway:      true,
+				NoBGPExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering BGP External Masquerade NAT",
+			F:    testCtx.bgpExternalMasqueradeNATTest,
+			SkipFlags: SkipFlags{
+				NoGateway:      true,
+				NoBGPExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering BGP External Port Forward NAT",
+			F:    testCtx.bgpExternalPortForwardNATTest,
+			SkipFlags: SkipFlags{
+				NoGateway:      true,
+				NoBGPExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering BGP External Masquerade and Port Forward NAT",
+			F:    testCtx.bgpExternalMasqueradePortForwardNATTest,
+			SkipFlags: SkipFlags{
+				NoGateway:      true,
+				NoBGPExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering Static External No NAT",
+			F:    testCtx.staticExternalNoNATGatewayTest,
+			SkipFlags: SkipFlags{
+				NoGateway:         true,
+				NoStaticExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering Static External Static NAT",
+			F:    testCtx.staticExternalStaticNATGatewayTest,
+			SkipFlags: SkipFlags{
+				NoGateway:         true,
+				NoStaticExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering Static External Masquerade NAT",
+			F:    testCtx.staticExternalMasqueradeNATGatewayTest,
+			SkipFlags: SkipFlags{
+				NoGateway:         true,
+				NoStaticExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering Static External Port Forward NAT",
+			F:    testCtx.staticExternalPortForwardNATGatewayTest,
+			SkipFlags: SkipFlags{
+				NoGateway:         true,
+				NoStaticExternals: true,
+			},
+		},
+		{
+			Name: "Gateway Peering Static External Masquerade and Port Forward NAT",
+			F:    testCtx.staticExternalMasqueradePortForwardNATGatewayTest,
+			SkipFlags: SkipFlags{
+				NoGateway:         true,
+				NoStaticExternals: true,
+			},
+		},
+	}
+}

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -18,6 +18,7 @@ import (
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 	"go.githedgehog.com/fabric/pkg/util/apiutil"
 	"go.githedgehog.com/fabricator/pkg/util/sshutil"
+	"golang.org/x/sync/errgroup"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -353,10 +354,12 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringMasqueradeSourceNATTest(ctx cont
 	// Only VPC1 has masquerade NAT - VPC1's traffic will be source-NATed
 	vpc1NATCIDR := []string{"192.168.11.0/24"}
 
-	appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
+	if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
 		VPC1NATCIDR: vpc1NATCIDR,
 		VPC1NATMode: NATModeMasquerade,
-	})
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+	}
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
 		return false, nil, fmt.Errorf("setting up NAT gateway peerings: %w", err)
@@ -418,9 +421,11 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringStaticSourceNATTest(ctx context.
 	// Only VPC1 has NAT - this means VPC1's traffic will be source-NATed
 	vpc1NATCIDR := []string{"192.168.21.0/24"}
 
-	appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
+	if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
 		VPC1NATCIDR: vpc1NATCIDR,
-	})
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+	}
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
 		return false, nil, fmt.Errorf("setting up static source NAT peerings: %w", err)
@@ -485,10 +490,12 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringBidirectionalStaticNATTest(ctx c
 	vpc1NATCIDR := []string{"192.168.31.0/24"}
 	vpc2NATCIDR := []string{"192.168.32.0/24"}
 
-	appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
+	if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
 		VPC1NATCIDR: vpc1NATCIDR,
 		VPC2NATCIDR: vpc2NATCIDR,
-	})
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+	}
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
 		return false, nil, fmt.Errorf("setting up bidirectional NAT peerings: %w", err)
@@ -631,6 +638,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringOverlapNATTest(ctx context.Conte
 	originalSubnet := targetAttachment.Spec.Subnet
 	originalVLAN := donorVPC.Spec.Subnets[originalSubnetName].VLAN
 
+	newVLAN := originalVLAN + 100 // Use different VLAN to avoid conflicts
 	// Create the new IPv4Namespace with the same subnet range as the existing VPC's namespace
 	overlapNS := &vpcapi.IPv4Namespace{
 		TypeMeta: kmetav1.TypeMeta{
@@ -664,7 +672,6 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringOverlapNATTest(ctx context.Conte
 	})
 
 	// Create the new VPC in the overlap namespace with the SAME subnet CIDR as existingVPC
-	newVLAN := originalVLAN + 100 // Use different VLAN to avoid conflicts
 	overlapVPC := &vpcapi.VPC{
 		TypeMeta: kmetav1.TypeMeta{
 			Kind:       vpcapi.KindVPC,
@@ -830,10 +837,12 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringOverlapNATTest(ctx context.Conte
 	existingVPCNATCIDR := []string{"192.168.71.0/24"}
 	overlapVPCNATCIDR := []string{"192.168.72.0/24"}
 
-	appendGwPeeringSpec(gwPeerings, existingVPC, overlapVPC, &GwPeeringOptions{
+	if err := appendGwPeeringSpec(gwPeerings, existingVPC, overlapVPC, &GwPeeringOptions{
 		VPC1NATCIDR: existingVPCNATCIDR,
 		VPC2NATCIDR: overlapVPCNATCIDR,
-	})
+	}); err != nil {
+		return false, reverts, fmt.Errorf("setting up gateway peering: %w", err)
+	}
 
 	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
 		return false, reverts, fmt.Errorf("setting up overlap NAT gateway peerings: %w", err)
@@ -856,6 +865,318 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringOverlapNATTest(ctx context.Conte
 	slog.Info("Overlap NAT test completed successfully")
 
 	return false, reverts, nil
+}
+
+// testPortForwardInboundConnectivity tests inbound port-forward NAT connectivity.
+// The peering side with port-forward NAT (vpc1) exposes a NAT pool CIDR; the other side (vpc2)
+// connects to vpc1's NAT IPs on the forwarded external port. The gateway translates to the
+// real vpc1 server port (5201). This mirrors the port-forward semantics: inbound only.
+func (testCtx *VPCPeeringTestCtx) testPortForwardInboundConnectivity(
+	ctx context.Context,
+	vpc1, vpc2 *vpcapi.VPC,
+	vpc1NATCIDRStr string,
+	externalPort int,
+) error {
+	servers := &wiringapi.ServerList{}
+	if err := testCtx.kube.List(ctx, servers); err != nil {
+		return fmt.Errorf("listing servers: %w", err)
+	}
+
+	var vpc1Servers, vpc2Servers []string
+	for _, server := range servers.Items {
+		attachedSubnets, err := apiutil.GetAttachedSubnets(ctx, testCtx.kube, server.Name)
+		if err != nil {
+			continue
+		}
+		for subnetName := range attachedSubnets {
+			if strings.HasPrefix(subnetName, vpc1.Name+"/") {
+				vpc1Servers = append(vpc1Servers, server.Name)
+
+				break
+			}
+			if strings.HasPrefix(subnetName, vpc2.Name+"/") {
+				vpc2Servers = append(vpc2Servers, server.Name)
+
+				break
+			}
+		}
+	}
+
+	if len(vpc1Servers) == 0 || len(vpc2Servers) == 0 {
+		return fmt.Errorf("need servers in both VPCs for port-forward test") //nolint:goerr113
+	}
+
+	sshConfigs := map[string]*sshutil.Config{}
+	for _, serverName := range append(vpc1Servers, vpc2Servers...) {
+		sshCfg, err := testCtx.getSSH(ctx, serverName)
+		if err != nil {
+			return fmt.Errorf("getting ssh config for %s: %w", serverName, err)
+		}
+		sshConfigs[serverName] = sshCfg
+	}
+
+	// Discover vpc1 server IPs
+	serverIPs := map[string]netip.Addr{}
+	for _, serverName := range vpc1Servers {
+		stdout, stderr, err := sshConfigs[serverName].Run(ctx, "ip -o -4 addr show | awk '{print $2, $4}'")
+		if err != nil {
+			return fmt.Errorf("getting IP for %s: %w: %s", serverName, err, stderr)
+		}
+		var eligibleAddrs []netip.Addr
+		for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) != 2 {
+				continue
+			}
+			if excludedInterfaces[fields[0]] {
+				continue
+			}
+			addr, err := netip.ParsePrefix(fields[1])
+			if err != nil {
+				continue
+			}
+			eligibleAddrs = append(eligibleAddrs, addr.Addr())
+		}
+		if len(eligibleAddrs) != 1 {
+			return fmt.Errorf("server %s has %d eligible IPs, expected exactly 1", serverName, len(eligibleAddrs)) //nolint:goerr113
+		}
+		serverIPs[serverName] = eligibleAddrs[0]
+		slog.Debug("Discovered vpc1 server IP", "server", serverName, "ip", eligibleAddrs[0].String())
+	}
+
+	natPrefix, err := netip.ParsePrefix(vpc1NATCIDRStr)
+	if err != nil {
+		return fmt.Errorf("parsing NAT CIDR %s: %w", vpc1NATCIDRStr, err)
+	}
+	natPoolStart := natPrefix.Masked().Addr()
+
+	if len(vpc1.Spec.Subnets) != 1 {
+		return fmt.Errorf("VPC %s has %d subnets, port-forward test requires exactly one", vpc1.Name, len(vpc1.Spec.Subnets)) //nolint:goerr113
+	}
+	var vpc1SubnetStart netip.Addr
+	for _, subnet := range vpc1.Spec.Subnets {
+		prefix, err := netip.ParsePrefix(subnet.Subnet)
+		if err != nil {
+			return fmt.Errorf("parsing VPC subnet: %w", err)
+		}
+		vpc1SubnetStart = prefix.Masked().Addr()
+	}
+
+	// Test inbound port-forward: vpc2 server → vpc1's NAT IP:externalPort → vpc1 server:5201
+	for _, serverB := range vpc1Servers { // iperf3 server side (behind NAT)
+		natIP, err := calculateStaticNATIP(serverIPs[serverB], vpc1SubnetStart, natPoolStart)
+		if err != nil {
+			return fmt.Errorf("calculating NAT IP for %s: %w", serverB, err)
+		}
+
+		for _, serverA := range vpc2Servers { // iperf3 client side (initiates connection)
+			slog.Debug("Testing port-forward inbound",
+				"from", serverA, "to", serverB, "natIP", natIP, "externalPort", externalPort)
+
+			serverBName := serverB
+			serverAName := serverA
+			g, gCtx := errgroup.WithContext(ctx)
+
+			g.Go(func() error {
+				cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 -s -1",
+					testCtx.tcOpts.IPerfsSeconds+25)
+				if _, stderr, err := retrySSHCmd(gCtx, sshConfigs[serverBName], cmd, serverBName); err != nil {
+					return fmt.Errorf("iperf3 server on %s: %w: %s", serverBName, err, stderr)
+				}
+
+				return nil
+			})
+
+			g.Go(func() error {
+				// Wait for iperf3 server to start listening on port 5201
+				maxWait := 10 * time.Second
+				checkInterval := 100 * time.Millisecond
+				start := time.Now()
+				for {
+					if time.Since(start) >= maxWait {
+						return fmt.Errorf("iperf3 server on %s did not start within %s", serverBName, maxWait) //nolint:goerr113
+					}
+					checkCmd := fmt.Sprintf("timeout 1 ss -ltn | grep -q ' \\*:%d '", iperf3DefaultPort)
+					if _, _, checkErr := retrySSHCmd(gCtx, sshConfigs[serverBName], checkCmd, serverBName); checkErr == nil {
+						break
+					}
+					select {
+					case <-gCtx.Done():
+						return fmt.Errorf("waiting for iperf3 server: %w", gCtx.Err())
+					case <-time.After(checkInterval):
+					}
+				}
+				// Connect to vpc1's NAT IP on the forwarded external port
+				cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 -c %s -p %d -t %d",
+					testCtx.tcOpts.IPerfsSeconds+25, natIP.String(), externalPort, testCtx.tcOpts.IPerfsSeconds)
+				if _, stderr, err := retrySSHCmd(gCtx, sshConfigs[serverAName], cmd, serverAName); err != nil {
+					return fmt.Errorf("iperf3 client from %s to %s:%d: %w: %s", serverAName, natIP, externalPort, err, stderr)
+				}
+
+				return nil
+			})
+
+			if err := g.Wait(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Test gateway peering with port-forwarding NAT only
+// Port-forward NAT is INBOUND: vpc2 connects to vpc1's NAT IP:15201, gateway forwards to vpc1's real IP:5201.
+// vpc1 cannot initiate connections to vpc2 (port-forward does not enable outbound NAT).
+//
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.52.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Port Forward:
+//	          Rules:
+//	          - Protocol: TCP
+//	            Port: 5201
+//	            As: 15201
+//	  vpc-02:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  10.50.2.0/24
+func (testCtx *VPCPeeringTestCtx) gatewayPeeringPortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 2 {
+		return true, nil, fmt.Errorf("not enough VPCs for port-forward NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc1 := &vpcs.Items[0]
+	vpc2 := &vpcs.Items[1]
+
+	portForwardRules := []gwapi.PeeringNATPortForwardEntry{
+		{Protocol: gwapi.PeeringNATProtocolTCP, Port: "5201", As: "15201"},
+	}
+
+	if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
+		VPC1NATCIDR:          []string{"192.168.52.0/24"},
+		VPC1NATMode:          NATModePortForward,
+		VPC1PortForwardRules: portForwardRules,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+	}
+
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up port-forward NAT peerings: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	// Port-forward is INBOUND only: vpc2 connects to vpc1's NAT IP on the forwarded external port.
+	// vpc1 cannot initiate connections to vpc2 (no outbound NAT).
+	const vpc1NATCIDR = "192.168.52.0/24"
+	if err := testCtx.testPortForwardInboundConnectivity(ctx, vpc1, vpc2, vpc1NATCIDR, 15201); err != nil {
+		return false, nil, fmt.Errorf("testing port-forward inbound connectivity: %w", err)
+	}
+
+	return false, nil, nil
+}
+
+// Test gateway peering with combined masquerade and port-forwarding NAT
+// Masquerade enables outbound NAT from vpc1 to vpc2; port-forward enables inbound on port 15201→5201.
+// Both directions are tested: outbound via masquerade (vpc1→vpc2) and inbound via port-forward (vpc2→vpc1).
+//
+// Peering spec:
+//
+//	Gateway Group:  default
+//	Peering:
+//	  vpc-01:
+//	    Expose:
+//	      As:
+//	        Cidr:  192.168.51.0/24
+//	      Ips:
+//	        Cidr:  10.50.1.0/24
+//	      Nat:
+//	        Masquerade:
+//	          Idle Timeout:  5m0s
+//	        Port Forward:
+//	          Rules:
+//	          - Protocol: TCP
+//	            Port: 5201
+//	            As: 15201
+//	  vpc-02:
+//	    Expose:
+//	      Ips:
+//	        Cidr:  10.50.2.0/24
+func (testCtx *VPCPeeringTestCtx) gatewayPeeringMasqueradePortForwardNATTest(ctx context.Context) (bool, []RevertFunc, error) {
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	if len(vpcs.Items) < 2 {
+		return true, nil, fmt.Errorf("not enough VPCs for masquerade+port-forward NAT test") //nolint:goerr113
+	}
+
+	sort.Slice(vpcs.Items, func(i, j int) bool {
+		return vpcs.Items[i].Name < vpcs.Items[j].Name
+	})
+
+	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec)
+	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec)
+	gwPeerings := make(map[string]*gwapi.PeeringSpec)
+
+	vpc1 := &vpcs.Items[0]
+	vpc2 := &vpcs.Items[1]
+
+	portForwardRules := []gwapi.PeeringNATPortForwardEntry{
+		{Protocol: gwapi.PeeringNATProtocolTCP, Port: "5201", As: "15201"},
+	}
+
+	if err := appendGwPeeringSpec(gwPeerings, vpc1, vpc2, &GwPeeringOptions{
+		VPC1NATCIDR:          []string{"192.168.51.0/24"},
+		VPC1NATMode:          NATModeMasqueradePortForward,
+		VPC1PortForwardRules: portForwardRules,
+	}); err != nil {
+		return false, nil, fmt.Errorf("setting up gateway peering: %w", err)
+	}
+
+	if err := DoSetupPeerings(ctx, testCtx.kube, vpcPeerings, externalPeerings, gwPeerings, true); err != nil {
+		return false, nil, fmt.Errorf("setting up masquerade+port-forward NAT peerings: %w", err)
+	}
+
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
+	}
+
+	// Outbound direction: vpc1 reaches vpc2 via masquerade NAT (vpc1 traffic appears from 192.168.51.x)
+	if err := testCtx.testNATGatewayConnectivity(ctx, vpc1, vpc2, nil, nil); err != nil {
+		return false, nil, fmt.Errorf("testing masquerade+port-forward NAT outbound connectivity: %w", err)
+	}
+
+	// Inbound direction: vpc2 connects to vpc1's NAT IP:15201, gateway forwards to vpc1 real IP:5201
+	const vpc1NATCIDR = "192.168.51.0/24"
+	if err := testCtx.testPortForwardInboundConnectivity(ctx, vpc1, vpc2, vpc1NATCIDR, 15201); err != nil {
+		return false, nil, fmt.Errorf("testing masquerade+port-forward NAT inbound connectivity: %w", err)
+	}
+
+	return false, nil, nil
 }
 
 // getNATTestCases returns the NAT test cases to be added to the multi-VPC single-subnet suite
@@ -885,6 +1206,20 @@ func getNATTestCases(testCtx *VPCPeeringTestCtx) []JUnitTestCase {
 		{
 			Name: "Gateway Peering Overlap NAT",
 			F:    testCtx.gatewayPeeringOverlapNATTest,
+			SkipFlags: SkipFlags{
+				NoGateway: true,
+			},
+		},
+		{
+			Name: "Gateway Peering Port Forward NAT",
+			F:    testCtx.gatewayPeeringPortForwardNATTest,
+			SkipFlags: SkipFlags{
+				NoGateway: true,
+			},
+		},
+		{
+			Name: "Gateway Peering Masquerade and Port Forward NAT",
+			F:    testCtx.gatewayPeeringMasqueradePortForwardNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
 			},

--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -467,7 +467,9 @@ func (testCtx *VPCPeeringTestCtx) gatewayFailoverTest(ctx context.Context) (bool
 	vpcPeerings := make(map[string]*vpcapi.VPCPeeringSpec, 0)
 	externalPeerings := make(map[string]*vpcapi.ExternalPeeringSpec, 0)
 	gwPeerings := make(map[string]*gwapi.PeeringSpec, 1)
-	appendGwPeeringSpec(gwPeerings, &vpcs.Items[0], &vpcs.Items[1], nil)
+	if err := appendGwPeeringSpec(gwPeerings, &vpcs.Items[0], &vpcs.Items[1], nil); err != nil {
+		return false, reverts, fmt.Errorf("setting up gateway peering: %w", err)
+	}
 	// set the peering to use our custom gateway group
 	for _, spec := range gwPeerings {
 		spec.GatewayGroup = failoverTestGroup

--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -581,6 +581,103 @@ func setPortBreakout(ctx context.Context, kube kclient.Client, swName string, po
 	return nil
 }
 
+// extBGPNATAnnotation is the annotation key on an External object that specifies the NAT pool CIDR
+// for BGP external NAT tests. Each environment must use a unique CIDR so that when multiple
+// environments run tests simultaneously, the edge device (DS2000) routes return traffic to the
+// correct environment's gateway. The CIDR is dynamically learned by the edge device via BGP from
+// the gateway when a peering is active, and withdrawn when the peering is removed.
+// Example: hhfab.githedgehog.com/test-bgp-nat-pool: 192.168.85.0/24 (env-5)
+const extBGPNATAnnotation = "hhfab.githedgehog.com/test-bgp-nat-pool"
+
+// extStaticNATPoolAnnotation is the annotation key on a static External object that specifies
+// the NAT pool CIDR for static external NAT tests. Each environment must use a unique /24 CIDR
+// because the return routes are pre-configured as static routes on the shared edge device (DS2000)
+// pointing to that environment's gateway — multiple environments would conflict if they shared
+// the same CIDR. The annotation must be set to the /24 that DS2000 has a static route for via
+// this environment's static external path.
+// Example: hhfab.githedgehog.com/test-static-nat-pool: 192.168.81.0/24 (env-5)
+const extStaticNATPoolAnnotation = "hhfab.githedgehog.com/test-static-nat-pool"
+
+// getExternalBGPNATCIDR returns the BGP NAT pool CIDR from the External object's annotation.
+// Returns ("", nil) if the annotation is absent, which callers should treat as skip.
+func getExternalBGPNATCIDR(ctx context.Context, kube kclient.Client, extName string) (string, error) {
+	ext := &vpcapi.External{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Namespace: kmetav1.NamespaceDefault, Name: extName}, ext); err != nil {
+		return "", fmt.Errorf("getting external %s: %w", extName, err)
+	}
+
+	return ext.Annotations[extBGPNATAnnotation], nil
+}
+
+// getExternalStaticNATCIDR returns the static NAT pool CIDR from the External object's annotation.
+// Returns ("", nil) if the annotation is absent, which callers should treat as skip.
+func getExternalStaticNATCIDR(ctx context.Context, kube kclient.Client, extName string) (string, error) {
+	ext := &vpcapi.External{}
+	if err := kube.Get(ctx, kclient.ObjectKey{Namespace: kmetav1.NamespaceDefault, Name: extName}, ext); err != nil {
+		return "", fmt.Errorf("getting external %s: %w", extName, err)
+	}
+
+	return ext.Annotations[extStaticNATPoolAnnotation], nil
+}
+
+// getExternalRemoteIP returns the IP of the external device from its ExternalAttachment.
+// For static externals it uses spec.static.remoteIP; for BGP externals it uses spec.neighbor.ip.
+// Returns empty string without error if no attachment with an IP is found.
+func getExternalRemoteIP(ctx context.Context, kube kclient.Client, extName string) (string, error) {
+	attachList := &vpcapi.ExternalAttachmentList{}
+	if err := kube.List(ctx, attachList, kclient.MatchingLabels{vpcapi.LabelExternal: extName}); err != nil {
+		return "", fmt.Errorf("listing external attachments for %s: %w", extName, err)
+	}
+
+	for _, attach := range attachList.Items {
+		if attach.Spec.Static != nil && attach.Spec.Static.RemoteIP != "" {
+			return attach.Spec.Static.RemoteIP, nil
+		}
+		if attach.Spec.Neighbor.IP != "" {
+			return attach.Spec.Neighbor.IP, nil
+		}
+	}
+
+	return "", nil
+}
+
+// appendGwExtInvertedPortForwardPeeringSpec adds a gateway external peering where the port-forward
+// NAT is on the external side, allowing VPC to initiate connections to the external device.
+// VPC subnets are exposed as-is (no NAT). The external device IP is NAT'd to natCIDR with
+// port-forward rules, so VPC can connect to natCIDR:rule.As and reach extIP:rule.Port.
+// Note: this is the reverse of the typical customer use case (where an external client connects
+// INTO a VPC service). In tests, iperf is initiated from the VPC side (as client) targeting
+// iperf3 services pre-configured on the DS2000. The other direction was too difficult to automate.
+func appendGwExtInvertedPortForwardPeeringSpec(gwPeerings map[string]*gwapi.PeeringSpec, vpc *vpcapi.VPC, external, extIP, natCIDR string, portForwardRules []gwapi.PeeringNATPortForwardEntry) {
+	entryName := fmt.Sprintf("%s--%s", vpc.Name, external)
+
+	vpcExpose := gwapi.PeeringEntryExpose{}
+	for _, subnet := range vpc.Spec.Subnets {
+		vpcExpose.IPs = append(vpcExpose.IPs, gwapi.PeeringEntryIP{CIDR: subnet.Subnet})
+	}
+
+	extExpose := gwapi.PeeringEntryExpose{
+		IPs: []gwapi.PeeringEntryIP{{CIDR: extIP + "/32"}},
+		As:  []gwapi.PeeringEntryAs{{CIDR: natCIDR}},
+		NAT: &gwapi.PeeringNAT{
+			PortForward: &gwapi.PeeringNATPortForward{
+				Ports: portForwardRules,
+			},
+		},
+	}
+
+	gwPeerings[entryName] = &gwapi.PeeringSpec{
+		Peering: map[string]*gwapi.PeeringEntry{
+			vpc.Name: {
+				Expose: []gwapi.PeeringEntryExpose{vpcExpose},
+			},
+			"ext." + external: {
+				Expose: []gwapi.PeeringEntryExpose{extExpose},
+			},
+		},
+	}
+}
+
 // add a single gateway peering spec to an existing map, which will be the input for DoSetupPeerings
 // If vpc1Subnets is empty, all subnets from the respective VPC will be used
 func appendGwExtPeeringSpec(gwPeerings map[string]*gwapi.PeeringSpec, vpc1 *vpcapi.VPC, vpc1Subnets []string, external string) {
@@ -622,6 +719,10 @@ const (
 	NATModeStatic NATMode = iota
 	// NATModeMasquerade uses masquerade (many:1) NAT with connection tracking
 	NATModeMasquerade
+	// NATModePortForward uses port-forwarding NAT
+	NATModePortForward
+	// NATModeMasqueradePortForward uses combined masquerade and port-forwarding NAT (two separate expose entries)
+	NATModeMasqueradePortForward
 )
 
 // GwPeeringOptions contains optional parameters for gateway peering configuration
@@ -638,26 +739,112 @@ type GwPeeringOptions struct {
 	VPC1NATMode NATMode
 	// VPC2NATMode specifies the NAT mode for VPC2 (default: static)
 	VPC2NATMode NATMode
+	// VPC1PortForwardRules specifies port-forwarding rules for VPC1
+	VPC1PortForwardRules []gwapi.PeeringNATPortForwardEntry
+	// VPC2PortForwardRules specifies port-forwarding rules for VPC2
+	VPC2PortForwardRules []gwapi.PeeringNATPortForwardEntry
 }
 
-// buildNATConfig creates a NAT configuration based on the specified mode
-func buildNATConfig(mode NATMode) *gwapi.PeeringNAT {
-	if mode == NATModeMasquerade {
-		return &gwapi.PeeringNAT{
-			Masquerade: &gwapi.PeeringNATMasquerade{
-				IdleTimeout: kmetav1.Duration{Duration: 5 * time.Minute},
-			},
+// GwExtPeeringOptions contains optional parameters for gateway external peering configuration
+type GwExtPeeringOptions struct {
+	// VPCSubnets specifies which subnets from VPC to expose (if empty, all subnets are used)
+	VPCSubnets []string
+	// VPCNATCIDR specifies the NAT CIDR ranges for VPC
+	VPCNATCIDR []string
+	// VPCNATMode specifies the NAT mode for VPC (default: static)
+	VPCNATMode NATMode
+	// VPCPortForwardRules specifies port-forwarding rules for VPC
+	VPCPortForwardRules []gwapi.PeeringNATPortForwardEntry
+}
+
+// buildNATConfig creates a NAT configuration based on the specified mode and optional port-forward rules.
+// Returns an error for invalid inputs (e.g. NATModePortForward with no rules, or an unknown mode).
+func buildNATConfig(mode NATMode, portForwardRules []gwapi.PeeringNATPortForwardEntry) (*gwapi.PeeringNAT, error) {
+	nat := &gwapi.PeeringNAT{}
+
+	switch mode {
+	case NATModeStatic:
+		nat.Static = &gwapi.PeeringNATStatic{}
+	case NATModeMasquerade:
+		nat.Masquerade = &gwapi.PeeringNATMasquerade{
+			IdleTimeout: kmetav1.Duration{Duration: 5 * time.Minute},
 		}
+	case NATModePortForward:
+		if len(portForwardRules) == 0 {
+			return nil, fmt.Errorf("NATModePortForward requires at least one port-forward rule") //nolint:goerr113
+		}
+		nat.PortForward = &gwapi.PeeringNATPortForward{
+			IdleTimeout: kmetav1.Duration{Duration: 5 * time.Minute},
+			Ports:       portForwardRules,
+		}
+	case NATModeMasqueradePortForward:
+		// unreachable: buildExposes splits this mode into two separate expose entries
+		// (NATModeMasquerade + NATModePortForward) before calling buildNATConfig.
+		return nil, fmt.Errorf("NATModeMasqueradePortForward should not be passed to buildNATConfig directly") //nolint:goerr113
+	default:
+		return nil, fmt.Errorf("unknown NATMode %d passed to buildNATConfig", mode) //nolint:goerr113
 	}
 
-	return &gwapi.PeeringNAT{
-		Static: &gwapi.PeeringNATStatic{},
+	return nat, nil
+}
+
+// buildExposes constructs the PeeringEntryExpose slice for one side of a peering.
+// For NATModeMasqueradePortForward, two entries are returned (masquerade + port-forward),
+// because the gateway API schema does not allow both NAT types in a single expose entry;
+// two entries with the same IPs/As but different NAT blocks is the intended workaround.
+// natCIDRs must be non-empty whenever NAT is configured (gateway API requires expose.As
+// and expose.NAT together). portForwardRules is only used for port-forward modes.
+func buildExposes(subnets, natCIDRs []string, mode NATMode, portForwardRules []gwapi.PeeringNATPortForwardEntry) ([]gwapi.PeeringEntryExpose, error) {
+	makeBase := func() gwapi.PeeringEntryExpose {
+		e := gwapi.PeeringEntryExpose{}
+		for _, subnet := range subnets {
+			e.IPs = append(e.IPs, gwapi.PeeringEntryIP{CIDR: subnet})
+		}
+		for _, natCIDR := range natCIDRs {
+			e.As = append(e.As, gwapi.PeeringEntryAs{CIDR: natCIDR})
+		}
+
+		return e
 	}
+
+	if mode == NATModeMasqueradePortForward {
+		if len(natCIDRs) == 0 {
+			return nil, fmt.Errorf("NATModeMasqueradePortForward requires natCIDRs: gateway API requires expose.As and expose.NAT together") //nolint:goerr113
+		}
+		masq := makeBase()
+		masqNAT, err := buildNATConfig(NATModeMasquerade, nil)
+		if err != nil {
+			return nil, fmt.Errorf("building masquerade NAT config: %w", err)
+		}
+		masq.NAT = masqNAT
+		pf := makeBase()
+		pfNAT, err := buildNATConfig(NATModePortForward, portForwardRules)
+		if err != nil {
+			return nil, fmt.Errorf("building port-forward NAT config: %w", err)
+		}
+		pf.NAT = pfNAT
+
+		return []gwapi.PeeringEntryExpose{masq, pf}, nil
+	}
+
+	e := makeBase()
+	if len(natCIDRs) > 0 || len(portForwardRules) > 0 {
+		if len(natCIDRs) == 0 {
+			return nil, fmt.Errorf("NAT configuration requires natCIDRs: gateway API requires expose.As and expose.NAT together") //nolint:goerr113
+		}
+		natCfg, err := buildNATConfig(mode, portForwardRules)
+		if err != nil {
+			return nil, fmt.Errorf("building NAT config: %w", err)
+		}
+		e.NAT = natCfg
+	}
+
+	return []gwapi.PeeringEntryExpose{e}, nil
 }
 
 // appendGwPeeringSpec adds a single gateway peering spec to an existing map, which will be the input for DoSetupPeerings
 // If opts is nil, default options are used (all subnets, no NAT).
-func appendGwPeeringSpec(gwPeerings map[string]*gwapi.PeeringSpec, vpc1, vpc2 *vpcapi.VPC, opts *GwPeeringOptions) {
+func appendGwPeeringSpec(gwPeerings map[string]*gwapi.PeeringSpec, vpc1, vpc2 *vpcapi.VPC, opts *GwPeeringOptions) error {
 	entryName := fmt.Sprintf("%s--%s", vpc1.Name, vpc2.Name)
 
 	// Handle nil opts
@@ -683,40 +870,67 @@ func appendGwPeeringSpec(gwPeerings map[string]*gwapi.PeeringSpec, vpc1, vpc2 *v
 		}
 	}
 
-	vpc1Expose := gwapi.PeeringEntryExpose{}
-	for _, subnet := range vpc1Subnets {
-		vpc1Expose.IPs = append(vpc1Expose.IPs, gwapi.PeeringEntryIP{CIDR: subnet})
+	vpc1Exposes, err := buildExposes(vpc1Subnets, opts.VPC1NATCIDR, opts.VPC1NATMode, opts.VPC1PortForwardRules)
+	if err != nil {
+		return fmt.Errorf("building VPC1 exposes for %s: %w", vpc1.Name, err)
 	}
-	// Add NAT ranges and config if provided for VPC1
-	for _, natCIDR := range opts.VPC1NATCIDR {
-		vpc1Expose.As = append(vpc1Expose.As, gwapi.PeeringEntryAs{CIDR: natCIDR})
-	}
-	if len(opts.VPC1NATCIDR) > 0 {
-		vpc1Expose.NAT = buildNATConfig(opts.VPC1NATMode)
-	}
-
-	vpc2Expose := gwapi.PeeringEntryExpose{}
-	for _, subnet := range vpc2Subnets {
-		vpc2Expose.IPs = append(vpc2Expose.IPs, gwapi.PeeringEntryIP{CIDR: subnet})
-	}
-	// Add NAT ranges and config if provided for VPC2
-	for _, natCIDR := range opts.VPC2NATCIDR {
-		vpc2Expose.As = append(vpc2Expose.As, gwapi.PeeringEntryAs{CIDR: natCIDR})
-	}
-	if len(opts.VPC2NATCIDR) > 0 {
-		vpc2Expose.NAT = buildNATConfig(opts.VPC2NATMode)
+	vpc2Exposes, err := buildExposes(vpc2Subnets, opts.VPC2NATCIDR, opts.VPC2NATMode, opts.VPC2PortForwardRules)
+	if err != nil {
+		return fmt.Errorf("building VPC2 exposes for %s: %w", vpc2.Name, err)
 	}
 
 	gwPeerings[entryName] = &gwapi.PeeringSpec{
 		Peering: map[string]*gwapi.PeeringEntry{
 			vpc1.Name: {
-				Expose: []gwapi.PeeringEntryExpose{vpc1Expose},
+				Expose: vpc1Exposes,
 			},
 			vpc2.Name: {
-				Expose: []gwapi.PeeringEntryExpose{vpc2Expose},
+				Expose: vpc2Exposes,
 			},
 		},
 	}
+
+	return nil
+}
+
+// appendGwExtPeeringSpecWithNAT adds a gateway external peering spec with NAT configuration.
+// If opts is nil, default options are used (all subnets, no NAT).
+func appendGwExtPeeringSpecWithNAT(gwPeerings map[string]*gwapi.PeeringSpec, vpc *vpcapi.VPC, external string, opts *GwExtPeeringOptions) error {
+	entryName := fmt.Sprintf("%s--%s", vpc.Name, external)
+
+	if opts == nil {
+		opts = &GwExtPeeringOptions{}
+	}
+
+	vpcSubnets := opts.VPCSubnets
+	if len(vpcSubnets) == 0 {
+		vpcSubnets = make([]string, 0, len(vpc.Spec.Subnets))
+		for _, subnet := range vpc.Spec.Subnets {
+			vpcSubnets = append(vpcSubnets, subnet.Subnet)
+		}
+	}
+
+	extExpose := gwapi.PeeringEntryExpose{
+		DefaultDestination: true,
+	}
+
+	vpcExposes, err := buildExposes(vpcSubnets, opts.VPCNATCIDR, opts.VPCNATMode, opts.VPCPortForwardRules)
+	if err != nil {
+		return fmt.Errorf("building VPC exposes for %s: %w", vpc.Name, err)
+	}
+
+	gwPeerings[entryName] = &gwapi.PeeringSpec{
+		Peering: map[string]*gwapi.PeeringEntry{
+			vpc.Name: {
+				Expose: vpcExposes,
+			},
+			"ext." + external: {
+				Expose: []gwapi.PeeringEntryExpose{extExpose},
+			},
+		},
+	}
+
+	return nil
 }
 
 func (testCtx *VPCPeeringTestCtx) waitForDHCPRenewal(ctx context.Context, serverName, ifName string, shortLeaseTime uint32) error {


### PR DESCRIPTION
Adds a full NAT test matrix for gateway peerings with external networks, covering all combinations of external type × NAT mode. Also refactors the external selection and NAT spec-building helpers to support the new test variants cleanly.

Part of https://github.com/githedgehog/internal/issues/305

---

## Background

**Gateway peering** connects VPCs (or a VPC to an upstream network) through a dedicated gateway device that can apply NAT rules. This is different from fabric-native VPC peering: the gateway sits in the data path and can rewrite IP addresses before forwarding.

**Externals** are upstream network devices (routers/ISPs) that VPCs can reach through a gateway peering. Two types exist:
- **BGP external** — the gateway and the upstream device exchange routes dynamically via BGP. When a peering is created, the gateway advertises the NAT pool CIDR to the upstream router; when it's torn down, the route is withdrawn.
- **Static external** — routes are pre-configured as static entries on the shared edge device (DS2000). No route exchange happens at peering time; the upstream device always has the route.

**NAT modes** tested (per external type):
| Mode | What happens |
|---|---|
| No NAT | VPC IPs are visible to the external device as-is |
| Static | Each VPC IP maps 1:1 to a fixed IP in the NAT pool (e.g. `10.50.1.5` → `192.168.85.5`) |
| Masquerade | All VPC IPs appear as one shared IP — like a home router. Connection-tracked. |
| Port Forward | Inbound connections on an external port are forwarded to a specific VPC server port |
| Masquerade + Port Forward | Both outbound masquerade and inbound port-forwarding active simultaneously |

---

## Why per-environment NAT pool CIDRs (the annotations)

All test environments share a single physical edge device (DS2000). If two environments used the same NAT pool CIDR, DS2000 could not route return traffic to the correct environment's gateway — it would go to whichever environment last advertised the route.

Each environment's `External` object carries an annotation with its assigned pool:
```
hhfab.githedgehog.com/test-bgp-nat-pool:    192.168.85.0/24  # env-5
hhfab.githedgehog.com/test-static-nat-pool: 192.168.81.0/24  # env-5
```
Tests read the annotation at runtime and skip if it's absent, so environments without the annotation configured are not affected.

---

## The "inverted" port-forward tests

Port-forward is an *inbound* feature — an external client initiates a connection to a NATed IP, and the gateway forwards it to a server behind NAT. In our lab, "the external client" would be DS2000, but we have no SSH access to DS2000 to trigger connections from it.

The workaround: flip the NAT onto the *external side*. The external device's IP is exposed behind a virtual IP in the NAT pool (`.200` by convention), with a port-forward rule `5201→15201`. A VPC server then acts as the iperf3 client connecting to `<natpool>.200:15201`, and the gateway forwards that to `<ds2000-ip>:5201` where an iperf3 server is listening. This exercises the port-forward dataplane without needing outbound access from DS2000.

---

## Why MasqueradePortForward produces two expose entries

The gateway API schema does not allow a single `expose` entry to carry both `NAT.Masquerade` and `NAT.PortForward` blocks simultaneously. The workaround (`buildExposes`) emits two expose entries with identical `IPs`/`As` fields but different `NAT` blocks. The gateway processes both and applies both rule types to traffic.

---

## Why BGP tests retry for up to 2 minutes after WaitReady

`WaitReady` confirms that fabric switches have programmed their forwarding tables. But for BGP externals, there is additional work: the gateway must advertise the NAT pool CIDR to DS2000 via BGP, and DS2000 must accept and install that route. This propagation takes extra time that is not visible from the fabric side. Static externals skip the wait because DS2000 already has a static route for the pool — there is nothing to propagate.

---

## Changes

- `rt_nat_external_tests.go` (new) — 10 new test cases covering the full BGP × static × NAT mode matrix, plus connectivity helpers (`testNATExternalConnectivity`, `testIperfToExternal`)
- `rt_utils.go` — new NAT modes (`NATModePortForward`, `NATModeMasqueradePortForward`), new `buildExposes` helper, `appendGwExtPeeringSpecWithNAT`, `appendGwExtInvertedPortForwardPeeringSpec`; `appendGwPeeringSpec` now returns an error
- `rt_base.go` — `findExternals` replaces inline external-selection loops; separately tracks `extName` (BGP) and `staticExtName`; `NoStaticExternals` skip flag is now wired into `selectAndRunSuite`
- `rt_multi_vpc_single_subnet_suite.go` / `rt_single_vpc_suite.go` / `rt_nat_tests.go` — updated callers of `appendGwPeeringSpec` to handle the new error return
- `testing.go` — removed `expose.As` guard that blocked NAT peerings from being verified
- `.github/workflows/run-vlab.yaml` — pin `lab-ci` checkout to `pau/nat-tests-annotations` (contains per-environment NAT pool annotation configuration)