### PR TITLE
fix(testing): prefer non-MCLAG leaf for RoCE basic traffic test

### DIFF
--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -1556,22 +1556,26 @@ outer:
 			return false, nil, fmt.Errorf("listing connections for switch %s: %w", candidateSwitch, err)
 		}
 
+		// Prefer leaves whose server connections are single-homed (Unbundled or
+		// Bundled). MCLAG and ESLAG members err-disable for minutes after a
+		// rebooting peer comes back, which races against the UC3 polling
+		// window. MCLAG is also on the deprecation path, so we don't want
+		// post-RoCE tests baking MCLAG-specific timing assumptions in.
 		for _, conn := range connList.Items {
-			_, servers, _, _, err := conn.Spec.Endpoints()
-			if err == nil && len(servers) > 0 {
+			if connHasSingleHomedServer(candidateSwitch, conn) {
 				swName = candidateSwitch
-				slog.Debug("Selected RoCE leaf with servers", "switch", swName)
+				slog.Debug("Selected RoCE leaf with non-MCLAG server connection", "switch", swName, "connection", conn.Name)
 
 				break outer
 			}
 		}
-		slog.Debug("Skipping RoCE leaf with no servers", "switch", candidateSwitch)
+		slog.Debug("Skipping RoCE leaf with no non-MCLAG server connections", "switch", candidateSwitch)
 	}
 
 	if swName == "" {
-		slog.Info("No RoCE-capable leaves with servers found, skipping test")
+		slog.Info("No RoCE-capable leaves with non-MCLAG server connections found, skipping test")
 
-		return true, nil, fmt.Errorf("no RoCE leaves with servers found") //nolint:goerr113
+		return true, nil, fmt.Errorf("no RoCE leaves with non-MCLAG server connections found") //nolint:goerr113
 	}
 	slog.Debug("Using RoCE leaf switch for test", "switch", swName)
 

--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -523,6 +523,26 @@ func setRoCE(ctx context.Context, kube kclient.Client, swName string, roce bool)
 	return nil
 }
 
+// connHasSingleHomedServer returns true if conn is a server-bearing connection
+// that is single-homed to the named switch (Unbundled or Bundled). MCLAG and
+// ESLAG connections err-disable their LAG members for minutes after a
+// rebooting peer comes back, which deadlines flake tests that need traffic to
+// transit a freshly-rebooted switch; pick a non-MCLAG candidate instead.
+func connHasSingleHomedServer(swName string, conn wiringapi.Connection) bool {
+	switch {
+	case conn.Spec.Unbundled != nil:
+		return conn.Spec.Unbundled.Link.Switch.DeviceName() == swName
+	case conn.Spec.Bundled != nil:
+		for _, link := range conn.Spec.Bundled.Links {
+			if link.Switch.DeviceName() == swName {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // single-switch, dumbed down (no update as we don't need it here) version of WaitSwitchesReady
 func waitSwitchReady(ctx context.Context, kube kclient.Client, swName string, appliedFor time.Duration, timeout time.Duration) error {
 	if timeout > 0 {

--- a/pkg/hhfab/show-tech/switch.sh
+++ b/pkg/hhfab/show-tech/switch.sh
@@ -72,6 +72,45 @@ run_sonic_cmd() {
     run_sonic_cmd "show mclag brief"
     run_sonic_cmd "show mclag interface"
     run_sonic_cmd "show port-channel summary"
+
+    # teamd per-LAG state captures LACP partner info and member oper status,
+    # which "show port-channel summary" hides when a LAG is err-disabled.
+    # Enumerate via /sys/class/net rather than parsing sonic-cli output, which
+    # is empty on some SONiC builds.
+    echo -e "\n=== Teamd LAG State ==="
+    for pc in $(ls /sys/class/net/ 2>/dev/null | grep '^PortChannel' | sort); do
+        echo -e "\n--- teamdctl $pc state ---"
+        teamdctl "$pc" state 2>&1
+    done
+} >> "$OUTPUT_FILE" 2>&1
+
+# ---------------------------
+# QoS / Queue Counters
+# ---------------------------
+# Direct view of the per-queue transmit/receive counters and PFC state that
+# RoCE / DSCP-marking tests assert on. The agent serialises a filtered subset
+# into kube state, so the raw view is needed when those tests fail.
+{
+    echo -e "\n=== QoS and Queue Counters ==="
+    run_sonic_cmd "show queue counters"
+    run_sonic_cmd "show priority-flow-control statistics"
+    run_sonic_cmd "show qos map dscp-tc"
+    run_sonic_cmd "show qos map tc-queue"
+    run_sonic_cmd "show qos map tc-pg"
+    run_sonic_cmd "show qos scheduler-policy"
+    run_sonic_cmd "show qos wred-policy"
+} >> "$OUTPUT_FILE" 2>&1
+
+# ---------------------------
+# err-disable / link-flap timeline
+# ---------------------------
+# show interface status err-disabled only gives the latest event per port; this
+# filtered syslog view gives the full sequence (with timestamps) so post-mortems
+# can reconstruct flap/recovery against the test timeline. Scan only the current
+# syslog so log rotation can't bury the most recent events under older ones.
+{
+    echo -e "\n=== Error-Disable Timeline ==="
+    grep -hE "ERR_DISABLED|err-disable|err_disable|lag-status-down" /var/log/syslog 2>/dev/null | tail -200
 } >> "$OUTPUT_FILE" 2>&1
 
 # ---------------------------


### PR DESCRIPTION
## Summary

- `roceBasicTest` was picking any leaf with server connections, including ones whose only server links are MCLAG. After `setRoCE` reboots the chosen switch, MCLAG/ICCP renegotiation keeps the server-facing LAG members err-disabled for ~5 minutes, well past the test's 60 s UC3 polling window. Traffic flows entirely through the surviving MCLAG peer, the chosen switch's UC3 counters never increment, and the test fails.
- MCLAG is on the deprecation path, so masking this with a longer wait would bake MCLAG-specific timing into a test that should outlive MCLAG. Switch the selection to prefer single-homed server connections (`Unbundled` or `Bundled`); skip the test if no leaf qualifies.
- Extend switch show-tech with the per-queue counters, teamd LAG state, QoS map snapshots and errdisable timeline that would have made this self-diagnosable from the bundle.

Fixes #1487 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes flakiness in the RoCE basic traffic test by changing leaf switch selection logic to avoid MCLAG-only configurations. After a leaf reboot, MCLAG/ICCP renegotiation can leave server-facing LAG members err-disabled for ~5 minutes, exceeding the test's polling window. The test now prefers leaves with single-homed server connections (Unbundled or Bundled) and is skipped if no qualifying leaf is available. Enhanced diagnostics are included in the show-tech bundle to make failures more diagnosable.

## Changes

### Leaf Selection Logic (`pkg/hhfab/rt_single_vpc_suite.go`)
- Modified `roceBasicTest` to prefer RoCE-capable leaves with single-homed server connections
- Added filter using `connHasSingleHomedServer` to skip leaves whose only server-facing links are MCLAG/ESLAG
- Updated skip/error messages to reflect the new selection criteria

### Helper Function (`pkg/hhfab/rt_utils.go`)
- Added `connHasSingleHomedServer(swName string, conn wiringapi.Connection) bool` helper function
- Determines if a connection is single-homed to a switch by checking Unbundled or Bundled membership
- Explicitly avoids MCLAG/ESLAG configurations to prevent post-reboot timing issues

### Enhanced Diagnostics (`pkg/hhfab/show-tech/switch.sh`)
- Added "Teamd LAG State" section enumerating PortChannel interfaces and running `teamdctl` for each
- Added "QoS and Queue Counters" section capturing per-queue counters, PFC statistics, and QoS/WRED/scheduler mappings via `sonic-cli` commands
- Added "Error-Disable Timeline" section extracting relevant syslog entries (ERR_DISABLED/err-disable/lag-status-down) to show event sequence beyond per-port snapshots

## Related Issues
- Fixes `#1487`: RoCE flag and basic traffic marking test reporting UC3 counter failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->