### PR TITLE
feat(hhfab): add scp helper

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1286,6 +1286,25 @@ func Run(ctx context.Context) error {
 						},
 					},
 					{
+						Name:  "scp",
+						Usage: "scp files to/from a VLAB VM or HW if supported (use ':path' for remote paths)",
+						Flags: flatten(defaultFlags, accessNameFlags, []cli.Flag{
+							&cli.StringFlag{
+								Name:    "username",
+								Aliases: []string{"u"},
+								Usage:   "target device scp username (default: admin for switches, core for servers)",
+							},
+						}),
+						Before: before(false),
+						Action: func(c *cli.Context) error {
+							if err := hhfab.DoVLABSCP(ctx, workDir, cacheDir, accessName, c.String("username"), c.Args().Slice()); err != nil {
+								return fmt.Errorf("scp: %w", err)
+							}
+
+							return nil
+						},
+					},
+					{
 						Name:   "serial",
 						Usage:  "get serial console of a VLAB VM or HW if supported",
 						Flags:  flatten(defaultFlags, accessNameFlags),

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -147,6 +147,15 @@ func DoVLABSSH(ctx context.Context, workDir, cacheDir, name, username string, ar
 	return c.VLABAccess(ctx, vlab, VLABAccessSSH, name, username, args)
 }
 
+func DoVLABSCP(ctx context.Context, workDir, cacheDir, name, username string, args []string) error {
+	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
+	if err != nil {
+		return err
+	}
+
+	return c.VLABAccess(ctx, vlab, VLABAccessSCP, name, username, args)
+}
+
 func DoVLABSerial(ctx context.Context, workDir, cacheDir, name string, args []string) error {
 	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
 	if err != nil {

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -41,6 +41,7 @@ type VLABAccessType string
 
 const (
 	VLABAccessSSH       VLABAccessType = "ssh"
+	VLABAccessSCP       VLABAccessType = "scp"
 	VLABAccessSerial    VLABAccessType = "serial"
 	VLABAccessSerialLog VLABAccessType = "serial log"
 
@@ -58,15 +59,15 @@ var SSHQuietFlags = []string{
 }
 
 func (c *Config) VLABAccess(ctx context.Context, vlab *VLAB, t VLABAccessType, name, username string, inArgs []string) error {
-	if len(inArgs) > 0 && t != VLABAccessSSH {
-		return fmt.Errorf("arguments only supported for ssh") //nolint:goerr113
+	if len(inArgs) > 0 && t != VLABAccessSSH && t != VLABAccessSCP {
+		return fmt.Errorf("arguments only supported for ssh and scp") //nolint:goerr113
 	}
 
 	if t == VLABAccessSSH && username == "" {
 		return fmt.Errorf("username is required") //nolint:err113
 	}
-	if t != VLABAccessSSH && username != "" {
-		return fmt.Errorf("username is only supported for ssh") //nolint:err113
+	if t != VLABAccessSSH && t != VLABAccessSCP && username != "" {
+		return fmt.Errorf("username is only supported for ssh and scp") //nolint:err113
 	}
 
 	if err := c.checkForBins(); err != nil {
@@ -181,6 +182,86 @@ func (c *Config) VLABAccess(ctx context.Context, vlab *VLAB, t VLABAccessType, n
 
 		if len(inArgs) > 0 {
 			args = append(args, "PATH=$PATH:/opt/bin "+strings.Join(inArgs, " "))
+		}
+	case VLABAccessSCP:
+		if len(inArgs) < 2 {
+			return fmt.Errorf("scp requires source and destination arguments") //nolint:goerr113
+		}
+
+		if username == "" {
+			if entry.IsSwitch {
+				username = "admin"
+			} else {
+				username = "core"
+			}
+		}
+
+		var remoteHost string
+
+		if entry.SSHPort > 0 { //nolint:gocritic
+			slog.Info("SCP using local port", "name", name, "port", entry.SSHPort)
+
+			remoteHost = "127.0.0.1"
+			cmdName = VLABCmdSCP
+			args = append(slices.Clone(SSHQuietFlags),
+				"-P", fmt.Sprintf("%d", entry.SSHPort),
+				"-i", filepath.Join(VLABDir, VLABSSHKeyFile),
+			)
+		} else if entry.IsSwitch {
+			slog.Info("SCP through control node", "name", name, "type", "switch")
+
+			swIP, err := c.getSwitchIP(ctx, name)
+			if err != nil {
+				return fmt.Errorf("getting switch IP: %w", err)
+			}
+
+			remoteHost = swIP
+			proxyCmd := fmt.Sprintf("ssh %s -i %s -W %%h:%%p -p %d core@127.0.0.1",
+				strings.Join(SSHQuietFlags, " "),
+				filepath.Join(VLABDir, VLABSSHKeyFile),
+				getSSHPort(0), // TODO get control node ID
+			)
+
+			cmdName = VLABCmdSCP
+			args = append(slices.Clone(SSHQuietFlags),
+				"-i", filepath.Join(VLABDir, VLABSSHKeyFile),
+				"-o", "ProxyCommand="+proxyCmd,
+			)
+		} else if entry.IsNode {
+			slog.Info("SCP through control node", "name", name, "type", "gateway")
+
+			nodeIP, err := c.getNodeIP(ctx, name)
+			if err != nil {
+				return fmt.Errorf("getting node IP: %w", err)
+			}
+
+			remoteHost = nodeIP
+			proxyCmd := fmt.Sprintf("ssh %s -i %s -W %%h:%%p -p %d core@127.0.0.1",
+				strings.Join(SSHQuietFlags, " "),
+				filepath.Join(VLABDir, VLABSSHKeyFile),
+				getSSHPort(0), // TODO get control node ID
+			)
+
+			cmdName = VLABCmdSCP
+			args = append(slices.Clone(SSHQuietFlags),
+				"-i", filepath.Join(VLABDir, VLABSSHKeyFile),
+				"-o", "ProxyCommand="+proxyCmd,
+			)
+		} else {
+			return fmt.Errorf("SCP not available: %s", name) //nolint:goerr113
+		}
+
+		var hasRemote bool
+		for _, arg := range inArgs {
+			if strings.HasPrefix(arg, ":") {
+				hasRemote = true
+				args = append(args, username+"@"+remoteHost+arg)
+			} else {
+				args = append(args, arg)
+			}
+		}
+		if !hasRemote {
+			return fmt.Errorf("scp requires at least one remote path; prefix the remote path with ':' (for example ':~/file')") //nolint:goerr113
 		}
 	case VLABAccessSerial:
 		if entry.SerialSock != "" { //nolint:gocritic

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -67,6 +67,7 @@ const (
 	VLABCmdQemuSystem = "qemu-system-x86_64"
 	VLABCmdSocat      = "socat"
 	VLABCmdSSH        = "ssh"
+	VLABCmdSCP        = "scp"
 	VLABCmdLess       = "less"
 	VLABCmdExpect     = "expect"
 


### PR DESCRIPTION
same as ssh, automatically configure the port and/or proxy via the control node. remote paths are to be prefixed with a ':'.

this commit was generated in large part by claude code and refined/tested manually by me.