### PR TITLE
chore(test): remove gateway peering iPerfsMinSpeed cap

### DIFF
--- a/pkg/hhfab/hhnet.sh
+++ b/pkg/hhfab/hhnet.sh
@@ -39,10 +39,6 @@ function setup_bond() {
 
     sudo ip l a "$bond_name" type bond miimon 100 mode 802.3ad xmit_hash_policy "$hash_policy"
 
-    if [ -n "$mtu" ]; then
-        sudo ip l s "$bond_name" mtu "$mtu"
-    fi
-
     for iface in "${@:4}"; do
         # cannot enslave interface if it is up
         sudo ip l s "$iface" down 2> /dev/null || echo "warning: could not bring down $iface" >&2
@@ -50,6 +46,14 @@ function setup_bond() {
     done
 
     sudo ip l s "$bond_name" up
+
+    # Set MTU after bring-up: enslaving triggers carrier events that cause
+    # systemd-networkd to re-apply its default config and reset slave MTUs.
+    # Setting bond MTU last ensures it sticks and propagates to all slaves.
+    if [ -n "$mtu" ]; then
+        sleep 1
+        sudo ip l s "$bond_name" mtu "$mtu"
+    fi
 }
 
 function setup_vlan() {

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -763,6 +763,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringOverlapNATTest(ctx context.Conte
 		netconfCmd, err := GetServerNetconfCmd(targetConn, ServerNetconfOpts{
 			VLAN:       originalVLAN,
 			HashPolicy: testCtx.setupOpts.HashPolicy,
+			MTU:        testCtx.setupOpts.InterfaceMTU,
 		})
 		if err != nil {
 			return fmt.Errorf("getting netconf command for %s: %w", targetServer, err)
@@ -811,6 +812,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringOverlapNATTest(ctx context.Conte
 	netconfCmd, err := GetServerNetconfCmd(targetConn, ServerNetconfOpts{
 		VLAN:       newVLAN,
 		HashPolicy: testCtx.setupOpts.HashPolicy,
+		MTU:        testCtx.setupOpts.InterfaceMTU,
 	})
 	if err != nil {
 		return false, reverts, fmt.Errorf("getting netconf command for server %s: %w", targetServer, err)

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -1987,6 +1987,22 @@ func DoSetupPeerings(ctx context.Context, kube client.Client, vpcPeerings map[st
 		if err := WaitReady(ctx, kube, WaitReadyOpts{AppliedFor: 15 * time.Second, Timeout: 10 * time.Minute}); err != nil {
 			return fmt.Errorf("waiting for ready: %w", err)
 		}
+
+		if len(gwPeerings) > 0 {
+			// Gateway peering routes propagate via BGP EVPN from the gateway to
+			// the leaf switches. WaitReady confirms the fabric agents applied
+			// their config, but the routes still need to arrive in the leaf RIB
+			// and then be programmed into the switch ASIC hardware forwarding
+			// tables by orchagent/syncd. Without this delay, traffic can hit the
+			// software slow-path and report throughput below line rate.
+			const gwRouteSettleDelay = 10 * time.Second
+			slog.Info("Waiting for gateway peering routes to settle in HW FIB", "delay", gwRouteSettleDelay)
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("sleeping for gateway route settle: %w", ctx.Err())
+			case <-time.After(gwRouteSettleDelay):
+			}
+		}
 	}
 
 	return nil
@@ -2905,8 +2921,8 @@ func checkToolboxLock(ctx context.Context, server string, ssh *sshutil.Config, t
 }
 
 // iperf3SpeedRetries is the number of additional attempts for iperf3 tests that fail due to low speed.
-// This helps handle transient network congestion or ECMP hash imbalance issues.
-const iperf3SpeedRetries = 2
+// Gateway VM vCPU scheduling jitter causes per-worker throughput variance near the ceiling.
+const iperf3SpeedRetries = 4
 
 // iperf3RetryDelay is the delay between retry attempts to allow network conditions to stabilize.
 const iperf3RetryDelay = 2 * time.Second
@@ -2917,11 +2933,6 @@ func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string,
 	}
 
 	iPerfsMinSpeed := opts.IPerfsMinSpeed
-	// Gateway peering uses kernel-based dataplane which achieves ~1-1.5 Gbps on hlab
-	if reachability.Reason == ReachabilityReasonGatewayPeering {
-		// iPerfsMinSpeed = min(iPerfsMinSpeed, 1000) TODO: Remove when https://github.com/githedgehog/fabricator/issues/1593 is solved
-		iPerfsMinSpeed = min(iPerfsMinSpeed, 700)
-	}
 
 	var lastError *IperfError
 	for attempt := 0; attempt <= iperf3SpeedRetries; attempt++ {


### PR DESCRIPTION
After env-ci-1 swap we achieve:
```
2026-04-09T11:43:05.2795294Z 11:43:05 DBG IPerf3 result from=server-3 to=server-6 sendSpeed="3313.01 Mbps" receiveSpeed="3307.24 Mbps" sent="2071.46 MB" received="2068.05 MB" minSpeed="700.00 Mbps"
2026-04-09T11:43:11.2755157Z 11:43:11 DBG IPerf3 result from=server-6 to=server-3 sendSpeed="5057.18 Mbps" receiveSpeed="5049.66 Mbps" sent="3161.72 MB" received="3158.70 MB" minSpeed="700.00 Mbps"
```

With jumbo frames we achieve almost line-rate:
```
2026-04-08T23:30:20.5990302Z 23:30:20 DBG IPerf3 result from=server-6 to=server-3 sendSpeed="9355.81 Mbps" receiveSpeed="9337.69 Mbps" sent="5848.04 MB" received="5838.08 MB" minSpeed="700.00 Mbps"
2026-04-08T23:30:26.6145529Z 23:30:26 DBG IPerf3 result from=server-3 to=server-6 sendSpeed="9680.53 Mbps" receiveSpeed="9665.25 Mbps" sent="6061.29 MB" received="6053.43 MB" minSpeed="700.00 Mbps"
```

This PR as is is intended to be merged after we eventually merge https://github.com/githedgehog/fabricator/pull/1556 

If we don't plan to progress the MTU PR we could just increase the threshold to accommodate what the GW achieves today with smaller MTU for the time being

Closes #1650