### PR TITLE
feat(testing): expose --iperfs-speed on release-test

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -89,6 +89,7 @@ const (
 	FlagGatewayLogLevel           = "gateway-log-level"
 	FlagGatewayTag                = "gateway-tag"
 	FlagShowTech                  = "show-tech"
+	FlagIPerfsSpeed               = "iperfs-speed"
 )
 
 func main() {
@@ -1572,7 +1573,7 @@ Examples:
 								Value: 10,
 							},
 							&cli.Float64Flag{
-								Name:  "iperfs-speed",
+								Name:  FlagIPerfsSpeed,
 								Usage: "minimum speed in Mbits/s for iperf3 test to consider successful (0 to not check speeds)",
 								Value: 8200,
 							},
@@ -1622,7 +1623,7 @@ Examples:
 								WaitSwitchesReady: c.Bool("wait-switches-ready"),
 								PingsCount:        c.Int("pings"),
 								IPerfsSeconds:     c.Int("iperfs"),
-								IPerfsMinSpeed:    c.Float64("iperfs-speed"),
+								IPerfsMinSpeed:    c.Float64(FlagIPerfsSpeed),
 								CurlsCount:        c.Int("curls"),
 								Sources:           c.StringSlice("source"),
 								Destinations:      c.StringSlice("destination"),
@@ -1734,9 +1735,18 @@ Examples:
 								Usage:   "collect show-tech diagnostics on failure",
 								Value:   true,
 							},
+							&cli.Float64Flag{
+								Name:  FlagIPerfsSpeed,
+								Usage: "minimum speed in Mbits/s for iperf3 test to consider successful (0 to not check speeds)",
+								Value: 8200,
+							},
 						}),
 						Before: before(false),
 						Action: func(c *cli.Context) error {
+							iperfsSpeed := c.Float64(FlagIPerfsSpeed)
+							if iperfsSpeed < 0 {
+								return fmt.Errorf("--%s must be >= 0, got %g", FlagIPerfsSpeed, iperfsSpeed) //nolint:goerr113
+							}
 							opts := hhfab.ReleaseTestOpts{
 								Regexes:        c.StringSlice(FlagRegEx),
 								InvertRegex:    c.Bool(FlagInvertRegex),
@@ -1748,6 +1758,7 @@ Examples:
 								VPCMode:        vpcapi.VPCMode(handleL2VNI(c.String(FlagNameVPCMode))),
 								ListTests:      c.Bool(FlagListTests),
 								ShowTechDump:   c.Bool(FlagShowTech),
+								IPerfsMinSpeed: iperfsSpeed,
 							}
 							if err := hhfab.DoVLABReleaseTest(ctx, workDir, cacheDir, opts); err != nil {
 								return fmt.Errorf("release-test: %w", err)

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -92,7 +92,7 @@ func makeTestCtx(ctx context.Context, kube kclient.Client, setupOpts SetupVPCsOp
 		WaitSwitchesReady: false,
 		PingsCount:        5,
 		IPerfsSeconds:     3,
-		IPerfsMinSpeed:    8200,
+		IPerfsMinSpeed:    rtOpts.IPerfsMinSpeed,
 		CurlsCount:        1,
 		RequireAllServers: setupOpts.VPCMode == vpcapi.VPCModeL2VNI, // L3VNI will skip eslag servers
 	}

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3481,6 +3481,7 @@ type ReleaseTestOpts struct {
 	VPCMode        vpcapi.VPCMode
 	ListTests      bool
 	ShowTechDump   bool
+	IPerfsMinSpeed float64
 }
 
 func (c *Config) ReleaseTest(ctx context.Context, vlab *VLAB, opts ReleaseTestOpts) error {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -760,6 +760,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						Regexes:        opts.ReleaseTestRegexes,
 						InvertRegex:    opts.ReleaseTestRegexesInvert,
 						ShowTechDump:   true,
+						IPerfsMinSpeed: 8200,
 					}
 					slog.Debug("Running release-test", "opts", releaseTestOpts)
 					if err := c.ReleaseTest(ctx, vlab, releaseTestOpts); err != nil {


### PR DESCRIPTION
## Summary

- Add `--iperfs-speed` flag on `vlab release-test` (default 8200, matching the existing flag on `vlab test-connectivity`).
- Plumbs through `ReleaseTestOpts.IPerfsMinSpeed` into `testCtx.tcOpts`, replacing the hardcoded 8200 in `rt_base.go:95`.
- Extracts a `FlagIPerfsSpeed` constant; reuses it on both commands.
- Rejects negative values on release-test (matches the DSCP/TOS validation pattern).

## Why

Today the iperf3 throughput floor for release-test is hardcoded at 8200 Mbps in `rt_base.go`. That value assumes ~10 GbE switches with VMs sized for line-rate symmetric bidir. Two near-term needs surface a per-invocation override:

- **1G switches** (planned support): line rate ~0.94 Gbps, so 8200 Mbps is unreachable. Without a knob, release-test on a 1G fabric fails every iperf assertion.
- **Constrained VLAB servers** (e.g. env-4 today): unidir line-rate fine, but bidir-with-4-streams lands at ~7.2 Gbps. A relaxed floor (e.g. 6500) lets the test pass at signal level without masking real failures (CPU-path fallback still would collapse under 1 Gbps).

A single flag covers both. test-connectivity already has the equivalent flag; this just mirrors it on release-test.

Default behavior unchanged: floor is 8200 Mbps when the flag isn't passed