### PR TITLE
fix(hhfab): wait for server host routes before connectivity probe

### DIFF
--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/netip"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
@@ -407,10 +409,6 @@ func (testCtx *VPCPeeringTestCtx) waitForNATPoolInLeaves(ctx context.Context, vp
 
 // wait until all switches in a set have a bunch of routes installed, or error out after 3 minutes
 func (testCtx *VPCPeeringTestCtx) waitForRoutesInSwitches(ctx context.Context, switches map[string]bool, routes []string, vrfName string) error {
-	const timeout = 3 * time.Minute
-	slog.Debug("Checking for routes in switches", "switches", switches, "routes", routes, "vrf", vrfName, "timeout", timeout)
-	toCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 	sshs := make(map[string]*sshutil.Config, len(switches))
 	for sw := range switches {
 		ssh, err := testCtx.getSSH(ctx, sw)
@@ -418,6 +416,21 @@ func (testCtx *VPCPeeringTestCtx) waitForRoutesInSwitches(ctx context.Context, s
 			return fmt.Errorf("getting ssh config for switch %s: %w", sw, err)
 		}
 		sshs[sw] = ssh
+	}
+
+	return waitForRoutesInSwitchesAt(ctx, sshs, switches, routes, vrfName, 3*time.Minute)
+}
+
+// waitForRoutesInSwitchesAt polls every switch in `switches` until each `route` is installed in
+// `vrfName`. SSH configs are looked up in `sshs` by switch name. Times out after `timeout`.
+func waitForRoutesInSwitchesAt(ctx context.Context, sshs map[string]*sshutil.Config, switches map[string]bool, routes []string, vrfName string, timeout time.Duration) error {
+	slog.Debug("Checking for routes in switches", "switches", switches, "routes", routes, "vrf", vrfName, "timeout", timeout)
+	toCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for sw := range switches {
+		if sshs[sw] == nil {
+			return fmt.Errorf("missing ssh config for switch %s", sw) //nolint:goerr113
+		}
 	}
 
 	for {
@@ -445,6 +458,57 @@ func (testCtx *VPCPeeringTestCtx) waitForRoutesInSwitches(ctx context.Context, s
 		case <-time.After(5 * time.Second):
 		}
 	}
+}
+
+// waitForServerRoutesOnLeaves waits for each discovered server's /32 host route to appear in the
+// FIB of every leaf attached to that server's VPC, in the VPC's VRF. Closes the race between IP
+// discovery (which SSHes the server and sees the freshly-leased address immediately) and EVPN
+// type-5 propagation across all participating leaves. `ips` is the sync.Map populated during the
+// discovery loop in TestConnectivity (server name -> netip.Prefix).
+func waitForServerRoutesOnLeaves(ctx context.Context, c *Config, vlab *VLAB, kube kclient.Client, ips *sync.Map, serverVPCs map[string]string, vpcModes map[string]vpcapi.VPCMode, timeout time.Duration) error {
+	routesByVPC := map[string][]string{}
+	ips.Range(func(k, v any) bool {
+		server, _ := k.(string)
+		addr, _ := v.(netip.Prefix)
+		vpcName := serverVPCs[server]
+		if vpcName == "" {
+			return true
+		}
+		route := netip.PrefixFrom(addr.Addr(), addr.Addr().BitLen()).String()
+		routesByVPC[vpcName] = append(routesByVPC[vpcName], route)
+
+		return true
+	})
+
+	for vpcName, routes := range routesByVPC {
+		leaves, err := getSwitchesForVPC(ctx, kube, vpcName)
+		if err != nil {
+			return fmt.Errorf("getting switches for vpc %s: %w", vpcName, err)
+		}
+		if len(leaves) == 0 {
+			continue
+		}
+		// Resolve SSH for each leaf via c.SSH so both VLAB VM-backed switches and HLAB hardware
+		// switches are covered; the per-server sshConfigs map only has servers.
+		sshs := make(map[string]*sshutil.Config, len(leaves))
+		for sw := range leaves {
+			ssh, err := c.SSH(ctx, vlab, sw)
+			if err != nil {
+				return fmt.Errorf("getting ssh config for switch %s: %w", sw, err)
+			}
+			sshs[sw] = ssh
+		}
+		vrfName := "VrfV" + vpcName
+		if vpcModes[vpcName] == vpcapi.VPCModeL3Flat {
+			vrfName = defaultVRFName
+		}
+		slog.Info("Waiting for server host routes on leaves", "vpc", vpcName, "leaves", leaves, "routes", routes, "vrf", vrfName)
+		if err := waitForRoutesInSwitchesAt(ctx, sshs, leaves, routes, vrfName, timeout); err != nil {
+			return fmt.Errorf("waiting for host routes on vpc %s: %w", vpcName, err)
+		}
+	}
+
+	return nil
 }
 
 // check that the DHCP lease is within the expected range.

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -473,6 +473,8 @@ type ServerAttachState struct {
 	Attached   bool
 	ESLAG      bool
 	L3VNI      bool
+	VPCName    string
+	VPCMode    vpcapi.VPCMode
 }
 
 func getServerAttachState(ctx context.Context, kube client.Client, server *wiringapi.Server, checkVPCMode bool) (ServerAttachState, error) {
@@ -508,13 +510,13 @@ func getServerAttachState(ctx context.Context, kube client.Client, server *wirin
 			return sa, fmt.Errorf("expected at most one VPC attachment for connection %q, got %d", conn.Name, numAttaches)
 		}
 		sa.Attached = true
+		sa.VPCName = attaches.Items[0].Spec.VPCName()
 		if checkVPCMode {
-			attach := attaches.Items[0]
-			vpcName := attach.Spec.VPCName()
 			vpc := &vpcapi.VPC{}
-			if err := kube.Get(ctx, client.ObjectKey{Name: vpcName, Namespace: metav1.NamespaceDefault}, vpc); err != nil {
-				return sa, fmt.Errorf("getting VPC %q: %w", vpcName, err)
+			if err := kube.Get(ctx, client.ObjectKey{Name: sa.VPCName, Namespace: metav1.NamespaceDefault}, vpc); err != nil {
+				return sa, fmt.Errorf("getting VPC %q: %w", sa.VPCName, err)
 			}
+			sa.VPCMode = vpc.Spec.Mode
 			if vpc.Spec.Mode != vpcapi.VPCModeL2VNI {
 				sa.L3VNI = true
 			}
@@ -2151,6 +2153,8 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 	}
 
 	serverIDs := map[string]uint64{}
+	serverVPCs := map[string]string{}
+	vpcModes := map[string]vpcapi.VPCMode{}
 	for _, server := range servers.Items {
 		// Skip servers not in the list of sources or destinations, if both are specified
 		if len(opts.Sources) > 0 && len(opts.Destinations) > 0 {
@@ -2158,16 +2162,19 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 				continue
 			}
 		}
-		if sa, err := getServerAttachState(ctx, kube, &server, true); err != nil {
+		sa, err := getServerAttachState(ctx, kube, &server, true)
+		if err != nil {
 			return fmt.Errorf("checking server %q attachment state: %w", server.Name, err)
-		} else if !sa.Attached {
+		}
+		if !sa.Attached {
 			if opts.RequireAllServers {
 				return fmt.Errorf("server %q is not attached, but RequireAllServers is set", server.Name)
 			}
 			slog.Debug("Skipping non-attached server", "server", server.Name)
 
 			continue
-		} else if sa.ESLAG && sa.L3VNI {
+		}
+		if sa.ESLAG && sa.L3VNI {
 			slog.Warn("Skipping server attached to an L3VNI VPC via ESLAG", "server", server.Name)
 
 			continue
@@ -2183,6 +2190,8 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 		}
 
 		serverIDs[server.Name] = serverID
+		serverVPCs[server.Name] = sa.VPCName
+		vpcModes[sa.VPCName] = sa.VPCMode
 	}
 
 	slices.SortFunc(servers.Items, func(a, b wiringapi.Server) int {
@@ -2256,6 +2265,10 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("discovering server IPs: %w", err)
+	}
+
+	if err := waitForServerRoutesOnLeaves(ctx, c, vlab, kube, &ips, serverVPCs, vpcModes, 3*time.Minute); err != nil {
+		slog.Warn("Gate before connectivity probe did not see all server host routes; continuing anyway", "err", err)
 	}
 
 	slog.Info("Running pings, iperfs and curls", "servers", len(servers.Items))


### PR DESCRIPTION
## Summary

Closes the race in `TestConnectivity` where IP discovery (SSH on the server, sees the freshly-leased address immediately) outruns EVPN type-5 propagation across the participating leaves. With a DHCP-churning test running just before, the parallel probe completes inside the convergence gap and fails `sent=N, rcvd=0` on every pair involving the perturbed server.

Adds a gate between IP discovery and the probe loop: for each discovered `/32`, wait until the route appears in the FIB of every leaf attached to its VPC, in the right VRF. 3-minute timeout, log+continue on failure (the gate cannot regress a passing test).

Sits in `TestConnectivity`, so every release-test that calls it (Bundled, MCLAG, Mesh Failover; NAT; multi-VPC) is gated without per-test changes. Reproduced on env-5 (mesh + spine-leaf) and on HLAB CI (`h-gw-iso-l2vni-rt`).

Refs: githedgehog/internal#399

## Test plan

Pre-merge (manual on env-5 + HLAB CI):

- [ ] 5x consecutive release-test single-vpc-suite passes on env-5 / spine-leaf / l3vni
      (each invocation runs DHCP static lease → Bundled Failover, the racing sequence)
- [ ] 5x consecutive release-test single-vpc-suite passes on env-5 / mesh / l3vni
      (covers Bundled and Mesh Failover after the same DHCP static lease preamble)
- [ ] 5x consecutive h-gw-iso-l2vni-rt passes on HLAB CI
      (MCLAG Failover after DHCP static lease)
- [ ] Gate observability: `Waiting for server host routes on leaves` log line appears in runs where the race would previously have fired, with a wait time that resolves before the 3-minute deadline (HLAB serial-SSH polling can take >60s per iteration, hence the wider window); gate is not a no-op
- [ ] No regression in NAT or multi-VPC suites on env-5

Post-merge: `run-vlab-analyzer --failed-only 7` shows zero hits for `Bundled Failover DHCP Race` and `MCLAG Failover DHCP Race` over the following week.