### PR TITLE
feat(testing): use iperf3 --bidir for symmetric pairs

### DIFF
--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -275,8 +275,8 @@ func (testCtx *VPCPeeringTestCtx) testNATGatewayConnectivity(
 				if err != nil {
 					return err
 				}
-				if ie := checkIPerf(ctx, testCtx.tcOpts, serverA, serverB, sshConfigs[serverA], sshConfigs[serverB], destIP, reachability); ie != nil {
-					iperfErrors = append(iperfErrors, ie)
+				if ies := checkIPerf(ctx, testCtx.tcOpts, serverA, serverB, sshConfigs[serverA], sshConfigs[serverB], destIP, reachability, false); len(ies) > 0 {
+					iperfErrors = append(iperfErrors, ies...)
 				}
 			}
 		}

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -2282,8 +2282,22 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 			i++
 		}
 	}
+	// Lookup used by each goroutine to check whether the reverse pair is also under test.
+	requestedPairs := make(map[[2]string]bool, len(opts.Sources)*len(opts.Destinations))
+	for _, a := range opts.Sources {
+		for _, b := range opts.Destinations {
+			if a == b {
+				continue
+			}
+			requestedPairs[[2]string{a, b}] = true
+		}
+	}
+
 	wg := &sync.WaitGroup{}
-	errChan := make(chan error, len(opts.Sources)*len(opts.Destinations)+len(opts.Sources))
+	// Buffered for the worst case where every directed pair contributes both a
+	// ping error and an iperf error (and bidir runs report two iperf errors per
+	// canonical pair) plus one curl error per source.
+	errChan := make(chan error, 2*len(opts.Sources)*len(opts.Destinations)+len(opts.Sources))
 
 	for _, serverA := range opts.Sources {
 		for _, serverB := range opts.Destinations {
@@ -2334,6 +2348,26 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 							return pe
 						}
 
+						if opts.IPerfsSeconds <= 0 {
+							return nil
+						}
+
+						bidir := false
+						if expectedReachable.Reachable && requestedPairs[[2]string{serverB, serverA}] {
+							revReachable, err := IsServerReachable(ctx, kube, serverB, serverA, c.Fab.Spec.Config.Gateway.Enable)
+							if err != nil {
+								return fmt.Errorf("checking reverse reachability for bidir: %w", err)
+							}
+							if revReachable.Reachable {
+								bidir = true
+							}
+						}
+
+						// In bidir mode the lex-larger direction has nothing left to drive.
+						if bidir && serverA > serverB {
+							return nil
+						}
+
 						if err := iperfs.Acquire(ctx, 1); err != nil {
 							return fmt.Errorf("acquiring iperf3 semaphore: %s", err)
 						}
@@ -2351,8 +2385,8 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 							return fmt.Errorf("checkToolbockLock: %w", err)
 						}
 
-						if ie := checkIPerf(ctx, opts, serverA, serverB, clientA, clientB, ipB.Addr(), expectedReachable); ie != nil {
-							return ie
+						for _, ie := range checkIPerf(ctx, opts, serverA, serverB, clientA, clientB, ipB.Addr(), expectedReachable, bidir) {
+							errChan <- ie
 						}
 
 						return nil
@@ -2924,7 +2958,7 @@ const iperf3SpeedRetries = 2
 // iperf3RetryDelay is the delay between retry attempts to allow network conditions to stabilize.
 const iperf3RetryDelay = 2 * time.Second
 
-func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string, fromSSH, toSSH *sshutil.Config, toIP netip.Addr, reachability Reachability) *IperfError {
+func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string, fromSSH, toSSH *sshutil.Config, toIP netip.Addr, reachability Reachability, bidir bool) []*IperfError {
 	if opts.IPerfsSeconds <= 0 || !reachability.Reachable {
 		return nil
 	}
@@ -2935,53 +2969,68 @@ func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string,
 	if reachability.Reason == ReachabilityReasonGatewayPeering {
 		iPerfsMinSpeed = min(iPerfsMinSpeed, 5000)
 	}
-
-	var lastError *IperfError
+	var lastErrors []*IperfError
 	for attempt := 0; attempt <= iperf3SpeedRetries; attempt++ {
 		if attempt > 0 {
-			slog.Warn("Retrying iperf3 test due to low speed", "from", from, "to", to,
-				"attempt", attempt+1, "maxAttempts", iperf3SpeedRetries+1,
-				"previousSentSpeed", lastError.SentSpeed, "previousRcvdSpeed", lastError.RcvdSpeed,
-				"minSpeed", lastError.MinSpeed)
+			logArgs := []any{"from", from, "to", to, "bidir", bidir, "attempt", attempt + 1, "maxAttempts", iperf3SpeedRetries + 1}
+			for _, le := range lastErrors {
+				logArgs = append(logArgs,
+					fmt.Sprintf("previousSentSpeed[%s->%s]", le.Source, le.Destination), le.SentSpeed,
+					fmt.Sprintf("previousRcvdSpeed[%s->%s]", le.Source, le.Destination), le.RcvdSpeed,
+				)
+			}
+			slog.Warn("Retrying iperf3 test due to low speed", logArgs...)
 			// Brief delay before retry to allow network conditions to stabilize
 			select {
 			case <-ctx.Done():
-				return lastError
+				return lastErrors
 			case <-time.After(iperf3RetryDelay):
 			}
 		}
 
-		ie := runIPerf3Test(ctx, opts, from, to, fromSSH, toSSH, toIP, iPerfsMinSpeed)
-		if ie == nil {
+		ies := runIPerf3Test(ctx, opts, from, to, fromSSH, toSSH, toIP, iPerfsMinSpeed, bidir)
+		if len(ies) == 0 {
 			if attempt > 0 {
-				slog.Info("iperf3 test succeeded on retry", "from", from, "to", to, "attempt", attempt+1)
+				slog.Info("iperf3 test succeeded on retry", "from", from, "to", to, "bidir", bidir, "attempt", attempt+1)
 			}
+
 			return nil
 		}
 
-		// Only retry on speed-related failures
-		if !ie.SendSpeedTooLow {
-			return ie
+		// Retry only when every failure is send-speed-too-low.
+		allSendTooLow := true
+		for _, ie := range ies {
+			if !ie.SendSpeedTooLow {
+				allSendTooLow = false
+
+				break
+			}
+		}
+		if !allSendTooLow {
+			return ies
 		}
 
-		lastError = ie
+		lastErrors = ies
 	}
 
 	// All retries exhausted
-	return lastError
+	return lastErrors
 }
 
-func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to string, fromSSH, toSSH *sshutil.Config, toIP netip.Addr, iPerfsMinSpeed float64) *IperfError {
-	ie := &IperfError{
-		Source:      from,
-		Destination: to,
-		MinSpeed:    asMbps(iPerfsMinSpeed * 1_000_000),
+func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to string, fromSSH, toSSH *sshutil.Config, toIP netip.Addr, iPerfsMinSpeed float64, bidir bool) []*IperfError {
+	minSpeedStr := asMbps(iPerfsMinSpeed * 1_000_000)
+	// Forward direction: client (`from`) sends to server (`to`).
+	fwd := &IperfError{Source: from, Destination: to, MinSpeed: minSpeedStr}
+	// Reverse direction (bidir only): server (`to`) sends back to client (`from`).
+	var rev *IperfError
+	if bidir {
+		rev = &IperfError{Source: to, Destination: from, MinSpeed: minSpeedStr}
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(opts.IPerfsSeconds+30)*time.Second)
 	defer cancel()
 
-	slog.Debug("Running iperf3", "from", from, "to", to)
+	slog.Debug("Running iperf3", "from", from, "to", to, "bidir", bidir)
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -2992,19 +3041,19 @@ func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to stri
 		report, parseErr := parseIPerf3Report([]byte(stdout))
 		if err != nil {
 			if parseErr == nil && report.Error != "" {
-				ie.ServerMsg = report.Error
+				fwd.ServerMsg = report.Error
 
 				return fmt.Errorf("running iperf3 server: %w: %s", err, report.Error)
 			}
 			slog.Warn("iperf3 server error, but could not retrieve error message from command output", "parseErr", parseErr, "stdout", stdout, "stderr", stderr)
-			ie.ServerMsg = fmt.Sprintf("%s: %s", err, stderr)
+			fwd.ServerMsg = fmt.Sprintf("%s: %s", err, stderr)
 
 			return fmt.Errorf("running iperf3 server: %w", err)
 		}
 		if parseErr != nil {
 			// Log the raw output to help diagnose what iperf3 returned instead of valid JSON
 			slog.Warn("iperf3 server report parse failed", "parseErr", parseErr, "stdout", stdout, "stderr", stderr)
-			ie.ServerMsg = fmt.Sprintf("cannot parse iperf3 report: %s", parseErr)
+			fwd.ServerMsg = fmt.Sprintf("cannot parse iperf3 report: %s", parseErr)
 
 			return fmt.Errorf("parsing server's iperf3 report: %w", parseErr)
 		}
@@ -3021,7 +3070,7 @@ func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to stri
 		for {
 			// Check timeout before attempting SSH command
 			if time.Since(start) >= maxWait {
-				ie.ClientMsg = fmt.Sprintf("iperf3 server did not start listening within %s", maxWait)
+				fwd.ClientMsg = fmt.Sprintf("iperf3 server did not start listening within %s", maxWait)
 				return fmt.Errorf("iperf3 server on %s did not start listening within %s", to, maxWait)
 			}
 
@@ -3044,6 +3093,9 @@ func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to stri
 		}
 
 		cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 -P 4 -J -c %s -t %d", opts.IPerfsSeconds+25, toIP.String(), opts.IPerfsSeconds)
+		if bidir {
+			cmd += " --bidir"
+		}
 
 		if opts.IPerfsDSCP > 0 {
 			cmd += fmt.Sprintf(" --dscp %d", opts.IPerfsDSCP)
@@ -3055,57 +3107,106 @@ func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to stri
 		report, parseErr := parseIPerf3Report([]byte(stdout))
 		if err != nil {
 			if parseErr == nil && report.Error != "" {
-				ie.ClientMsg = report.Error
+				fwd.ClientMsg = report.Error
 
 				return fmt.Errorf("running iperf3 client: %w: %s", err, report.Error)
 			}
-			ie.ClientMsg = fmt.Sprintf("%s: %s", err, stderr)
+			fwd.ClientMsg = fmt.Sprintf("%s: %s", err, stderr)
 
 			return fmt.Errorf("running iperf3 client: %w", err)
 		}
 		if parseErr != nil {
 			// Log the raw output to help diagnose what iperf3 returned instead of valid JSON
 			slog.Warn("iperf3 client report parse failed", "parseErr", parseErr, "stdout", stdout, "stderr", stderr)
-			ie.ClientMsg = fmt.Sprintf("cannot parse iperf3 report: %s", parseErr)
+			fwd.ClientMsg = fmt.Sprintf("cannot parse iperf3 report: %s", parseErr)
 
 			return fmt.Errorf("parsing client's iperf3 report: %w", parseErr)
 		}
 
-		slog.Debug("IPerf3 result", "from", from, "to", to,
-			"sendSpeed", asMbps(report.End.SumSent.BitsPerSecond),
-			"receiveSpeed", asMbps(report.End.SumReceived.BitsPerSecond),
-			"sent", asMB(float64(report.End.SumSent.Bytes)),
-			"received", asMB(float64(report.End.SumReceived.Bytes)),
-			"minSpeed", asMbps(iPerfsMinSpeed*1_000_000),
-		)
-		ie.SentSpeed = asMbps(report.End.SumSent.BitsPerSecond)
-		ie.RcvdSpeed = asMbps(report.End.SumReceived.BitsPerSecond)
+		fwdSent := report.End.SumSent
+		fwdRcvd := report.End.SumReceived
+		logArgs := []any{
+			"from", from, "to", to, "bidir", bidir,
+			"sendSpeed", asMbps(fwdSent.BitsPerSecond),
+			"receiveSpeed", asMbps(fwdRcvd.BitsPerSecond),
+			"sent", asMB(float64(fwdSent.Bytes)),
+			"received", asMB(float64(fwdRcvd.Bytes)),
+			"minSpeed", asMbps(iPerfsMinSpeed * 1_000_000),
+		}
+		if bidir {
+			logArgs = append(logArgs,
+				"reverseSendSpeed", asMbps(report.End.SumSentBidirReverse.BitsPerSecond),
+				"reverseReceiveSpeed", asMbps(report.End.SumReceivedBidirReverse.BitsPerSecond),
+			)
+		}
+		slog.Debug("IPerf3 result", logArgs...)
 
-		if iPerfsMinSpeed > 0 {
-			sendTooLow := report.End.SumSent.BitsPerSecond < iPerfsMinSpeed*1_000_000
-			rcvTooLow := report.End.SumReceived.BitsPerSecond < iPerfsMinSpeed*1_000_000
+		fwd.SentSpeed = asMbps(fwdSent.BitsPerSecond)
+		fwd.RcvdSpeed = asMbps(fwdRcvd.BitsPerSecond)
+		if rev != nil {
+			rev.SentSpeed = asMbps(report.End.SumSentBidirReverse.BitsPerSecond)
+			rev.RcvdSpeed = asMbps(report.End.SumReceivedBidirReverse.BitsPerSecond)
+		}
 
-			if sendTooLow {
-				ie.SendSpeedTooLow = true
-				ie.ClientMsg = "iperf3 send speed too low"
+		if iPerfsMinSpeed <= 0 {
+			return nil
+		}
 
-				return errors.New(ie.ClientMsg)
-			}
-			if rcvTooLow {
-				ie.ClientMsg = "iperf3 receive speed too low"
+		threshold := iPerfsMinSpeed * 1_000_000
+		applySpeedCheck(fwd, fwdSent.BitsPerSecond, fwdRcvd.BitsPerSecond, threshold, "")
+		if rev != nil {
+			applySpeedCheck(rev, report.End.SumSentBidirReverse.BitsPerSecond, report.End.SumReceivedBidirReverse.BitsPerSecond, threshold, "reverse ")
+		}
 
-				return errors.New(ie.ClientMsg)
-			}
+		if fwd.ClientMsg != "" || (rev != nil && rev.ClientMsg != "") {
+			// Surface a single error to the errgroup; per-direction errors are
+			// returned via fwd/rev to the caller.
+			return errors.New("iperf3 speed check failed")
 		}
 
 		return nil
 	})
 
-	if err := g.Wait(); err != nil {
-		return ie
+	if err := g.Wait(); err == nil {
+		return nil
 	}
 
-	return nil
+	var out []*IperfError
+	if isReportableIperfError(fwd) {
+		out = append(out, fwd)
+	}
+	if rev != nil && isReportableIperfError(rev) {
+		out = append(out, rev)
+	}
+	if len(out) == 0 {
+		// Fallback: g.Wait reported a non-empty error but no per-direction
+		// state captured it (shouldn't normally happen). Return at least the
+		// forward shell so the caller sees something.
+		out = append(out, fwd)
+	}
+
+	return out
+}
+
+// applySpeedCheck mutates ie to flag a low-speed failure when either the send
+// or receive throughput is below threshold. label prepends a direction tag to
+// the diagnostic message (e.g. "reverse ").
+func applySpeedCheck(ie *IperfError, sentBps, rcvdBps, thresholdBps float64, label string) {
+	if sentBps < thresholdBps {
+		ie.SendSpeedTooLow = true
+		ie.ClientMsg = fmt.Sprintf("iperf3 %ssend speed too low", label)
+
+		return
+	}
+	if rcvdBps < thresholdBps {
+		ie.ClientMsg = fmt.Sprintf("iperf3 %sreceive speed too low", label)
+	}
+}
+
+// isReportableIperfError returns true if any per-direction state was populated
+// indicating that direction failed.
+func isReportableIperfError(ie *IperfError) bool {
+	return ie.ClientMsg != "" || ie.ServerMsg != ""
 }
 
 func checkCurl(ctx context.Context, opts TestConnectivityOpts, curls *semaphore.Weighted, from string, fromSSH *sshutil.Config, toIP string, expected bool) *CurlError {
@@ -3177,8 +3278,10 @@ type iperf3ReportInterval struct {
 }
 
 type iperf3ReportEnd struct {
-	SumSent     iperf3ReportSum `json:"sum_sent"`
-	SumReceived iperf3ReportSum `json:"sum_received"`
+	SumSent                 iperf3ReportSum `json:"sum_sent"`
+	SumReceived             iperf3ReportSum `json:"sum_received"`
+	SumSentBidirReverse     iperf3ReportSum `json:"sum_sent_bidir_reverse"`
+	SumReceivedBidirReverse iperf3ReportSum `json:"sum_received_bidir_reverse"`
 }
 
 type iperf3ReportSum struct {


### PR DESCRIPTION
Implements @Frostman's idea to test both directions at once to halve iperf probe execution time for symmetric (intra-VPC, switch-peering) pairs.

`h-gw-iso-l2vni-rt` `Run and test hybrid VLAB` step:
- master: `3h 7m 39s`
- this PR: `2h 40m 48s` (-26m51s, ~14%)
