### PR TITLE
feat(vlab): detect unexpected pod restarts in fab namespace

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -362,6 +362,7 @@ jobs:
             ${{ inputs.hybrid && '--controls-restricted=false' || '' }} \
             ${{ (inputs.upgradefrom == '' && inputs.hybrid) && '--ready switch-reinstall' || '' }} \
             --ready=inspect \
+            --ready=inspect-pods \
             "${HHFAB_TEST_ARGS[@]}" \
             --ready=exit \
             ${{ inputs.pause_on_failure && inputs.debug && '--pause-on-failure' || '' }} \

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1086,6 +1086,12 @@ func Run(ctx context.Context) error {
 								Value: true,
 							},
 							&cli.BoolFlag{
+								Name:    "inspect-pods-strict",
+								Usage:   "fail the run (instead of warn) on container restarts in the fab namespace when using --ready=inspect-pods",
+								EnvVars: []string{"HHFAB_INSPECT_PODS_STRICT"},
+								Value:   false,
+							},
+							&cli.BoolFlag{
 								Name:    FlagPauseOnFailure,
 								Aliases: []string{"p"},
 								Usage:   "pause running on-ready commands or release tests on failure (for troubleshooting)",
@@ -1249,6 +1255,7 @@ func Run(ctx context.Context) error {
 									ReleaseTestRegexesInvert: c.Bool(FlagReleaseTestRegexesInvert),
 									ReleaseTestOnReadyOnly:   c.Bool(FlagReleaseTestOnReadyOnly),
 									InterfaceMTU:             ifMTU,
+									InspectPodsStrict:        c.Bool("inspect-pods-strict"),
 								},
 							}); err != nil {
 								return fmt.Errorf("running VLAB: %w", err)
@@ -1658,6 +1665,29 @@ Examples:
 								Strict:         c.Bool("strict"),
 							}); err != nil {
 								return fmt.Errorf("inspect: %w", err)
+							}
+
+							return nil
+						},
+					},
+					{
+						Name:    "inspect-pods",
+						Aliases: []string{"pods"},
+						Usage:   "check for unexpected container restarts in the fab namespace",
+						Flags: flatten(defaultFlags, []cli.Flag{
+							&cli.BoolFlag{
+								Name:    "strict",
+								Usage:   "fail (error) instead of warn if any container in the fab namespace has restarted",
+								EnvVars: []string{"HHFAB_INSPECT_PODS_STRICT"},
+								Value:   false,
+							},
+						}),
+						Before: before(false),
+						Action: func(c *cli.Context) error {
+							if err := hhfab.DoVLABInspectPods(ctx, workDir, cacheDir, hhfab.InspectPodsOpts{
+								Strict: c.Bool("strict"),
+							}); err != nil {
+								return fmt.Errorf("inspect-pods: %w", err)
 							}
 
 							return nil

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -228,6 +228,15 @@ func DoVLABInspect(ctx context.Context, workDir, cacheDir string, opts InspectOp
 	return c.Inspect(ctx, vlab, opts)
 }
 
+func DoVLABInspectPods(ctx context.Context, workDir, cacheDir string, opts InspectPodsOpts) error {
+	c, _, err := loadVLABForHelpers(ctx, workDir, cacheDir)
+	if err != nil {
+		return err
+	}
+
+	return c.InspectPods(ctx, opts)
+}
+
 func DoVLABReleaseTest(ctx context.Context, workDir, cacheDir string, opts ReleaseTestOpts) error {
 	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
 	if err != nil && !opts.ListTests {

--- a/pkg/hhfab/inspectpods.go
+++ b/pkg/hhfab/inspectpods.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	fabapi "go.githedgehog.com/fabricator/api/fabricator/v1beta1"
+	coreapi "k8s.io/api/core/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type InspectPodsOpts struct {
+	Namespace string
+	Strict    bool
+}
+
+// helm-install-* are Jobs that track helm's own retry loop, not real restarts.
+const helmInstallPrefix = "helm-install-"
+
+type containerRestart struct {
+	pod        string
+	container  string
+	restarts   int32
+	lastReason string
+}
+
+func (c *Config) InspectPods(ctx context.Context, opts InspectPodsOpts) error {
+	if opts.Namespace == "" {
+		opts.Namespace = fabapi.FabNamespace
+	}
+
+	slog.Info("Inspecting pods for restarts", "namespace", opts.Namespace, "strict", opts.Strict)
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	cacheCancel, kube, err := getKubeClientWithCache(ctx, c.WorkDir)
+	if err != nil {
+		return fmt.Errorf("creating kube client: %w", err)
+	}
+	defer cacheCancel()
+
+	pods := &coreapi.PodList{}
+	if err := kube.List(ctx, pods, kclient.InNamespace(opts.Namespace)); err != nil {
+		return fmt.Errorf("listing pods in namespace %q: %w", opts.Namespace, err)
+	}
+
+	var restarts []containerRestart
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, helmInstallPrefix) {
+			continue
+		}
+
+		var statuses []coreapi.ContainerStatus
+		statuses = append(statuses, pod.Status.InitContainerStatuses...)
+		statuses = append(statuses, pod.Status.ContainerStatuses...)
+		for _, cs := range statuses {
+			if cs.RestartCount == 0 {
+				continue
+			}
+
+			lastReason := ""
+			if cs.LastTerminationState.Terminated != nil {
+				lastReason = cs.LastTerminationState.Terminated.Reason
+			}
+
+			restarts = append(restarts, containerRestart{
+				pod:        pod.Name,
+				container:  cs.Name,
+				restarts:   cs.RestartCount,
+				lastReason: lastReason,
+			})
+		}
+	}
+
+	if len(restarts) == 0 {
+		slog.Info("No container restarts detected", "namespace", opts.Namespace)
+
+		return nil
+	}
+
+	slices.SortFunc(restarts, func(a, b containerRestart) int {
+		return strings.Compare(a.pod+"/"+a.container, b.pod+"/"+b.container)
+	})
+
+	logf := slog.Warn
+	if opts.Strict {
+		logf = slog.Error
+	}
+
+	logf("Detected unexpected container restarts", "namespace", opts.Namespace, "containers", len(restarts))
+	for _, r := range restarts {
+		logf("Container restarted", "pod", r.pod, "container", r.container, "restarts", r.restarts, "lastReason", r.lastReason)
+	}
+
+	if opts.Strict {
+		return fmt.Errorf("found %d container(s) with restarts in namespace %q", len(restarts), opts.Namespace) //nolint:err113
+	}
+
+	return nil
+}

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -110,6 +110,7 @@ type VLABRunOpts struct {
 	ReleaseTestRegexesInvert bool
 	ReleaseTestOnReadyOnly   bool
 	InterfaceMTU             uint16
+	InspectPodsStrict        bool
 }
 
 type OnReady string
@@ -122,6 +123,7 @@ const (
 	OnReadyTestConnectivity OnReady = "test-connectivity"
 	OnReadyWait             OnReady = "wait"
 	OnReadyInspect          OnReady = "inspect"
+	OnReadyInspectPods      OnReady = "inspect-pods"
 	OnReadyReleaseTest      OnReady = "release-test"
 )
 
@@ -133,6 +135,7 @@ var AllOnReady = []OnReady{
 	OnReadyTestConnectivity,
 	OnReadyWait,
 	OnReadyInspect,
+	OnReadyInspectPods,
 	OnReadyReleaseTest,
 }
 
@@ -143,6 +146,7 @@ var fromShortOnReadyMap = map[string]OnReady{
 	"conns":     OnReadyTestConnectivity,
 	"wait":      OnReadyWait,
 	"inspect":   OnReadyInspect,
+	"pods":      OnReadyInspectPods,
 	"rt":        OnReadyReleaseTest,
 }
 
@@ -752,6 +756,14 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 					slog.Debug("Running inspect", "opts", inspectOpts)
 					if err := c.Inspect(ctx, vlab, inspectOpts); err != nil {
 						return c.handleShutdownWithPause(ctx, vlab, opts, fmt.Errorf("inspecting: %w", err))
+					}
+				case OnReadyInspectPods:
+					inspectPodsOpts := InspectPodsOpts{
+						Strict: opts.InspectPodsStrict,
+					}
+					slog.Debug("Running inspect-pods", "opts", inspectPodsOpts)
+					if err := c.InspectPods(ctx, inspectPodsOpts); err != nil {
+						return c.handleShutdownWithPause(ctx, vlab, opts, fmt.Errorf("inspecting pods: %w", err))
 					}
 				case OnReadyReleaseTest:
 					releaseTestOpts := ReleaseTestOpts{


### PR DESCRIPTION
Detects unexpected container restarts in the `fab` namespace and can fail the run. Addresses githedgehog/internal#379 (CI-enforcement slice of githedgehog/internal#363).

Lists pods in `fab` and flags any container with `restartCount > 0`, excluding `helm-install-*` jobs (those track helm's own retry loop, not real restarts).

New `hhfab vlab inspect-pods [--strict]` command plus a `--ready=inspect-pods` hook. A toggle controls severity: default logs WRN and exits 0; `--strict` (or `HHFAB_INSPECT_PODS_STRICT=true`, or `vlab up --inspect-pods-strict`) logs ERR and fails. Wired non-strict into `run-vlab.yaml` so CI warns now without breaking on the known gateway dataplane restarts (githedgehog/dataplane#1526); flipping to strict later is a one-line yaml change.

Verified on a live env-5 VLAB:

```
WRN Detected unexpected container restarts namespace=fab containers=3
WRN Container restarted pod=fab-node-config-sdg6x container=config restarts=2 lastReason=Error
WRN Container restarted pod=gw--gateway-1--dataplane-xz6jf container=dataplane restarts=3 lastReason=Error
WRN Container restarted pod=gw--gateway-2--dataplane-6nvnh container=dataplane restarts=3 lastReason=Error
```

Non-strict exits 0, `--strict` exits 1, and all `helm-install-*` jobs are excluded despite nonzero restart counts.

Follow-up: enable `--inspect-pods-strict` in CI once githedgehog/dataplane#1526 and #1779 close.
