### PR TITLE
fix(testing): preserve findExternals' static external choice

### DIFF
--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -179,12 +179,17 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		return true
 	}
 
+	// isViableStaticExt: static, has prefixes to advertise, has at least one static attachment.
+	isViableStaticExt := func(ext *vpcapi.External) bool {
+		return ext.Spec.Static != nil && len(ext.Spec.Static.Prefixes) > 0 && hasStaticAttachment(ext.Name)
+	}
+
 	// First pass: prefer hardware externals
 	for _, ext := range extList.Items {
 		if !isHardware(&ext) || !hasAttachment(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if staticExt == "" && isViableStaticExt(&ext) {
 			staticExt = ext.Name
 			slog.Info("Using hardware static external", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {
@@ -201,7 +206,7 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		if !hasAttachment(ext.Name) || !allAttachmentsHW(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if staticExt == "" && isViableStaticExt(&ext) {
 			staticExt = ext.Name
 			slog.Info("Using virtual static external (hw-attached)", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {
@@ -218,7 +223,7 @@ func findExternals(ctx context.Context, kube kclient.Client, extList *vpcapi.Ext
 		if !hasAttachment(ext.Name) {
 			continue
 		}
-		if ext.Spec.Static != nil && staticExt == "" && hasStaticAttachment(ext.Name) {
+		if staticExt == "" && isViableStaticExt(&ext) {
 			staticExt = ext.Name
 			slog.Info("Using virtual static external (virtual switch)", "external", staticExt)
 		} else if ext.Spec.Static == nil && bgpExt == "" {
@@ -909,46 +914,6 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOt
 			slog.Warn("No viable static external found, static external tests will be skipped")
 			skipFlags.NoStaticExternals = true
 		}
-	}
-
-	// Check for static externals have attachments
-	skipFlags.NoStaticExternals = true
-	for _, ext := range extList.Items {
-		if ext.Spec.Static != nil && len(ext.Spec.Static.Prefixes) > 0 {
-			// Check if it has at least one static attachment configured
-			extAttachList := &vpcapi.ExternalAttachmentList{}
-			if err := kube.List(ctx, extAttachList, kclient.MatchingLabels{vpcapi.LabelExternal: ext.Name}); err != nil {
-				slog.Warn("Failed to list external attachments for static external", "external", ext.Name, "error", err)
-
-				continue
-			}
-
-			// Find an attachment with static config
-			hasStaticAttach := false
-			for _, attach := range extAttachList.Items {
-				if attach.Spec.Static != nil {
-					hasStaticAttach = true
-					slog.Debug("Found static attachment", "external", ext.Name, "attachment", attach.Name)
-
-					break
-				}
-			}
-
-			if !hasStaticAttach {
-				slog.Debug("Static external has no static attachments configured", "external", ext.Name)
-
-				continue
-			}
-
-			testCtx.staticExtName = ext.Name
-			skipFlags.NoStaticExternals = false
-			slog.Info("Found static external with attachment for testing", "external", ext.Name)
-
-			break
-		}
-	}
-	if skipFlags.NoStaticExternals {
-		slog.Info("No static externals with attachments found, static external tests will be skipped")
 	}
 
 	fabricator := &fabricatorapi.Fabricator{}


### PR DESCRIPTION
`findExternals` in `pkg/hhfab/rt_base.go` walks externals in three passes (hw, virtual-on-hw-link, pure virtual) and picks the hw-preferred static external. Right after the call, a leftover loop iterated `extList.Items` in API order and unconditionally overwrote `testCtx.staticExtName` with whichever static external came first. The loop predates `findExternals` knowing about static externals (commit 42de11a5c, "add L2 external release test") and was never cleaned up when `findExternals` was extended in bf51fb30a.

In HLAB envs with both a hw-attached static external and a virt-external-attached one, this regressed the Static External Peering release test: the virt-external (`acl-test` on env-4) was selected, the framework wired `vpc-XX--acl-test` with `permit: 0.0.0.0/0`, but the External's actual advertised prefixes were narrower, so VPCs had no 0/0 route and the curl from the chosen server failed.

## Fix

- Fold the empty-prefix guard from the dead loop into `findExternals` via a small `isViableStaticExt` helper (covers all three passes).
- Delete the loop. `findExternals` is now the single source of truth for `staticExtName`; the skip flag is already set from its return value.

## Validation

env-4 HLAB. Before:
```
06:53:59 INF Using hardware static external external=static-defa
06:53:59 INF Found static external with attachment for testing external=acl-test
...
11:53:23 ERR FAIL test="Static External Peering" error="testing static external connectivity: curl from server-8: should be reachable but curl failed (expected true)"
```

After (rebuilt hhfab from this branch, rerun on the same env):
```
16:02:55 INF Using hardware static external external=static-defa
```

(no overwrite line, peering created against `static-defa`, test passes.)

## Companion

githedgehog/lab#395 narrows env-4's `acl-test` External prefix from `0.0.0.0/0` to `100.99.100.0/24` (the link subnet only). Mirrors the lab-ci#21 pattern. Independent fix: with this PR alone, env-4 picks `static-defa` and the Static External Peering test passes regardless of `acl-test`'s prefix; with lab#395 alone, the previous run on env-4 (`Only Externals` test) is also unblocked because `acl-test`'s 0/0 no longer wins the per-VPC ECMP race against hw externals. Both merged together leave env-4 release-test clean on master.