### PR TITLE
ci(workflows): pre-warm zot binary before local-registry readiness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,8 +209,9 @@ jobs:
           LOCALREG_SYNC_USERNAME: ${{ github.actor }}
           LOCALREG_SYNC_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          just --timestamp _zot
           just --timestamp _localreg &
-          for i in $(seq 1 30); do curl -sf http://127.0.0.1:30000/v2/ > /dev/null 2>&1 && break || sleep 1; done
+          for i in $(seq 1 60); do curl -sf http://127.0.0.1:30000/v2/ > /dev/null 2>&1 && break || sleep 1; done
           curl -sf http://127.0.0.1:30000/v2/ > /dev/null 2>&1 || { echo "Local registry failed to start"; exit 1; }
           echo "Local registry is ready"
 

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -172,8 +172,9 @@ jobs:
       - name: Setup local registry
         id: setup-registry
         run: |
+          just --timestamp _zot
           just --timestamp _localreg &
-          for i in $(seq 1 30); do curl -sf http://127.0.0.1:30000/v2/ > /dev/null 2>&1 && break || sleep 1; done
+          for i in $(seq 1 60); do curl -sf http://127.0.0.1:30000/v2/ > /dev/null 2>&1 && break || sleep 1; done
           curl -sf http://127.0.0.1:30000/v2/ > /dev/null 2>&1 || { echo "Local registry failed to start"; exit 1; }
           echo "Local registry is ready"
 


### PR DESCRIPTION
## Summary

The `Setup local registry` step kicks off `just _localreg &` in the background, which (transitively via `just _zot`) wget-downloads the 40 MB zot binary on cold-cache runners. The readiness curl loop starts the same instant, and on slower runners the wget alone consumes most of the 30-second budget, tripping `Local registry failed to start` before zot serve binds the port. Observed multiple times on PR #1763's 5 release-test dispatches today, all on upgrade RT jobs (`v-up26.01-*`).

Two minimal changes per workflow:
1. Run `just _zot` synchronously *before* the background `_localreg`, so the wget time is out of the readiness window.
2. Bump the readiness loop from 30 to 60 iterations for zot-serve startup margin.

Applies to `ci.yaml` and `run-vlab.yaml`. `trivy-security-scan.yml` only does the background spawn with no readiness loop, untouched.

Refs: #1687

## Test plan

- [ ] 5x consecutive CI dispatches on PR branch with `releasetest=true` show zero "Local registry failed to start" hits
- [ ] No regression in setup-local-registry timing on warm-cache runners (should be marginally faster: `_zot` is a no-op when binary cached, then the readiness loop only waits for zot serve startup)
- [ ] `run-vlab-analyzer` shows zero hits on the tightened `Local Registry Readiness Timeout` pattern for runs after merge

Post-merge: re-evaluate whether 60s is too generous; can tighten to 45s if warm-cache runners consistently come up in <5s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# ci(workflows): pre-warm zot binary before local-registry readiness

## Overview
Addresses cold-cache startup failures in CI workflows where the zot binary download (~40 MB) was consuming most of the 30-second readiness window, causing "Local registry failed to start" errors before zot could bind its port.

## Changes
- **Pre-warm binary download**: Added synchronous `just --timestamp _zot` execution before spawning the background local registry process (`just _localreg`), ensuring the binary is cached outside the readiness window
- **Extended readiness timeout**: Increased the readiness polling loop from 30 to 60 iterations in both workflows, providing additional startup margin for zot serve
- **Files modified**:
  - `.github/workflows/ci.yaml` (bundle job, +2/-1 lines)
  - `.github/workflows/run-vlab.yaml` (+2/-1 lines)
  - `.github/workflows/trivy-security-scan.yml` (unchanged - no readiness loop present)

## Benefits
- Eliminates readiness timeouts on slow runners by decoupling binary download from readiness checks
- No performance regression on warm-cache runners (cached `_zot` becomes a no-op)
- Provides additional startup margin for zot serve on warm-cache runners while maintaining compatibility

## Testing
- Multiple consecutive CI runs with `releasetest=true` validation for zero registry startup failures
- Warm-cache performance verification (binary caching confirmed as no-op)
- Post-merge monitoring via run-vlab-analyzer to eliminate timeout occurrences and evaluate further optimization (potential reduction to 45s on consistently faster warm-cache runners)

## References
- Issue `#1687`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->