### PR TITLE
Release Tests Breakout AutoNeg workaround

### DIFF
--- a/pkg/hhfab/rt_no_vpc_suite.go
+++ b/pkg/hhfab/rt_no_vpc_suite.go
@@ -145,6 +145,23 @@ func breakoutTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []Reve
 					if portProfile.Breakout == nil {
 						continue
 					}
+					// skip ports where portAutoNegs has sub-ports that won't be valid in any
+					// 1-offset breakout mode (we only test with 1-offset modes, which only
+					// generate sub-port /1); e.g. E1/1 configured as 2x400G with autoNeg on
+					// E1/1/2 can't be switched to 1x800G without the webhook rejecting it
+					hasConflict := false
+					for autoNegPort := range agent.Spec.Switch.PortAutoNegs {
+						if strings.HasPrefix(autoNegPort, portName+"/") && strings.TrimPrefix(autoNegPort, portName+"/") != "1" {
+							hasConflict = true
+
+							break
+						}
+					}
+					if hasConflict {
+						slog.Debug("Skipping port with portAutoNegs conflicting with 1-offset breakout modes", "port", portName, "switch", agent.Name)
+
+						continue
+					}
 					unusedPort = portName
 					breakoutProfile = portProfile.Breakout
 					slog.Debug("Found unused port for breakout", "port", unusedPort, "switch", agent.Name, "switchProfile", swProfile.Name)


### PR DESCRIPTION
Addresses https://github.com/githedgehog/internal/issues/341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements a workaround for auto-negotiation configuration failures in the release test suite's breakout port tests. When selecting ports for 1-offset breakout testing, the code now skips ports whose `portAutoNegs` contain sub-port entries other than the single `/1` form, preventing attempts to set auto-negotiation on unsupported sub-ports (e.g., E1/1/2) that trigger the admission webhook validation error.

## Changes

**File: `pkg/hhfab/rt_no_vpc_suite.go`**

- Modified `breakoutTest` to filter candidate ports during breakout selection. A port is now considered conflicting and skipped if any `portAutoNegs` entry starts with `portName/` and is not equal to `portName/1`. Conflicting ports are logged at debug level.

## Context

Addresses recurring failures observed on env-5 where the webhook "vswitch.kb.io" denied requests to configure auto-negotiation on unsupported sub-ports. Excluding those ports from the test prevents the validation error and reduces flaky release-test failures.

Lines changed: +17/-0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->