### PR TITLE
minor release-test fixes

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -87,6 +87,7 @@ const (
 	FlagReleaseTestRegexesInvert  = "release-test-regexes-invert"
 	FlagGatewayLogLevel           = "gateway-log-level"
 	FlagGatewayTag                = "gateway-tag"
+	FlagShowTech                  = "show-tech"
 )
 
 func main() {
@@ -1675,6 +1676,12 @@ func Run(ctx context.Context) error {
 								Aliases: []string{"list", "l"},
 								Usage:   "list all available tests and exit",
 							},
+							&cli.BoolFlag{
+								Name:    FlagShowTech,
+								Aliases: []string{"s"},
+								Usage:   "collect show-tech diagnostics on failure",
+								Value:   true,
+							},
 						}),
 						Before: before(false),
 						Action: func(c *cli.Context) error {
@@ -1688,6 +1695,7 @@ func Run(ctx context.Context) error {
 								HashPolicy:     c.String(FlagHashPolicy),
 								VPCMode:        vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
 								ListTests:      c.Bool(FlagListTests),
+								ShowTechDump:   c.Bool(FlagShowTech),
 							}
 							if err := hhfab.DoVLABReleaseTest(ctx, workDir, cacheDir, opts); err != nil {
 								return fmt.Errorf("release-test: %w", err)

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -65,6 +65,7 @@ type VPCPeeringTestCtx struct {
 	pauseOnFail      bool
 	roceLeaves       []string
 	noSetup          bool
+	showTechDump     bool
 }
 
 // Test function types
@@ -107,6 +108,7 @@ func makeTestCtx(ctx context.Context, kube kclient.Client, setupOpts SetupVPCsOp
 	testCtx.extended = rtOpts.Extended
 	testCtx.failFast = rtOpts.FailFast
 	testCtx.pauseOnFail = rtOpts.PauseOnFailure
+	testCtx.showTechDump = rtOpts.ShowTechDump
 
 	// Detect virtual switches and disable IPerf min speed check if all switches are virtual
 	switches := &wiringapi.SwitchList{}
@@ -993,6 +995,11 @@ func sanitizeNameForFolder(name string) string {
 // Diagnostics are organized in folders: <root>/<suite-name>/<test-name>/
 // For suite setup failures, use testName = "suite-setup"
 func (testCtx *VPCPeeringTestCtx) collectDiagnosticsOnFailure(ctx context.Context, suiteName, testName string) {
+	if !testCtx.showTechDump {
+		slog.Info("Skipping collection of show-tech diagnostics")
+
+		return
+	}
 	rootDir := filepath.Join(testCtx.vlabCfg.WorkDir, ShowTechOutputDir)
 	suiteDir := filepath.Join(rootDir, sanitizeNameForFolder(suiteName))
 	testDir := filepath.Join(suiteDir, sanitizeNameForFolder(testName))

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3358,6 +3358,7 @@ type ReleaseTestOpts struct {
 	HashPolicy     string
 	VPCMode        vpcapi.VPCMode
 	ListTests      bool
+	ShowTechDump   bool
 }
 
 func (c *Config) ReleaseTest(ctx context.Context, vlab *VLAB, opts ReleaseTestOpts) error {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -756,6 +756,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						PauseOnFailure: opts.PauseOnFailure,
 						Regexes:        opts.ReleaseTestRegexes,
 						InvertRegex:    opts.ReleaseTestRegexesInvert,
+						ShowTechDump:   true,
 					}
 					slog.Debug("Running release-test", "opts", releaseTestOpts)
 					if err := c.ReleaseTest(ctx, vlab, releaseTestOpts); err != nil {


### PR DESCRIPTION
- correctly honor fail-fast flag
- add an option to disable show tech dump (default behavior is unchanged)