### PR TITLE
chore(hhfab): add scp examples and clearer remote-path error

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1307,6 +1307,15 @@ func Run(ctx context.Context) error {
 					{
 						Name:  "scp",
 						Usage: "scp files to/from a VLAB VM or HW if supported (use ':path' for remote paths)",
+						Description: `Prefix the remote path with ':' so it is resolved on the target device (-n).
+
+Examples:
+  Download a remote file into the current directory:
+    hhfab vlab scp -n leaf-01 :/etc/hostname .
+  Upload a local file to the device home dir:
+    hhfab vlab scp -n leaf-01 ./patch.bin :~/patch.bin
+  Recursively copy a remote directory (pass -r through to scp after --):
+    hhfab vlab scp -n leaf-01 -- -r :/var/log/frr ./frr-logs`,
 						Flags: flatten(defaultFlags, accessNameFlags, []cli.Flag{
 							&cli.StringFlag{
 								Name:    "username",

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -261,7 +261,7 @@ func (c *Config) VLABAccess(ctx context.Context, vlab *VLAB, t VLABAccessType, n
 			}
 		}
 		if !hasRemote {
-			return fmt.Errorf("scp requires at least one remote path; prefix the remote path with ':' (for example ':~/file')") //nolint:goerr113
+			return fmt.Errorf("scp requires at least one remote path; prefix the remote path with ':' (for example: hhfab vlab scp -n %s :/etc/hostname .)", name) //nolint:goerr113
 		}
 	case VLABAccessSerial:
 		if entry.SerialSock != "" { //nolint:gocritic


### PR DESCRIPTION
Found myself scratching my head the first time I tried using hhfab vlab scp, so thought someone else could also benefit from a bit of help