### PR TITLE
feat(testing): allow separate min-speed floor for bidir iperf3

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -89,6 +89,8 @@ const (
 	FlagGatewayLogLevel           = "gateway-log-level"
 	FlagGatewayTag                = "gateway-tag"
 	FlagShowTech                  = "show-tech"
+	FlagIPerfsSpeed               = "iperfs-speed"
+	FlagIPerfsBidirSpeed          = "iperfs-bidir-speed"
 )
 
 func main() {
@@ -1572,10 +1574,11 @@ Examples:
 								Value: 10,
 							},
 							&cli.Float64Flag{
-								Name:  "iperfs-speed",
+								Name:  FlagIPerfsSpeed,
 								Usage: "minimum speed in Mbits/s for iperf3 test to consider successful (0 to not check speeds)",
 								Value: 8200,
 							},
+							iperfsBidirSpeedFlag(),
 							&cli.IntFlag{
 								Name:  "curls",
 								Usage: "number of curl tests to run for each server to test external connectivity (0 to disable)",
@@ -1618,17 +1621,26 @@ Examples:
 							if cliTOS > 255 {
 								return fmt.Errorf("tos value must be between 0 and 255, got %d", cliTOS) //nolint:goerr113
 							}
+							iperfsSpeed := c.Float64(FlagIPerfsSpeed)
+							if iperfsSpeed < 0 {
+								return fmt.Errorf("--%s must be >= 0, got %g", FlagIPerfsSpeed, iperfsSpeed) //nolint:goerr113
+							}
+							iperfsBidirSpeed := c.Float64(FlagIPerfsBidirSpeed)
+							if iperfsBidirSpeed < 0 {
+								return fmt.Errorf("--%s must be >= 0, got %g", FlagIPerfsBidirSpeed, iperfsBidirSpeed) //nolint:goerr113
+							}
 							if err := hhfab.DoVLABTestConnectivity(ctx, workDir, cacheDir, hhfab.TestConnectivityOpts{
-								WaitSwitchesReady: c.Bool("wait-switches-ready"),
-								PingsCount:        c.Int("pings"),
-								IPerfsSeconds:     c.Int("iperfs"),
-								IPerfsMinSpeed:    c.Float64("iperfs-speed"),
-								CurlsCount:        c.Int("curls"),
-								Sources:           c.StringSlice("source"),
-								Destinations:      c.StringSlice("destination"),
-								IPerfsDSCP:        uint8(cliDSCP),
-								IPerfsTOS:         uint8(cliTOS),
-								RequireAllServers: c.Bool("all-servers"),
+								WaitSwitchesReady:   c.Bool("wait-switches-ready"),
+								PingsCount:          c.Int("pings"),
+								IPerfsSeconds:       c.Int("iperfs"),
+								IPerfsMinSpeed:      iperfsSpeed,
+								IPerfsMinSpeedBidir: iperfsBidirSpeed,
+								CurlsCount:          c.Int("curls"),
+								Sources:             c.StringSlice("source"),
+								Destinations:        c.StringSlice("destination"),
+								IPerfsDSCP:          uint8(cliDSCP),
+								IPerfsTOS:           uint8(cliTOS),
+								RequireAllServers:   c.Bool("all-servers"),
 							}); err != nil {
 								return fmt.Errorf("test-connectivity: %w", err)
 							}
@@ -1734,20 +1746,26 @@ Examples:
 								Usage:   "collect show-tech diagnostics on failure",
 								Value:   true,
 							},
+							iperfsBidirSpeedFlag(),
 						}),
 						Before: before(false),
 						Action: func(c *cli.Context) error {
+							iperfsBidirSpeed := c.Float64(FlagIPerfsBidirSpeed)
+							if iperfsBidirSpeed < 0 {
+								return fmt.Errorf("--%s must be >= 0, got %g", FlagIPerfsBidirSpeed, iperfsBidirSpeed) //nolint:goerr113
+							}
 							opts := hhfab.ReleaseTestOpts{
-								Regexes:        c.StringSlice(FlagRegEx),
-								InvertRegex:    c.Bool(FlagInvertRegex),
-								ResultsFile:    c.String(FlagResultsFile),
-								Extended:       c.Bool(FlagExtended),
-								FailFast:       c.Bool(FlagNameFailFast),
-								PauseOnFailure: c.Bool(FlagPauseOnFailure),
-								HashPolicy:     c.String(FlagHashPolicy),
-								VPCMode:        vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
-								ListTests:      c.Bool(FlagListTests),
-								ShowTechDump:   c.Bool(FlagShowTech),
+								Regexes:             c.StringSlice(FlagRegEx),
+								InvertRegex:         c.Bool(FlagInvertRegex),
+								ResultsFile:         c.String(FlagResultsFile),
+								Extended:            c.Bool(FlagExtended),
+								FailFast:            c.Bool(FlagNameFailFast),
+								PauseOnFailure:      c.Bool(FlagPauseOnFailure),
+								HashPolicy:          c.String(FlagHashPolicy),
+								VPCMode:             vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
+								ListTests:           c.Bool(FlagListTests),
+								ShowTechDump:        c.Bool(FlagShowTech),
+								IPerfsMinSpeedBidir: iperfsBidirSpeed,
 							}
 							if err := hhfab.DoVLABReleaseTest(ctx, workDir, cacheDir, opts); err != nil {
 								return fmt.Errorf("release-test: %w", err)
@@ -2002,4 +2020,12 @@ func handleL2VNI(in string) string {
 	}
 
 	return in
+}
+
+func iperfsBidirSpeedFlag() cli.Flag {
+	return &cli.Float64Flag{
+		Name:  FlagIPerfsBidirSpeed,
+		Usage: "minimum speed in Mbits/s for bidir iperf3 tests (0 to reuse the unidir floor)",
+		Value: 0,
+	}
 }

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -89,12 +89,13 @@ func makeTestCtx(ctx context.Context, kube kclient.Client, setupOpts SetupVPCsOp
 	testCtx.vlab = vlab
 	testCtx.setupOpts = setupOpts
 	testCtx.tcOpts = TestConnectivityOpts{
-		WaitSwitchesReady: false,
-		PingsCount:        5,
-		IPerfsSeconds:     3,
-		IPerfsMinSpeed:    8200,
-		CurlsCount:        1,
-		RequireAllServers: setupOpts.VPCMode == vpcapi.VPCModeL2VNI, // L3VNI will skip eslag servers
+		WaitSwitchesReady:   false,
+		PingsCount:          5,
+		IPerfsSeconds:       3,
+		IPerfsMinSpeed:      8200,
+		IPerfsMinSpeedBidir: rtOpts.IPerfsMinSpeedBidir,
+		CurlsCount:          1,
+		RequireAllServers:   setupOpts.VPCMode == vpcapi.VPCModeL2VNI, // L3VNI will skip eslag servers
 	}
 	testCtx.wrOpts = WaitReadyOpts{
 		AppliedFor: waitAppliedFor,

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -2065,19 +2065,20 @@ func (ce *CurlError) Error() string {
 }
 
 type TestConnectivityOpts struct {
-	WaitSwitchesReady bool
-	PingsCount        int
-	PingsParallel     int64
-	IPerfsSeconds     int
-	IPerfsMinSpeed    float64
-	IPerfsParallel    int64
-	IPerfsDSCP        uint8
-	IPerfsTOS         uint8
-	CurlsCount        int
-	CurlsParallel     int64
-	Sources           []string
-	Destinations      []string
-	RequireAllServers bool
+	WaitSwitchesReady   bool
+	PingsCount          int
+	PingsParallel       int64
+	IPerfsSeconds       int
+	IPerfsMinSpeed      float64
+	IPerfsMinSpeedBidir float64
+	IPerfsParallel      int64
+	IPerfsDSCP          uint8
+	IPerfsTOS           uint8
+	CurlsCount          int
+	CurlsParallel       int64
+	Sources             []string
+	Destinations        []string
+	RequireAllServers   bool
 }
 
 func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConnectivityOpts) error {
@@ -3002,6 +3003,9 @@ func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string,
 	}
 
 	iPerfsMinSpeed := opts.IPerfsMinSpeed
+	if bidir && opts.IPerfsMinSpeedBidir > 0 {
+		iPerfsMinSpeed = opts.IPerfsMinSpeedBidir
+	}
 	// Gateway peering uses kernel-based dataplane; observed sustained throughput on HLAB is
 	// ~5-6.5 Gbps with periodic real packet loss, so cap floor at 5000 to avoid flake.
 	if reachability.Reason == ReachabilityReasonGatewayPeering {
@@ -3471,16 +3475,17 @@ func (c *Config) Inspect(ctx context.Context, vlab *VLAB, opts InspectOpts) erro
 }
 
 type ReleaseTestOpts struct {
-	Regexes        []string
-	InvertRegex    bool
-	ResultsFile    string
-	Extended       bool
-	FailFast       bool
-	PauseOnFailure bool
-	HashPolicy     string
-	VPCMode        vpcapi.VPCMode
-	ListTests      bool
-	ShowTechDump   bool
+	Regexes             []string
+	InvertRegex         bool
+	ResultsFile         string
+	Extended            bool
+	FailFast            bool
+	PauseOnFailure      bool
+	HashPolicy          string
+	VPCMode             vpcapi.VPCMode
+	ListTests           bool
+	ShowTechDump        bool
+	IPerfsMinSpeedBidir float64
 }
 
 func (c *Config) ReleaseTest(ctx context.Context, vlab *VLAB, opts ReleaseTestOpts) error {


### PR DESCRIPTION
## Summary

- Add `IPerfsMinSpeedBidir` to `TestConnectivityOpts` and `ReleaseTestOpts`. When `bidir=true` and the value is >0, `checkIPerf` uses it in place of the unidir floor; default 0 preserves existing behavior everywhere.
- Surface as `--iperfs-bidir-min-speed` on `vlab test-connectivity` and `vlab release-test` (default 0).

## Why

On env-4 the symmetric-pair bidir iperf3 path is throttled by virtio/vhost-net concurrent send+recv on the server VMs. Probe results (server-1 \<-> server-2):

| Direction | Throughput |
|---|---|
| Unidir 1→2 | 9.90 Gbps |
| Unidir 2→1 | 9.91 Gbps |
| Bidir 1\<->2 | 7.21 Gbps each |

Both unidir directions clear the 8200 Mbps floor; bidir hits a per-direction ceiling around 7.2 Gbps. The 8200 Mbps unidir floor is correct (it still detects CPU-path fallback, which would collapse to sub-1 Gbps); the bidir floor needs to be lower on envs with VM servers. Two clean release-test runs on env-4 with `--iperfs-bidir-min-speed 6500`.

Default 0 means no behavior change on HLAB / CI / vlab runner.