### PR TITLE
fix: keep WaitReady polling during agent rollover

### DIFF
--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -252,12 +252,7 @@ func WaitReady(ctx context.Context, kube client.Reader, opts WaitReadyOpts) erro
 			}
 		}
 
-		if len(swNotReady) == 0 && len(swNotUpdated) > 0 {
-			slices.Sort(swNotUpdated)
-			slog.Warn("All switches ready, but some not updated", "notUpdated", swNotUpdated)
-
-			return fmt.Errorf("all switches ready but some not updated")
-		} else if idx%opts.PrintEvery == 0 && (len(swNotReady) > 0 || len(swNotUpdated) > 0) {
+		if idx%opts.PrintEvery == 0 && (len(swNotReady) > 0 || len(swNotUpdated) > 0) {
 			slog.Info("Switches status", "notReady", swNotReady, "notUpdated", swNotUpdated)
 		}
 
@@ -304,16 +299,11 @@ func WaitReady(ctx context.Context, kube client.Reader, opts WaitReadyOpts) erro
 				gwNotReady = append(gwNotReady, gwName)
 			}
 		}
-		if len(gwNotReady) == 0 && len(gwNotUpdated) > 0 {
-			slices.Sort(gwNotUpdated)
-			slog.Warn("All gateways ready, but some not updated", "notUpdated", gwNotUpdated)
-
-			return fmt.Errorf("all gateways ready but some not updated")
-		} else if idx%opts.PrintEvery == 0 && (len(gwNotReady) > 0 || len(gwNotUpdated) > 0) {
+		if idx%opts.PrintEvery == 0 && (len(gwNotReady) > 0 || len(gwNotUpdated) > 0) {
 			slog.Info("Gateways status", "notReady", gwNotReady, "notUpdated", gwNotUpdated)
 		}
 
-		if len(swNotReady) == 0 && len(gwNotReady) == 0 {
+		if len(swNotReady) == 0 && len(swNotUpdated) == 0 && len(gwNotReady) == 0 && len(gwNotUpdated) == 0 {
 			slog.Info("All switches and gateways are ready", "took", time.Since(start))
 
 			return nil


### PR DESCRIPTION
## Summary

- `WaitReady` was bailing out with `all gateways ready but some not updated` (and the symmetric switches branch) the first time it observed a daemonset mid-rollover where the new agent had not yet written its first `Status.Version` / `Status.State.Dataplane.Version`. The outer 30 min `Timeout` was never used.
- Fix: drop the early returns; treat `notUpdated > 0` like any other "not yet at the expected state" condition and keep polling. The existing `Switches/Gateways status` log already surfaces it. Success now requires `notReady == 0 && notUpdated == 0` for both switches and gateways.

Closes #1732