### PR TITLE
chore: bump cert-manager to v1.20.2

### DIFF
--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -33,7 +33,7 @@ var Versions = fabapi.Versions{
 		K3s:               "v1.35.2-k3s1",
 		Zot:               "v2.1.15",
 		ZotChart:          "v0.1.67-hh1",
-		CertManager:       "v1.20.1",
+		CertManager:       "v1.20.2",
 		K9s:               "v0.50.18",
 		Toolbox:           "v0.12.0",
 		ReloaderChart:     "2.2.9",


### PR DESCRIPTION
Supersedes https://github.com/githedgehog/fabricator/pull/1661