### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/pkg/hhfab/vlabconfig.go
+++ b/pkg/hhfab/vlabconfig.go
@@ -956,6 +956,7 @@ func vlabFromConfig(cfg *VLABConfig, opts VLABRunOpts) (*VLAB, error) {
 			}
 		}
 
+		usernet := 0
 		for nicID, nicCfgRaw := range paddedNICs {
 			if nicID >= VLABMaxNICs {
 				return nil, fmt.Errorf("too many NICs for VM %q: %d", name, len(nics)) //nolint:goerr113
@@ -972,7 +973,6 @@ func vlabFromConfig(cfg *VLABConfig, opts VLABRunOpts) (*VLAB, error) {
 
 			netdev := ""
 			device := ""
-			usernet := 0
 			if nicType == NICTypeNoop || nicType == NICTypeDirect { //nolint:gocritic
 				port := getDirectNICPort(vmID, uint(nicID)) //nolint:gosec
 				netdev = fmt.Sprintf("socket,udp=127.0.0.1:%d", port)


### PR DESCRIPTION
To fix this without changing intended functionality, track `usernet` per VM rather than per NIC iteration.

Best fix:
- Move `usernet := 0` so it is declared once before the `for nicID, nicCfgRaw := range paddedNICs` loop.
- Remove the inner per-iteration declaration.
- Keep the existing `if usernet > 0` and `usernet++` logic unchanged.

This makes the counter persist across NICs of the same VM, so the second `NICTypeUsernet` correctly triggers the error, and `usernet++` becomes meaningful.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._