### PR TITLE
feat(hhfab): auto-derive VPC mode from switch profile

### DIFF
--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -89,13 +89,23 @@ func makeTestCtx(ctx context.Context, kube kclient.Client, setupOpts SetupVPCsOp
 	testCtx.vlabCfg = vlabCfg
 	testCtx.vlab = vlab
 	testCtx.setupOpts = setupOpts
+	// SetupVPCs skips ESLAG-attached servers when their resolved mode is non-
+	// L2VNI (auto-derived from SwitchProfile.Features.L2VNI or forced via the
+	// override). Relax RequireAllServers whenever any server in the fabric
+	// resolves to non-L2VNI so TestConnectivity does not flag those skips.
+	requireAll := true
+	if hasNonL2VNI, err := hasNonL2VNIServer(ctx, kube, setupOpts.VPCMode); err != nil {
+		slog.Warn("Failed to detect non-L2VNI servers; requiring all servers", "error", err)
+	} else if hasNonL2VNI {
+		requireAll = false
+	}
 	testCtx.tcOpts = TestConnectivityOpts{
 		WaitSwitchesReady: false,
 		PingsCount:        5,
 		IPerfsSeconds:     3,
 		IPerfsMinSpeed:    rtOpts.IPerfsMinSpeed,
 		CurlsCount:        1,
-		RequireAllServers: setupOpts.VPCMode == vpcapi.VPCModeL2VNI, // L3VNI will skip eslag servers
+		RequireAllServers: requireAll,
 	}
 	testCtx.wrOpts = WaitReadyOpts{
 		AppliedFor: waitAppliedFor,
@@ -430,8 +440,14 @@ func (testCtx *VPCPeeringTestCtx) setupTest(ctx context.Context, initialSuiteSet
 	if err := DoVLABSetupVPCs(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, opts); err != nil {
 		return fmt.Errorf("setting up VPCs: %w", err)
 	}
-	// in case of L3 VPC mode, we need to give it time to switch to the longer lease time and switches to learn the routes
-	if opts.VPCMode == vpcapi.VPCModeL3VNI || opts.VPCMode == vpcapi.VPCModeL3Flat {
+	// Any L3 VPC hands out a short DHCP lease on the first request to force a
+	// renewal that makes the leaf learn the host route, then the configured
+	// lease; give the switches time to learn those routes before testing.
+	// RequireAllServers was set to false earlier exactly when the fabric has a
+	// non-L2VNI server (derived from the stable SwitchProfiles), so reuse that
+	// intent instead of re-reading the freshly rewritten VPCs through the
+	// cached client, which can briefly return stale modes.
+	if !testCtx.tcOpts.RequireAllServers {
 		time.Sleep(10 * time.Second)
 	}
 

--- a/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
@@ -502,7 +502,7 @@ func staticExternalTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, 
 			return fmt.Errorf("configuring VLAN on %s: %w: %s", targetServer, err, stderr)
 		}
 		// in case of L3 VPC mode, we need to give it time to switch to the longer lease time and switches to learn the routes
-		if testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3VNI || testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3Flat {
+		if vpc.Spec.Mode != vpcapi.VPCModeL2VNI {
 			time.Sleep(10 * time.Second)
 		}
 

--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -162,21 +162,44 @@ func mclagTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertF
 // For each eslag connection, set one of the links down by shutting down the port on the switch,
 // then test connectivity. Repeat for the other link.
 func eslagTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
-	// l3vni mode is not compatible with ESLAG, so there will be no servers attached to ESLAG connections
-	if testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3VNI {
-		return true, nil, fmt.Errorf("L3VNI mode is not compatible with ESLAG") //nolint:goerr113
-	}
 	// list connections in the fabric, filter by ES-LAG connection type
 	conns := &wiringapi.ConnectionList{}
 	if err := testCtx.kube.List(ctx, conns, kclient.MatchingLabels{wiringapi.LabelConnectionType: wiringapi.ConnectionTypeESLAG}); err != nil {
 		return false, nil, fmt.Errorf("listing connections: %w", err)
 	}
-	if len(conns.Items) == 0 {
-		slog.Info("No ESLAG connections found, skipping test")
+	// ESLAG is not compatible with L3VNI / L3Flat: SetupVPCs skips those
+	// servers from VPC creation. Keep only ESLAG conns whose attached server
+	// landed in an L2VNI VPC; skip the test if none remain.
+	attachList := &vpcapi.VPCAttachmentList{}
+	if err := testCtx.kube.List(ctx, attachList); err != nil {
+		return false, nil, fmt.Errorf("listing VPCAttachments: %w", err)
+	}
+	vpcs := &vpcapi.VPCList{}
+	if err := testCtx.kube.List(ctx, vpcs); err != nil {
+		return false, nil, fmt.Errorf("listing VPCs: %w", err)
+	}
+	vpcModes := map[string]vpcapi.VPCMode{}
+	for _, vpc := range vpcs.Items {
+		vpcModes[vpc.Name] = vpc.Spec.Mode
+	}
+	l2vniConn := map[string]bool{}
+	for _, attach := range attachList.Items {
+		if mode, ok := vpcModes[attach.Spec.VPCName()]; ok && mode == vpcapi.VPCModeL2VNI {
+			l2vniConn[attach.Spec.Connection] = true
+		}
+	}
+	eligible := make([]wiringapi.Connection, 0, len(conns.Items))
+	for _, conn := range conns.Items {
+		if l2vniConn[conn.Name] {
+			eligible = append(eligible, conn)
+		}
+	}
+	if len(eligible) == 0 {
+		slog.Info("No ESLAG connections with L2VNI-attached servers found, skipping test")
 
 		return true, nil, errNoEslags
 	}
-	for _, conn := range conns.Items {
+	for _, conn := range eligible {
 		slog.Debug("Testing ESLAG connection", "connection", conn.Name)
 		if len(conn.Spec.ESLAG.Links) != 2 {
 			return false, nil, fmt.Errorf("ESLAG connection %s has %d links, expected 2", conn.Name, len(conn.Spec.ESLAG.Links)) //nolint:goerr113
@@ -1022,7 +1045,7 @@ func dnsNtpMtuTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []Rev
 
 	// Set DNS, NTP and MTU
 	slog.Debug("Setting DNS, NTP, MTU and DHCP lease time")
-	l3mode := testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3VNI || testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3Flat
+	l3mode := vpc.Spec.Mode != vpcapi.VPCModeL2VNI
 	dhcpOpts := &vpcapi.VPCDHCPOptions{
 		DNSServers:       []string{"1.1.1.1"},
 		TimeServers:      []string{"1.1.1.1"},
@@ -1073,7 +1096,7 @@ func dnsNtpMtuTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []Rev
 			return fmt.Errorf("bonding interfaces on %s: %w: %s", serverName, err, stderr)
 		}
 		// in case of L3 VPC mode, we need to give it time to switch to the longer lease time and switches to learn the routes
-		if testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3VNI || testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3Flat {
+		if vpc.Spec.Mode != vpcapi.VPCModeL2VNI {
 			time.Sleep(10 * time.Second)
 		}
 
@@ -1302,7 +1325,7 @@ func dhcpRenewalTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []R
 			defer wg.Done()
 
 			start := time.Now()
-			err := testCtx.waitForDHCPRenewal(ctx, srv.Name, srv.Interface, shortLeaseTime)
+			err := testCtx.waitForDHCPRenewal(ctx, srv.Name, srv.Interface, shortLeaseTime, testVPC.Spec.Mode)
 			duration := time.Since(start)
 
 			result := RenewalResult{

--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -952,8 +952,8 @@ func appendGwExtPeeringSpecWithNAT(gwPeerings map[string]*gwapi.PeeringSpec, vpc
 	return nil
 }
 
-func (testCtx *VPCPeeringTestCtx) waitForDHCPRenewal(ctx context.Context, serverName, ifName string, shortLeaseTime uint32) error {
-	isL3Mode := testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3VNI || testCtx.setupOpts.VPCMode == vpcapi.VPCModeL3Flat
+func (testCtx *VPCPeeringTestCtx) waitForDHCPRenewal(ctx context.Context, serverName, ifName string, shortLeaseTime uint32, vpcMode vpcapi.VPCMode) error {
+	isL3Mode := vpcMode != vpcapi.VPCModeL2VNI
 
 	ssh, err := testCtx.getSSH(ctx, serverName)
 	if err != nil {

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -573,6 +573,47 @@ func ResolveDefaultServerMTU(ctx context.Context, kube kclient.Client, opts *Set
 	return nil
 }
 
+// hasNonL2VNIServer reports whether any server in the fabric would land in a
+// non-L2VNI VPC under the given override. When override is L2VNI (empty
+// string) the modes are auto-derived per server, matching what SetupVPCs
+// will do, so callers can decide ahead of time whether the run will skip
+// ESLAG-attached servers.
+func hasNonL2VNIServer(ctx context.Context, kube kclient.Client, override vpcapi.VPCMode) (bool, error) {
+	if override != vpcapi.VPCModeL2VNI {
+		return true, nil
+	}
+	switchList := &wiringapi.SwitchList{}
+	if err := kube.List(ctx, switchList); err != nil {
+		return false, fmt.Errorf("listing switches: %w", err)
+	}
+	profileBySwitch := map[string]*wiringapi.SwitchProfile{}
+	for _, sw := range switchList.Items {
+		if _, seen := profileBySwitch[sw.Name]; seen {
+			continue
+		}
+		sp := &wiringapi.SwitchProfile{}
+		if err := kube.Get(ctx, kclient.ObjectKey{Name: sw.Spec.Profile, Namespace: kmetav1.NamespaceDefault}, sp); err != nil {
+			return false, fmt.Errorf("getting switch profile %q: %w", sw.Spec.Profile, err)
+		}
+		profileBySwitch[sw.Name] = sp
+	}
+	servers := &wiringapi.ServerList{}
+	if err := kube.List(ctx, servers); err != nil {
+		return false, fmt.Errorf("listing servers: %w", err)
+	}
+	for _, server := range servers.Items {
+		mode, err := autoDeriveVPCMode(ctx, kube, &server, profileBySwitch)
+		if err != nil {
+			return false, fmt.Errorf("auto-deriving mode for server %q: %w", server.Name, err)
+		}
+		if mode != vpcapi.VPCModeL2VNI {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // autoDeriveVPCMode returns the VPC mode hhfab should use for a VPC built
 // around this server. When every leaf the server attaches to advertises
 // Features.L2VNI=true, the result is L2VNI; if any attached leaf is

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -4,6 +4,7 @@
 package hhfab
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -572,6 +573,36 @@ func ResolveDefaultServerMTU(ctx context.Context, kube kclient.Client, opts *Set
 	return nil
 }
 
+// autoDeriveVPCMode returns the VPC mode hhfab should use for a VPC built
+// around this server. When every leaf the server attaches to advertises
+// Features.L2VNI=true, the result is L2VNI; if any attached leaf is
+// L3VNI-only (e.g. celestica-ds5000), the result is L3VNI. Servers with no
+// connections default to L2VNI. Used when SetupVPCsOpts.VPCMode is empty
+// so that the caller does not have to know the hardware capability mix.
+func autoDeriveVPCMode(ctx context.Context, kube kclient.Client, server *wiringapi.Server, profileBySwitch map[string]*wiringapi.SwitchProfile) (vpcapi.VPCMode, error) {
+	conns := &wiringapi.ConnectionList{}
+	if err := kube.List(ctx, conns, wiringapi.MatchingLabelsForListLabelServer(server.Name)); err != nil {
+		return "", fmt.Errorf("listing connections for server %q: %w", server.Name, err)
+	}
+	for _, conn := range conns.Items {
+		switches, _, _, _, err := conn.Spec.Endpoints()
+		if err != nil {
+			return "", fmt.Errorf("getting endpoints for connection %q: %w", conn.Name, err)
+		}
+		for _, swName := range switches {
+			profile, ok := profileBySwitch[swName]
+			if !ok || profile == nil {
+				continue
+			}
+			if !profile.Spec.Features.L2VNI {
+				return vpcapi.VPCModeL3VNI, nil
+			}
+		}
+	}
+
+	return vpcapi.VPCModeL2VNI, nil
+}
+
 func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) error {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
@@ -603,13 +634,19 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	if err := kube.List(ctx, &switchList); err != nil {
 		return fmt.Errorf("listing switches: %w", err)
 	}
-	allCumulus := true
+	profileBySwitch := map[string]*wiringapi.SwitchProfile{}
 	for _, sw := range switchList.Items {
+		if _, seen := profileBySwitch[sw.Name]; seen {
+			continue
+		}
 		sp := &wiringapi.SwitchProfile{}
 		if err := kube.Get(ctx, kclient.ObjectKey{Name: sw.Spec.Profile, Namespace: kmetav1.NamespaceDefault}, sp); err != nil {
 			return fmt.Errorf("getting switch profile %q: %w", sw.Spec.Profile, err)
 		}
-
+		profileBySwitch[sw.Name] = sp
+	}
+	allCumulus := true
+	for _, sp := range profileBySwitch {
 		if !slices.Contains(meta.NOSTypesCumulus, sp.Spec.NOSType) {
 			allCumulus = false
 
@@ -695,8 +732,47 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	}
 
 	slices.SortFunc(servers.Items, func(a, b wiringapi.Server) int {
-		return int(serverIDs[a.Name]) - int(serverIDs[b.Name])
+		return cmp.Compare(serverIDs[a.Name], serverIDs[b.Name])
 	})
+
+	// Resolve per-server VPC mode. When opts.VPCMode is set (l3vni / l3flat),
+	// every VPC takes that mode (force-everywhere override). Otherwise the
+	// mode is auto-derived from the SwitchProfile.Features.L2VNI of every
+	// leaf the server attaches to: L3VNI when any attached leaf is L3VNI-only,
+	// L2VNI everywhere else. Mode order = first-occurrence in numeric server
+	// order, so vpc-01 inherits the mode of the lowest-numbered server.
+	serverModes := make(map[string]vpcapi.VPCMode, len(servers.Items))
+	modeOrder := []vpcapi.VPCMode{}
+	seenMode := map[vpcapi.VPCMode]bool{}
+	for _, server := range servers.Items {
+		mode := opts.VPCMode
+		if mode == vpcapi.VPCModeL2VNI {
+			derived, err := autoDeriveVPCMode(ctx, kube, &server, profileBySwitch)
+			if err != nil {
+				return fmt.Errorf("auto-deriving VPC mode for server %q: %w", server.Name, err)
+			}
+			mode = derived
+		}
+		serverModes[server.Name] = mode
+		if !seenMode[mode] {
+			seenMode[mode] = true
+			modeOrder = append(modeOrder, mode)
+		}
+	}
+	if len(modeOrder) > 1 {
+		slog.Info("Mixed VPC modes detected", "modes", modeOrder)
+		modeIndex := map[vpcapi.VPCMode]int{}
+		for i, m := range modeOrder {
+			modeIndex[m] = i
+		}
+		slices.SortFunc(servers.Items, func(a, b wiringapi.Server) int {
+			if d := modeIndex[serverModes[a.Name]] - modeIndex[serverModes[b.Name]]; d != 0 {
+				return d
+			}
+
+			return cmp.Compare(serverIDs[a.Name], serverIDs[b.Name])
+		})
+	}
 
 	vlanNS := &wiringapi.VLANNamespace{}
 	if err := kube.Get(ctx, client.ObjectKey{Name: opts.VLANNamespace, Namespace: metav1.NamespaceDefault}, vlanNS); err != nil {
@@ -737,6 +813,8 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	subnetInVPC := 0
 	vpcID := 0
 	hostBGPDoneForVPC := false
+	placedAny := false
+	prevPlacedMode := vpcapi.VPCMode("")
 	vpcNames := map[string]bool{}
 	vpcs := []*vpcapi.VPC{}
 	attachNames := map[string]bool{}
@@ -746,7 +824,8 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	eslagServers := make(map[string]bool, 0)
 	hostBGPServers := map[string]bool{}
 	for _, server := range servers.Items {
-		if opts.VPCMode != vpcapi.VPCModeL2VNI {
+		serverMode := serverModes[server.Name]
+		if serverMode != vpcapi.VPCModeL2VNI {
 			if sa, err := getServerAttachState(ctx, kube, &server, false); err != nil {
 				return fmt.Errorf("checking server %q attachment state: %w", server.Name, err)
 			} else if sa.ESLAG {
@@ -756,6 +835,16 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 				continue
 			}
 		}
+		// Force a new VPC when the resolved mode changes since the last
+		// placed server: every VPC must be homogeneous in Spec.Mode.
+		if placedAny && serverMode != prevPlacedMode {
+			serverInSubnet = 0
+			subnetInVPC = 0
+			vpcID++
+			hostBGPDoneForVPC = false
+		}
+		placedAny = true
+		prevPlacedMode = serverMode
 		if serverInSubnet >= opts.ServersPerSubnet {
 			serverInSubnet = 0
 			subnetInVPC++
@@ -806,7 +895,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: vpcapi.VPCSpec{
-					Mode:    opts.VPCMode,
+					Mode:    serverMode,
 					Subnets: map[string]*vpcapi.VPCSubnet{},
 				},
 			}
@@ -1096,7 +1185,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 				expectedSubnet := expectedSubnets[server.Name]
 				// for hostBGP or non-l2vni subnets we expect a /32, else the same prefix lenght of the subnet
 				expectedBits := 32
-				if opts.VPCMode == vpcapi.VPCModeL2VNI && !isHostBGP {
+				if serverModes[server.Name] == vpcapi.VPCModeL2VNI && !isHostBGP {
 					expectedBits = expectedSubnet.Bits()
 				}
 				if !expectedSubnet.Contains(prefix.Addr()) {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -698,10 +698,43 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						return c.handleShutdownWithPause(ctx, vlab, opts, fmt.Errorf("setting up VPCs: %w", err))
 					}
 				case OnReadySetupPeerings:
-					// TODO make it configurable
-					peerings := []string{"1+2"}
-					if c.Fab.Spec.Config.Gateway.Enable {
-						peerings = append(peerings, "2+3:gw:vpc1=subnet-01:vpc2=subnet-01")
+					// Build peering requests defensively: only reference VPCs that
+					// actually exist after SetupVPCs. Auto-derived per-server modes
+					// can produce fewer than the canonical 3 VPCs (e.g. all-L3VNI
+					// runs skip ESLAG servers), in which case "2+3:gw" would dangle.
+					peerings, err := func() ([]string, error) {
+						cacheCancel, kube, err := getKubeClientWithCache(ctx, c.WorkDir)
+						if err != nil {
+							return nil, fmt.Errorf("creating kube client: %w", err)
+						}
+						defer cacheCancel()
+
+						vpcs := &vpcapi.VPCList{}
+						if err := kube.List(ctx, vpcs); err != nil {
+							return nil, fmt.Errorf("listing VPCs: %w", err)
+						}
+						existing := map[string]bool{}
+						for _, vpc := range vpcs.Items {
+							existing[vpc.Name] = true
+						}
+
+						out := []string{}
+						if existing["vpc-01"] && existing["vpc-02"] {
+							out = append(out, "1+2")
+						}
+						if c.Fab.Spec.Config.Gateway.Enable && existing["vpc-02"] && existing["vpc-03"] {
+							out = append(out, "2+3:gw:vpc1=subnet-01:vpc2=subnet-01")
+						}
+
+						return out, nil
+					}()
+					if err != nil {
+						return c.handleShutdownWithPause(ctx, vlab, opts, fmt.Errorf("planning peerings: %w", err))
+					}
+					if len(peerings) == 0 {
+						slog.Info("Skipping setup-peerings: not enough VPCs for the canonical 1+2 / 2+3:gw layout")
+
+						break
 					}
 
 					setupPeeringsOpts := SetupPeeringsOpts{


### PR DESCRIPTION
26.02 lifted the same-mode constraint on VPCPeering (fabric ddc72cc).
Requiring users to declare l2vni / l3vni is leftover friction now that
the only reason mode matters is the celestica-ds5000 L2VNI gap.

- SetupVPCs auto-derives each VPC's mode from SwitchProfile.Features.L2VNI
  of the attached leaves. `--vpc-mode` stays as a force-everywhere
  override (l3vni / l3flat).
- release-test reads per-VPC mode from VPC.Spec.Mode instead of the global
  setupOpts: ESLAG filter, per-VPC L3 waits, RequireAllServers relax.
- on-ready setup-peerings only references VPCs that exist after SetupVPCs.

Behavior change: `--vpc-mode=l2vni` (and the empty default) no longer
force L2VNI; they auto-derive. Identical on L2VNI-capable hardware;
mixed-mode VPCs on hardware with DS5000-only leaves.

Related: https://github.com/githedgehog/lab/pull/392