### PR TITLE
chore: fix dependabot weekly runs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/controller-runtime"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,8 +14,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Fixes #1743.

- Drop the orphaned `docker` ecosystem (no Dockerfile at repo root, so the run aborts every week).
- Group `k8s.io/*` and `sigs.k8s.io/controller-runtime` so they bump together; bumping `k8s.io/api` alone fails to resolve against the older `k8s.io/client-go` still vendored.