### PR TITLE
Run NAT External Release Tests on VLAB

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         run: |
           mkdir -p test-diagrams
           just run hhfab init -f --dev --gws 2
-          just run hhfab vlab gen
+          just run hhfab vlab gen --externals-bgp=1 --externals-static=1 --external-orphan-connections=1
 
           # Generate diagrams in all formats and save to test-diagrams directory
           just run hhfab diagram -f mermaid -o test-diagrams/default-vlab-diagram.mmd -v

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -272,7 +272,7 @@ jobs:
             --include-onie=${{ inputs.includeonie }} \
             --gateways=${{ inputs.gateway && 2 || 0 }} \
             ${{ inputs.custom_init_args }}
-          bin/hhfab vlab gen -v ${{ inputs.mesh && '--mesh-links-count=3' || '' }} ${{ inputs.custom_gen_args }}
+          bin/hhfab vlab gen -v --externals-bgp=1 --externals-static=1 --external-orphan-connections=1 ${{ inputs.mesh && '--mesh-links-count=3' || '' }} ${{ inputs.custom_gen_args }}
 
       - name: Init hhfab for hybrid mode
         if: ${{ inputs.upgradefrom == '' && inputs.hybrid }}

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -133,9 +133,10 @@ func makeTestCtx(ctx context.Context, kube kclient.Client, setupOpts SetupVPCsOp
 }
 
 // findExternals finds a viable BGP external and a viable static external, returning (bgpExtName, staticExtName).
-// Two passes ensure hardware externals always win regardless of API response order: pass 1 selects
+// Three passes ensure hardware externals always win regardless of API response order: pass 1 selects
 // hardware externals, pass 2 accepts virtual externals whose attachments all go through hardware
-// connections (same data path, only the peer device is emulated).
+// connections (same data path, only the peer device is emulated), pass 3 accepts any external with
+// attachments, needed in pure VLAB where both the switch and the external are virtual.
 func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.ExternalList, extAttachList *vpcapi.ExternalAttachmentList) (string, string) {
 	bgpExt, staticExt := "", ""
 
@@ -206,6 +207,23 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		} else if ext.Spec.Static == nil && bgpExt == "" {
 			bgpExt = ext.Name
 			slog.Info("Using virtual BGP external (hw-attached)", "external", bgpExt)
+		}
+		if bgpExt != "" && staticExt != "" {
+			return bgpExt, staticExt
+		}
+	}
+
+	// Third pass: any external with attachments (pure VLAB: both switch and external are virtual)
+	for _, ext := range extList.Items {
+		if !hasAttachment(ext.Name) {
+			continue
+		}
+		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+			staticExt = ext.Name
+			slog.Info("Using virtual static external (virtual switch)", "external", staticExt)
+		} else if ext.Spec.Static == nil && bgpExt == "" {
+			bgpExt = ext.Name
+			slog.Info("Using virtual BGP external (virtual switch)", "external", bgpExt)
 		}
 		if bgpExt != "" && staticExt != "" {
 			return bgpExt, staticExt

--- a/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
@@ -686,7 +686,7 @@ func (testCtx *VPCPeeringTestCtx) staticExternalTest(ctx context.Context) (bool,
 		return false, reverts, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 	// look for routes in the switch(es) before pinging, see https://github.com/githedgehog/fabricator/issues/932#issuecomment-3322976488
-	if err := testCtx.waitForRoutesInSwitches(ctx, routeCheckSw, []string{StaticExternalNH, StaticExternalDummyIface}, "default"); err != nil {
+	if err := testCtx.waitForRoutesInSwitches(ctx, routeCheckSw, []string{StaticExternalNH, StaticExternalDummyIface}, defaultVRFName); err != nil {
 		return false, reverts, fmt.Errorf("waiting for routes in switch %s vrf default: %w", switchName, err)
 	}
 

--- a/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
@@ -25,6 +25,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 				NoBGPExternals: true,
 				SubInterfaces:  true,
 				NoServers:      true,
+				VirtualSwitch:  true,
 			},
 		},
 		{
@@ -34,6 +35,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 				NoBGPExternals: true,
 				SubInterfaces:  true,
 				NoServers:      true,
+				VirtualSwitch:  true,
 			},
 		},
 		{
@@ -50,6 +52,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 			SkipFlags: SkipFlags{
 				SubInterfaces: true,
 				NoServers:     true,
+				VirtualSwitch: true,
 			},
 		},
 		{
@@ -100,6 +103,7 @@ func makeMultiVPCSingleSubnetSuite(testCtx *VPCPeeringTestCtx) *JUnitTestSuite {
 				NoBGPExternals: true,
 				NoGateway:      true,
 				NoServers:      true,
+				VirtualSwitch:  true,
 			},
 		},
 		{

--- a/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
@@ -390,7 +390,7 @@ func (testCtx *VPCPeeringTestCtx) gatewayPeeringLoopTest(ctx context.Context) (b
 
 		vrfName := "VrfV" + vpc.Name
 		if vpc.Spec.Mode == vpcapi.VPCModeL3Flat {
-			vrfName = "default"
+			vrfName = defaultVRFName
 		}
 
 		slog.Info("Waiting for gateway routes on leaves", "vpc", vpc.Name, "leaves", leavesForVPC, "routes", peerRoutes, "vrf", vrfName)

--- a/pkg/hhfab/rt_nat_external_tests.go
+++ b/pkg/hhfab/rt_nat_external_tests.go
@@ -16,26 +16,54 @@ import (
 	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 	"go.githedgehog.com/fabric/pkg/util/apiutil"
+	"go.githedgehog.com/fabricator/pkg/util/sshutil"
 	"golang.org/x/sync/semaphore"
 )
 
-// gwNATConvergenceTimeout is the maximum time to wait for the gateway NAT dataplane to
-// become active after a peering is established. WaitReady confirms the fabric switches are
-// ready, but the gateway still needs to program NAT rules (and, for BGP externals, advertise
-// routes to the upstream peer). Both take additional time that varies by environment.
-const gwNATConvergenceTimeout = 2 * time.Minute
+// gwNATPortForwardProbeTimeout is the maximum time to wait for the gateway's port-forward
+// NAT rule to become active in the dataplane after the peering is applied. Unlike fabric
+// route propagation (which waitForNATPoolInLeaves gates on), the gateway's DNAT rule
+// programming has its own latency that no Kubernetes condition signals.
+const gwNATPortForwardProbeTimeout = 2 * time.Minute
 
-// gwNATConvergenceInterval is the polling interval between retries while waiting for the
-// gateway NAT dataplane to converge.
-const gwNATConvergenceInterval = 5 * time.Second
+// gwNATPortForwardProbeInterval is the polling interval between TCP-reachability probes.
+const gwNATPortForwardProbeInterval = 5 * time.Second
+
+// waitForPortForwardReachable retries a TCP connect probe from the given server until it
+// succeeds or gwNATPortForwardProbeTimeout elapses. Used to gate iperf3 port-forward tests
+// on the actual reachability of the NAT-pool target IP:port; once a TCP handshake completes,
+// iperf3 can run exactly once and any failure is a real test failure rather than a
+// programming-lag race.
+func (testCtx *VPCPeeringTestCtx) waitForPortForwardReachable(ctx context.Context, sshCfg *sshutil.Config, server, host string, port int) error {
+	// nc -z performs a TCP connect probe with no data; -w2 caps the connect attempt at 2s.
+	// Same primitive used in show-tech/control.sh, so we know it's available on flatcar.
+	cmd := fmt.Sprintf("nc -zw2 %s %d", host, port)
+	deadline := time.Now().Add(gwNATPortForwardProbeTimeout)
+	var lastErr error
+	for {
+		if _, _, err := retrySSHCmd(ctx, sshCfg, cmd, server); err == nil {
+			return nil
+		} else { //nolint:revive
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("port-forward target %s:%d not reachable after %s: %w", host, port, gwNATPortForwardProbeTimeout, lastErr)
+		}
+		slog.Debug("Port-forward target not reachable yet, retrying", "server", server, "host", host, "port", port, "retryIn", gwNATPortForwardProbeInterval)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(gwNATPortForwardProbeInterval):
+		}
+	}
+}
 
 // testNATExternalConnectivity tests outbound connectivity from a VPC through a NAT gateway peering
 // by curling 1.0.0.1 directly, bypassing the standard peering check that does not understand NAT
-// expose CIDRs. Pass waitForBGPConvergence=true for BGP externals: WaitReady only confirms the
-// fabric switches are programmed, but the gateway still needs to advertise the NAT pool to DS2000
-// via BGP before return traffic can flow. Static externals have pre-configured routes so no wait
-// is needed.
-func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Context, vpc *vpcapi.VPC, extName string, waitForBGPConvergence bool) error {
+// expose CIDRs. Callers are expected to gate this on waitForNATPoolInLeaves first when the test
+// depends on a freshly-applied NAT pool route reaching the fabric, so any failure here is a real
+// connectivity failure, not a route-propagation race.
+func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Context, vpc *vpcapi.VPC, extName string) error {
 	servers := &wiringapi.ServerList{}
 	if err := testCtx.kube.List(ctx, servers); err != nil {
 		return fmt.Errorf("listing servers: %w", err)
@@ -68,25 +96,7 @@ func (testCtx *VPCPeeringTestCtx) testNATExternalConnectivity(ctx context.Contex
 		}
 
 		slog.Debug("Testing NAT external connectivity via curl", "server", server.Name)
-		curlErr := checkCurl(ctx, testCtx.tcOpts, curlSem, server.Name, sshCfg, "1.0.0.1", true)
-		if curlErr != nil && waitForBGPConvergence {
-			deadline := time.Now().Add(gwNATConvergenceTimeout)
-			for curlErr != nil {
-				if time.Now().After(deadline) {
-					break
-				}
-				slog.Debug("BGP routes not yet propagated, retrying", "server", server.Name, "error", curlErr, "retryIn", gwNATConvergenceInterval)
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-time.After(gwNATConvergenceInterval):
-				}
-				curlErr = checkCurl(ctx, testCtx.tcOpts, curlSem, server.Name, sshCfg, "1.0.0.1", true)
-			}
-			if curlErr != nil {
-				return fmt.Errorf("NAT external connectivity check (BGP not converged after %s): %w", gwNATConvergenceTimeout, curlErr)
-			}
-		} else if curlErr != nil {
+		if curlErr := checkCurl(ctx, testCtx.tcOpts, curlSem, server.Name, sshCfg, "1.0.0.1", true); curlErr != nil {
 			return fmt.Errorf("NAT external connectivity check: %w", curlErr)
 		}
 
@@ -230,7 +240,11 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalStaticNATTest(ctx context.Context) 
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName, true); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, bgpNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName); err != nil {
 		return false, nil, fmt.Errorf("testing BGP external static NAT connectivity: %w", err)
 	}
 
@@ -301,7 +315,11 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradeNATTest(ctx context.Conte
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName, true); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, bgpNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName); err != nil {
 		return false, nil, fmt.Errorf("testing BGP external masquerade NAT connectivity: %w", err)
 	}
 
@@ -400,7 +418,11 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalPortForwardNATTest(ctx context.Cont
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testIperfToExternal(ctx, vpc, bgpInvertedNATCIDR, true); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, bgpNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testIperfToExternal(ctx, vpc, bgpInvertedNATCIDR); err != nil {
 		return false, nil, fmt.Errorf("testing BGP external port-forward via iperf3: %w", err)
 	}
 
@@ -484,7 +506,11 @@ func (testCtx *VPCPeeringTestCtx) bgpExternalMasqueradePortForwardNATTest(ctx co
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName, true); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, bgpNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.extName); err != nil {
 		return false, nil, fmt.Errorf("testing BGP external masquerade+port-forward NAT connectivity: %w", err)
 	}
 
@@ -607,7 +633,11 @@ func (testCtx *VPCPeeringTestCtx) staticExternalStaticNATGatewayTest(ctx context
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName, false); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, staticNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName); err != nil {
 		return false, nil, fmt.Errorf("testing static external static NAT connectivity: %w", err)
 	}
 
@@ -678,7 +708,11 @@ func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradeNATGatewayTest(ctx con
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName, false); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, staticNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName); err != nil {
 		return false, nil, fmt.Errorf("testing static external masquerade NAT connectivity: %w", err)
 	}
 
@@ -687,10 +721,10 @@ func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradeNATGatewayTest(ctx con
 
 // testIperfToExternal runs iperf3 from a VPC server to invertedNATCIDR:15201, testing
 // connectivity through the gateway's inverted port-forward NAT (external side has NAT).
-// One server in the VPC is sufficient.
-// waitForBGPConvergence should be true for BGP externals where the port-forward target IP is
-// reachable only after BGP route propagation; false for static externals with pre-configured routes.
-func (testCtx *VPCPeeringTestCtx) testIperfToExternal(ctx context.Context, vpc *vpcapi.VPC, invertedNATCIDR string, waitForBGPConvergence bool) error {
+// One server in the VPC is sufficient. Callers are expected to gate this on
+// waitForNATPoolInLeaves first when the test depends on a freshly-applied NAT pool route, so any
+// failure here is a real connectivity failure rather than a route-propagation race.
+func (testCtx *VPCPeeringTestCtx) testIperfToExternal(ctx context.Context, vpc *vpcapi.VPC, invertedNATCIDR string) error {
 	servers := &wiringapi.ServerList{}
 	if err := testCtx.kube.List(ctx, servers); err != nil {
 		return fmt.Errorf("listing servers: %w", err)
@@ -725,28 +759,19 @@ func (testCtx *VPCPeeringTestCtx) testIperfToExternal(ctx context.Context, vpc *
 			return fmt.Errorf("getting ssh config for %s: %w", server.Name, err)
 		}
 
+		// Gate iperf3 on TCP reachability: the gateway's port-forward DNAT rule has its own
+		// programming lag separate from fabric route propagation, and probing a TCP handshake
+		// is the precise signal that both halves of the path (fabric route + gateway DNAT) are
+		// active. After the probe succeeds, iperf3 runs once and any failure is a real test
+		// failure.
+		if err := testCtx.waitForPortForwardReachable(ctx, sshCfg, server.Name, extNATIP, 15201); err != nil {
+			return fmt.Errorf("waiting for port-forward target reachability: %w", err)
+		}
+
 		cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 -J -c %s -p 15201 -t %d",
 			secs+25, extNATIP, secs)
 		slog.Debug("Testing iperf3 through inverted port-forward NAT", "server", server.Name, "target", extNATIP+":15201")
-		_, _, iperfErr := retrySSHCmd(ctx, sshCfg, cmd, server.Name)
-		if iperfErr != nil && waitForBGPConvergence {
-			deadline := time.Now().Add(gwNATConvergenceTimeout)
-			for iperfErr != nil {
-				if time.Now().After(deadline) {
-					break
-				}
-				slog.Debug("BGP port-forward route not yet propagated, retrying", "server", server.Name, "error", iperfErr, "retryIn", gwNATConvergenceInterval)
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-time.After(gwNATConvergenceInterval):
-				}
-				_, _, iperfErr = retrySSHCmd(ctx, sshCfg, cmd, server.Name)
-			}
-			if iperfErr != nil {
-				return fmt.Errorf("iperf3 from %s to %s:15201 (BGP not converged after %s): %w", server.Name, extNATIP, gwNATConvergenceTimeout, iperfErr)
-			}
-		} else if iperfErr != nil {
+		if _, _, iperfErr := retrySSHCmd(ctx, sshCfg, cmd, server.Name); iperfErr != nil {
 			return fmt.Errorf("iperf3 from %s to %s:15201: %w", server.Name, extNATIP, iperfErr)
 		}
 
@@ -846,7 +871,11 @@ func (testCtx *VPCPeeringTestCtx) staticExternalPortForwardNATGatewayTest(ctx co
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testIperfToExternal(ctx, vpc, staticInvertedNATCIDR, false); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, staticNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testIperfToExternal(ctx, vpc, staticInvertedNATCIDR); err != nil {
 		return false, nil, fmt.Errorf("testing static external port-forward via iperf3: %w", err)
 	}
 
@@ -930,7 +959,11 @@ func (testCtx *VPCPeeringTestCtx) staticExternalMasqueradePortForwardNATGatewayT
 		return false, nil, fmt.Errorf("waiting for switches to be ready: %w", err)
 	}
 
-	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName, false); err != nil {
+	if err := testCtx.waitForNATPoolInLeaves(ctx, vpc, staticNATCIDR); err != nil {
+		return false, nil, fmt.Errorf("waiting for NAT pool route to propagate: %w", err)
+	}
+
+	if err := testCtx.testNATExternalConnectivity(ctx, vpc, testCtx.staticExtName); err != nil {
 		return false, nil, fmt.Errorf("testing static external masquerade+port-forward NAT connectivity: %w", err)
 	}
 

--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -25,6 +25,10 @@ import (
 
 var AllZeroPrefix = []string{"0.0.0.0/0"}
 
+// defaultVRFName is the SONiC default VRF, used as a fallback when a VPC has no per-VRF table
+// (e.g. L3Flat mode) and as the lookup VRF for some static external route checks.
+const defaultVRFName = "default"
+
 // add a single VPC peering spec to an existing map, which will be the input for DoSetupPeerings
 func appendVpcPeeringSpecByName(vpcPeerings map[string]*vpcapi.VPCPeeringSpec, vpc1, vpc2, remote string, vpc1Subnets, vpc2Subnets []string) {
 	entryName := fmt.Sprintf("%s--%s", vpc1, vpc2)
@@ -377,6 +381,28 @@ func checkRouteInSwitch(ctx context.Context, ssh *sshutil.Config, switchName, ro
 	}
 
 	return stdout != "", nil
+}
+
+// waitForNATPoolInLeaves waits until the gateway-originated NAT pool CIDR appears in the FIB of
+// the leaves attached to the given VPC, in the VPC's VRF. WaitReady only confirms the gateway and
+// switches are programmed; this verifies the route has actually propagated through the fabric so
+// subsequent NAT-pool traffic has a valid forwarding path. Replaces blind iperf3/curl retry loops
+// with a precise reachability gate.
+func (testCtx *VPCPeeringTestCtx) waitForNATPoolInLeaves(ctx context.Context, vpc *vpcapi.VPC, poolCIDR string) error {
+	leaves, err := getSwitchesForVPC(ctx, testCtx.kube, vpc.Name)
+	if err != nil {
+		return fmt.Errorf("getting switches for vpc %s: %w", vpc.Name, err)
+	}
+	if len(leaves) == 0 {
+		return nil
+	}
+	vrfName := "VrfV" + vpc.Name
+	if vpc.Spec.Mode == vpcapi.VPCModeL3Flat {
+		vrfName = defaultVRFName
+	}
+	slog.Info("Waiting for NAT pool route on leaves", "vpc", vpc.Name, "leaves", leaves, "pool", poolCIDR, "vrf", vrfName)
+
+	return testCtx.waitForRoutesInSwitches(ctx, leaves, []string{poolCIDR}, vrfName)
 }
 
 // wait until all switches in a set have a bunch of routes installed, or error out after 3 minutes

--- a/pkg/hhfab/vlab_external_butane.tmpl.yaml
+++ b/pkg/hhfab/vlab_external_butane.tmpl.yaml
@@ -114,6 +114,13 @@ storage:
         inline: |
           Hedgehog VLAB External Instance
 
+    - path: /etc/sysctl.d/10-vrf-l3mdev-accept.conf
+      mode: 0644
+      contents:
+        inline: |
+          net.ipv4.tcp_l3mdev_accept=1
+          net.ipv4.udp_l3mdev_accept=1
+
     - path: /etc/frr/frr.conf
       mode: 0644
       user:
@@ -129,12 +136,15 @@ storage:
           vrf {{$vrfkey}}
            {{if $vrf.IsStatic}}{{range $prefix := .StaticCfg.Prefixes}}ip route {{$prefix}} 172.31.1.2 enp2s0 nexthop-vrf default{{end}}
            {{if ne $vrf.StaticCfg.SwitchIP ""}}ip route 10.0.0.0/16 {{$vrf.StaticCfg.SwitchIP}} {{$vrf.StaticCfg.NICName}}{{end}}
+           {{if and (ne $vrf.StaticCfg.NATPoolCIDR "") (ne $vrf.StaticCfg.SwitchIP "")}}ip route {{$vrf.StaticCfg.NATPoolCIDR}} {{$vrf.StaticCfg.SwitchIP}} {{$vrf.StaticCfg.NICName}}{{end}}
            {{else}}ip route 0.0.0.0/0 172.31.1.2 enp2s0 nexthop-vrf default {{end}}
           exit-vrf
           !{{if $vrf.IsStatic}}{{range $gwIP := .StaticCfg.GatewayIPs}}
           ip route {{$gwIP}} {{$vrf.StaticCfg.NICName}} nexthop-vrf {{$vrfkey}}
           ip prefix-list static-ext-routes permit {{$gwIP}}{{end}}
-          {{if ne $vrf.StaticCfg.SwitchIP ""}}ip route 10.0.0.0/16 {{$vrf.StaticCfg.SwitchIP}} {{$vrf.StaticCfg.NICName}} nexthop-vrf {{$vrfkey}}{{end}}{{else}}
+          {{if ne $vrf.StaticCfg.SwitchIP ""}}ip route 10.0.0.0/16 {{$vrf.StaticCfg.SwitchIP}} {{$vrf.StaticCfg.NICName}} nexthop-vrf {{$vrfkey}}{{end}}
+          {{if and (ne $vrf.StaticCfg.NATPoolCIDR "") (ne $vrf.StaticCfg.SwitchIP "")}}ip route {{$vrf.StaticCfg.NATPoolCIDR}} {{$vrf.StaticCfg.SwitchIP}} {{$vrf.StaticCfg.NICName}} nexthop-vrf {{$vrfkey}}
+          ip prefix-list static-ext-routes permit {{$vrf.StaticCfg.NATPoolCIDR}}{{end}}{{else}}
           bgp community-list standard {{$vrfkey}}In seq 5 permit {{$vrf.BGPCfg.InCommunity}}
           bgp community-list standard {{$vrfkey}}Out seq 5 permit {{$vrf.BGPCfg.OutCommunity}}
           !
@@ -284,6 +294,25 @@ systemd:
 
         [Service]
         ExecStart=/usr/bin/docker exec frr /usr/lib/frr/frr-reload
+
+    - name: iperf3.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=iperf3 server for VLAB external NAT tests
+        After=docker.service network-online.target
+        Wants=network-online.target
+        Requires=docker.service
+
+        [Service]
+        Type=simple
+        ExecStart=/usr/bin/docker run --name=iperf3 --rm --network=host ghcr.io/githedgehog/toolbox:latest iperf3 -s
+        ExecStop=/usr/bin/docker stop iperf3
+        Restart=on-failure
+        RestartSec=5
+
+        [Install]
+        WantedBy=multi-user.target
 
     - name: iptables-nat.service
       enabled: true

--- a/pkg/hhfab/vlabbuilder.go
+++ b/pkg/hhfab/vlabbuilder.go
@@ -925,6 +925,20 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 	externals := []vpcapi.External{}
 	extAsn := 64102
 
+	// Reserve disjoint /24 ranges per external type to keep auto-generated NAT
+	// pool CIDRs unique and non-overlapping: 192.168.91..99.0/24 for BGP (90+i)
+	// and 192.168.101..109.0/24 for static (100+i). 9 of each is plenty for any
+	// VLAB topology and avoids crossing into the adjacent range.
+	const maxExtBGPForNATPool = 9
+	const maxExtStaticForNATPool = 9
+	if b.ExtBGPCount > maxExtBGPForNATPool {
+		return fmt.Errorf("ExtBGPCount=%d exceeds %d (NAT pool CIDR scheme limit)", b.ExtBGPCount, maxExtBGPForNATPool) //nolint:goerr113
+	}
+	totalStaticExternals := int(b.ExtStaticCount) + int(b.ExtStaticProxyCount)
+	if totalStaticExternals > maxExtStaticForNATPool {
+		return fmt.Errorf("ExtStaticCount+ExtStaticProxyCount=%d exceeds %d (NAT pool CIDR scheme limit)", totalStaticExternals, maxExtStaticForNATPool) //nolint:goerr113
+	}
+
 	if b.ExtBGPCount > 0 {
 		inboundCommPrefix := 65102
 		communityRuleID := 1000
@@ -936,7 +950,10 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 				InboundCommunity:  fmt.Sprintf("%d:%d", inboundCommPrefix, communityRuleID),
 				OutboundCommunity: fmt.Sprintf("%d:%d", extAsn, communityRuleID),
 			}
-			ext, err := b.createExternal(ctx, externalName, externalSpec)
+			anns := map[string]string{
+				extBGPNATAnnotation: fmt.Sprintf("192.168.%d.0/24", 90+int(i)),
+			}
+			ext, err := b.createExternal(ctx, externalName, externalSpec, anns)
 			if err != nil {
 				return err
 			}
@@ -945,14 +962,20 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 		}
 	}
 
-	staticExternals := b.ExtStaticCount + b.ExtStaticProxyCount
-	if staticExternals > 0 {
+	if totalStaticExternals > 0 {
 		var externalName string
-		for i := uint8(1); i <= staticExternals; i++ {
-			if i <= b.ExtStaticProxyCount {
+		for i := 1; i <= totalStaticExternals; i++ {
+			var anns map[string]string
+			if i <= int(b.ExtStaticProxyCount) {
 				externalName = fmt.Sprintf("ext-sp-%02d", i)
+				// Proxy static externals have no SwitchIP, so the NAT pool return route
+				// can't be installed on the virtual external. Skip the annotation so NAT
+				// tests skip cleanly rather than running with broken data-plane wiring.
 			} else {
 				externalName = fmt.Sprintf("ext-snp-%02d", i)
+				anns = map[string]string{
+					extStaticNATPoolAnnotation: fmt.Sprintf("192.168.%d.0/24", 100+i),
+				}
 			}
 			externalSpec := vpcapi.ExternalSpec{
 				IPv4Namespace: "default",
@@ -960,7 +983,7 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 					Prefixes: []string{"0.0.0.0/0"},
 				},
 			}
-			ext, err := b.createExternal(ctx, externalName, externalSpec)
+			ext, err := b.createExternal(ctx, externalName, externalSpec, anns)
 			if err != nil {
 				return err
 			}
@@ -1381,14 +1404,15 @@ func (b *VLABBuilderBase) createConnectionWithName(ctx context.Context, name str
 	return conn, nil
 }
 
-func (b *VLABBuilderBase) createExternal(ctx context.Context, name string, spec vpcapi.ExternalSpec) (*vpcapi.External, error) {
+func (b *VLABBuilderBase) createExternal(ctx context.Context, name string, spec vpcapi.ExternalSpec, anns map[string]string) (*vpcapi.External, error) {
 	external := &vpcapi.External{
 		TypeMeta: kmetav1.TypeMeta{
 			Kind:       "External",
 			APIVersion: vpcapi.GroupVersion.String(),
 		},
 		ObjectMeta: kmetav1.ObjectMeta{
-			Name: name,
+			Name:        name,
+			Annotations: anns,
 		},
 		Spec: spec,
 	}

--- a/pkg/hhfab/vlabconfig.go
+++ b/pkg/hhfab/vlabconfig.go
@@ -102,10 +102,11 @@ type ExternalBGPVRFCfg struct {
 }
 
 type ExternalStaticVrfCfg struct {
-	Prefixes   []string `json:"prefixes"`   // the prefixes reachable via this external
-	GatewayIPs []string `json:"gatewayIPs"` // the addresses that can be used on the gateway to connect to this external
-	SwitchIP   string   `json:"switchIP"`   // the address on the switch on the other side of the attachment
-	NICName    string   `json:"nicName"`    // name of the NIC attachment
+	Prefixes    []string `json:"prefixes"`    // the prefixes reachable via this external
+	GatewayIPs  []string `json:"gatewayIPs"`  // the addresses that can be used on the gateway to connect to this external
+	SwitchIP    string   `json:"switchIP"`    // the address on the switch on the other side of the attachment
+	NICName     string   `json:"nicName"`     // name of the NIC attachment
+	NATPoolCIDR string   `json:"natPoolCIDR"` // NAT pool CIDR that the gateway source-NATs into; installs a return route toward the switch
 }
 
 type ExternalVRFCfg struct {
@@ -545,11 +546,23 @@ func createVLABConfig(ctx context.Context, controls []fabapi.ControlNode, nodes 
 				},
 			}
 		} else {
+			natPoolCIDR := external.Annotations[extStaticNATPoolAnnotation]
+			if natPoolCIDR != "" {
+				prefix, err := netip.ParsePrefix(natPoolCIDR)
+				if err != nil {
+					return nil, fmt.Errorf("invalid %s annotation on external %q: %q: %w", extStaticNATPoolAnnotation, external.Name, natPoolCIDR, err)
+				}
+				if !prefix.Addr().Is4() || prefix.Bits() != 24 {
+					return nil, fmt.Errorf("invalid %s annotation on external %q: %q: must be an IPv4 /24 prefix", extStaticNATPoolAnnotation, external.Name, natPoolCIDR) //nolint:goerr113
+				}
+				natPoolCIDR = prefix.Masked().String()
+			}
 			cfg.Externals.VRFs[external.Name] = ExternalVRFCfg{
 				TableID:  tableID,
 				IsStatic: true,
 				StaticCfg: ExternalStaticVrfCfg{
-					Prefixes: external.Spec.Static.Prefixes,
+					Prefixes:    external.Spec.Static.Prefixes,
+					NATPoolCIDR: natPoolCIDR,
 				},
 			}
 		}


### PR DESCRIPTION
Updates VLAB topology and enables Release Tests that work on BGP/Static Virtual Externals:
<img width="1566" height="877" alt="image" src="https://github.com/user-attachments/assets/ca3912a6-9af3-4795-b5ed-3d502ed644ed" />

It also enables iperf3 service in FRR VM to support port forwarding test-cases same as with HLAB