### PR TITLE
Test bumping k3s to 1.36.0

### DIFF
--- a/pkg/fab/README.md
+++ b/pkg/fab/README.md
@@ -29,7 +29,7 @@ oras push "ghcr.io/githedgehog/fabricator/flatcar-update:${FLATCAR_VERSION}" fla
 When bumping k3s version you may need to update the Fabricator's pause version as well as we're using the one from k3s.
 
 ```bash
-export K3S_VERSION="v1.35.3-k3s1"
+export K3S_VERSION="v1.36.0-k3s1"
 export K3S_VERSION_UPSTREAM="${K3S_VERSION//-/+}"
 
 wget "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION_UPSTREAM}/k3s"

--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -50,7 +50,7 @@ const (
 
 var Versions = fabapi.Versions{
 	Platform: fabapi.PlatformVersions{
-		K3s:               "v1.35.3-k3s1",
+		K3s:               "v1.36.0-k3s1",
 		Zot:               "v2.1.15",
 		ZotChart:          "v0.1.67-hh1",
 		CertManager:       "v1.20.2",


### PR DESCRIPTION
We don't want to bump to .0 k8s patch release, so just testing that we'll work with new minor release.