### PR TITLE
fix(hhfab): add vlab serial support for opengear console server

### DIFF
--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -284,6 +284,7 @@ func (c *Config) VLABAccess(ctx context.Context, vlab *VLAB, t VLABAccessType, n
 
 			cmdName = VLABCmdSSH
 			args = append(slices.Clone(SSHQuietFlags), "-p", parts[1], parts[0])
+			slog.Info("Connected over SSH; use <Enter>~? to list SSH escape commands, safe to use Ctrl+C/Ctrl+Z")
 		} else {
 			return fmt.Errorf("serial not available: %s", name) //nolint:goerr113
 		}

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -4,6 +4,7 @@
 package hhfab
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"errors"
@@ -312,9 +313,45 @@ func (c *Config) VLABAccess(ctx context.Context, vlab *VLAB, t VLABAccessType, n
 	cmd.Dir = c.WorkDir
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+
+	// Tee ssh's stderr so we can disambiguate the exit-255 case below without
+	// hiding stderr from the user.
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 
 	if err := cmd.Run(); err != nil {
+		// OpenSSH returns exit 255 for any non-clean session end: user `~.`,
+		// server-initiated close, SONiC idle auto-logout, parent process
+		// killed, and also for genuine connect-time failures. The clean cases
+		// either print a "Connection to <host>" line on stderr or print
+		// nothing (signal kills); the failure cases print specific
+		// auth/network/KEX error messages. Treat 255 as clean for the
+		// hardware-serial path unless stderr matches a known fatal pattern.
+		var exitErr *exec.ExitError
+		if t == VLABAccessSerial && entry.RemoteSerial != "" &&
+			errors.As(err, &exitErr) && exitErr.ExitCode() == 255 {
+			fatal := false
+			for _, sig := range []string{
+				"Permission denied",
+				"ssh: connect to host",
+				"ssh: Could not resolve",
+				"No route to host",
+				"ssh_dispatch_run_fatal",
+				"Bad packet length",
+			} {
+				if strings.Contains(stderrBuf.String(), sig) {
+					fatal = true
+
+					break
+				}
+			}
+			if !fatal {
+				slog.Info("Serial session ended")
+
+				return nil
+			}
+		}
+
 		return fmt.Errorf("failed to run command: %w", err)
 	}
 

--- a/pkg/hhfab/vlabhelpers_reinstall.exp
+++ b/pkg/hhfab/vlabhelpers_reinstall.exp
@@ -109,6 +109,10 @@ expect {
 		log_message "EXP-DBG" "Connected via second console type"
 		send "\r"
 	}
+	-ex "Connected over SSH; use <Enter>~? to list SSH escape commands, safe to use Ctrl+C/Ctrl+Z" {
+		log_message "EXP-DBG" "Connected via third console type"
+		send "\r"
+	}
 	-ex "The connection was unsuccessful" {
 		log_message "EXP-ERR" "Connection unsuccessful"
 		exit $ERROR_CONSOLE


### PR DESCRIPTION
## Summary

`hhfab vlab switch reinstall` runs `vlabhelpers_reinstall.exp`, which spawns
`hhfab vlab serial` and waits for one of two banner cues to confirm the
console is attached before driving the GRUB menu: the Avocent ACS server-side
banner (`Type the hot key to suspend the connection: <CTRL>Z`), or hhfab's
own `Use Ctrl+] to escape...` log line. The second cue was only emitted on
the local-VM `SerialSock` branch (where socat is the transport and Ctrl+] is
the accurate escape sequence). Hardware reached via `RemoteSerial` printed
neither cue, so console servers that don't emit an Avocent-style banner
(Opengear IM7xxx per-port "Unauthenticated SSH" listeners are a real
example on the new env-6 lab) caused the expect script to time out at
`ERROR_CONSOLE` even though the SSH session was healthy.

## Validation

End-to-end on env-6 (Opengear IM7248-2-DAC, firmware 4.1.0u2, Celestica
DS3001 and DS4001 switches on per-port unauthSSH listeners):

* `hhfab vlab switch reinstall -n ds4001-01`: expect matched the new banner
  (`EXP-DBG: Connected via third console type`), PDU cycle was triggered,
  GRUB navigation reached ONIE Install Mode. Identical flow validated by a
  standalone PDU + expect harness without hhfab in the loop.
* `hhfab vlab serial -n ds3001-01` followed by `<Enter>~.`: clean exit with
  `INF Serial session ended`, no `ERR` line.

Related PR: https://github.com/githedgehog/lab/pull/398