### PR TITLE
feat(hhfab): collect native SONiC tech-support tarballs (refs #1760)

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -97,6 +97,11 @@ on:
         type: boolean
         required: false
         default: false
+      collect_sonic_techsupport:
+        description: "On failure paths, also collect native SONiC tech-support tarballs"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -108,6 +113,7 @@ env:
   HHFAB_REG_REPO: 127.0.0.1:30000
   HHFAB_VLAB_COLLECT: true
   HHFAB_VLAB_COLLECT_FORCE: ${{ inputs.collect_show_tech }}
+  HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT: ${{ inputs.collect_sonic_techsupport }}
 
 jobs:
   run:

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1863,6 +1863,25 @@ Examples:
 								},
 							},
 							{
+								Name:  "show-tech",
+								Usage: "collect native SONiC tech-support tarballs from switches (if no switches specified, all switches will be targeted)",
+								Flags: flatten(defaultFlags, []cli.Flag{
+									&cli.StringSliceFlag{
+										Name:    "switch",
+										Aliases: []string{"s"},
+										Usage:   "switch name to collect tech-support from (repeatable)",
+									},
+								}),
+								Before: before(false),
+								Action: func(c *cli.Context) error {
+									if err := hhfab.DoSonicShowTech(ctx, workDir, cacheDir, c.StringSlice("switch")); err != nil {
+										return fmt.Errorf("sonic show-tech: %w", err)
+									}
+
+									return nil
+								},
+							},
+							{
 								Name:  "power",
 								Usage: "manage switch power state using the PDU (if no switches specified, all switches will be affected)",
 								Flags: flatten(pduFlags, []cli.Flag{

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -183,6 +183,17 @@ func DoShowTech(ctx context.Context, workDir, cacheDir string) error {
 	return c.VLABShowTech(ctx, vlab, ShowTechOpts{})
 }
 
+func DoSonicShowTech(ctx context.Context, workDir, cacheDir string, switches []string) error {
+	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
+	if err != nil {
+		return err
+	}
+
+	outDir := filepath.Join(workDir, "sonic-techsupport")
+
+	return c.CollectSonicTechsupport(ctx, vlab, switches, outDir)
+}
+
 func DoVLABSetupVPCs(ctx context.Context, workDir, cacheDir string, opts SetupVPCsOpts) error {
 	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
 	if err != nil {

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -1073,7 +1073,7 @@ func (testCtx *VPCPeeringTestCtx) collectDiagnosticsOnFailure(ctx context.Contex
 	slog.Info("Collecting diagnostics for failed test", "suite", suiteName, "test", testName, "output", testDir)
 
 	// Collect show-tech from VMs and switches using existing VLABShowTech
-	if err := testCtx.vlabCfg.VLABShowTech(ctx, testCtx.vlab, ShowTechOpts{OutputDir: testDir}); err != nil {
+	if err := testCtx.vlabCfg.VLABShowTech(ctx, testCtx.vlab, ShowTechOpts{OutputDir: testDir, OnFailure: true}); err != nil {
 		slog.Warn("Failed to collect show-tech diagnostics", "err", err)
 	} else {
 		slog.Info("Diagnostics collected successfully", "path", testDir)

--- a/pkg/hhfab/sonictechsupport.go
+++ b/pkg/hhfab/sonictechsupport.go
@@ -10,12 +10,19 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 )
+
+// EnvCollectSonicTechsupport opts the failure-path debug bundle into
+// collecting native SONiC tech-support tarballs. Unset or "false" means the
+// expensive collection is skipped even on failure; the manual CLI
+// `hhfab vlab switch show-tech` is unaffected.
+const EnvCollectSonicTechsupport = "HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT"
 
 const (
 	sonicTechsupportPerSwitchTimeout = 45 * time.Minute
@@ -25,6 +32,12 @@ const (
 	sonicTechsupportStartedMarker    = "tech-support process started"
 	sonicTechsupportInProgressMarker = "in progress"
 )
+
+func envCollectSonicTechsupport() bool {
+	v, _ := strconv.ParseBool(os.Getenv(EnvCollectSonicTechsupport))
+
+	return v
+}
 
 // Matches the tarball path SONiC emits in the status output, for example
 // /var/dump/sonic_dump_ds5000-01_20260530_120000.tar.gz.

--- a/pkg/hhfab/sonictechsupport.go
+++ b/pkg/hhfab/sonictechsupport.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+)
+
+const (
+	sonicTechsupportPerSwitchTimeout = 45 * time.Minute
+	sonicTechsupportPollInterval     = 15 * time.Second
+	sonicTechsupportStartCmd         = `sonic-cli -c "show tech-support"`
+	sonicTechsupportStatusCmd        = `sonic-cli -c "show tech-support status"`
+	sonicTechsupportStartedMarker    = "tech-support process started"
+	sonicTechsupportInProgressMarker = "in progress"
+)
+
+// Matches the tarball path SONiC emits in the status output, for example
+// /var/dump/sonic_dump_ds5000-01_20260530_120000.tar.gz.
+var sonicTechsupportDumpPathRE = regexp.MustCompile(`/var/dump/sonic_dump_[^\s"']+\.tar\.gz`)
+
+// CollectSonicTechsupport runs the native SONiC `show tech-support` on each
+// target switch, polls until completion, and downloads the resulting tarball
+// to outDir. VM switches accept the same sonic-cli command, but Broadcom
+// vendor support will only accept dumps captured from hardware switches.
+// Per-switch failures are logged as warnings and do not fail the call;
+// only outDir creation or kube listing errors are propagated.
+func (c *Config) CollectSonicTechsupport(
+	ctx context.Context,
+	vlab *VLAB,
+	switchNames []string,
+	outDir string,
+) error {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("creating sonic tech-support output directory: %w", err)
+	}
+
+	targets := switchNames
+	if len(targets) == 0 {
+		switches := wiringapi.SwitchList{}
+		if err := c.Client.List(ctx, &switches); err != nil {
+			return fmt.Errorf("listing switches: %w", err)
+		}
+		targets = make([]string, 0, len(switches.Items))
+		for _, sw := range switches.Items {
+			targets = append(targets, sw.Name)
+		}
+	}
+
+	if len(targets) == 0 {
+		slog.Info("No switches to collect SONiC tech-support from")
+
+		return nil
+	}
+
+	slog.Info("Collecting SONiC tech-support", "switches", targets, "outDir", outDir)
+
+	var wg sync.WaitGroup
+	for _, name := range targets {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.collectSonicTechsupportOne(ctx, vlab, name, outDir)
+		}()
+	}
+	wg.Wait()
+
+	return nil
+}
+
+func (c *Config) collectSonicTechsupportOne(ctx context.Context, vlab *VLAB, name, outDir string) {
+	swCtx, cancel := context.WithTimeout(ctx, sonicTechsupportPerSwitchTimeout)
+	defer cancel()
+
+	ssh, err := c.SSH(swCtx, vlab, name)
+	if err != nil {
+		slog.Warn("SONiC tech-support: ssh config unavailable", "switch", name, "err", err)
+
+		return
+	}
+
+	stdout, stderr, err := ssh.Run(swCtx, sonicTechsupportStartCmd)
+	if err != nil {
+		slog.Warn("SONiC tech-support: start command failed", "switch", name, "err", err, "stderr", stderr)
+
+		return
+	}
+	if !strings.Contains(strings.ToLower(stdout), sonicTechsupportStartedMarker) {
+		slog.Warn("SONiC tech-support: unexpected start response", "switch", name, "stdout", stdout)
+
+		return
+	}
+
+	remotePath, err := pollSonicTechsupportStatus(swCtx, ssh, name)
+	if err != nil {
+		slog.Warn("SONiC tech-support: polling status failed", "switch", name, "err", err)
+
+		return
+	}
+
+	localPath := filepath.Join(outDir, name+"-sonic-techsupport.tar.gz")
+	if err := ssh.DownloadPath(remotePath, localPath); err != nil {
+		slog.Warn("SONiC tech-support: download failed", "switch", name, "remote", remotePath, "err", err)
+
+		return
+	}
+
+	slog.Info("SONiC tech-support collected", "switch", name, "path", localPath)
+}
+
+// pollSonicTechsupportStatus polls until the dump path appears in the status
+// output. It returns the remote tarball path or an error if the context
+// expires, ssh fails, or the status output never advertises the path.
+func pollSonicTechsupportStatus(ctx context.Context, ssh interface {
+	Run(ctx context.Context, cmd string) (string, string, error)
+}, name string,
+) (string, error) {
+	ticker := time.NewTicker(sonicTechsupportPollInterval)
+	defer ticker.Stop()
+
+	for {
+		stdout, stderr, err := ssh.Run(ctx, sonicTechsupportStatusCmd)
+		if err != nil {
+			return "", fmt.Errorf("status command: %w (stderr=%q)", err, stderr)
+		}
+
+		lower := strings.ToLower(stdout)
+		match := sonicTechsupportDumpPathRE.FindString(stdout)
+		if !strings.Contains(lower, sonicTechsupportInProgressMarker) && match != "" {
+			return match, nil
+		}
+
+		slog.Debug("SONiC tech-support still running", "switch", name, "status", strings.TrimSpace(stdout))
+
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("context done while waiting for tech-support: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -700,6 +700,11 @@ func (c *Config) prepareShowTechVMConsoleScript(vmType, script string) (func(), 
 type ShowTechOpts struct {
 	// If empty, defaults to WorkDir/show-tech-output.
 	OutputDir string
+	// OnFailure marks this invocation as part of failure handling. It gates
+	// auxiliary collection that is too expensive to run on every success
+	// (currently: SONiC tech-support tarballs, additionally gated by env var
+	// HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT).
+	OnFailure bool
 }
 
 func (c *Config) VLABShowTech(ctx context.Context, vlab *VLAB, opts ShowTechOpts) error {
@@ -885,11 +890,13 @@ func (c *Config) VLABShowTech(ctx context.Context, vlab *VLAB, opts ShowTechOpts
 
 	slog.Info("Show tech files saved in", "folder", outDir)
 
-	// Phase A: always-on collection of native SONiC tech-support tarballs for
-	// Broadcom vendor escalation (issue #1760). Failures here must not turn
-	// an otherwise-successful run into a failure.
-	if err := c.CollectSonicTechsupport(ctx, vlab, nil, filepath.Join(outDir, "sonic-techsupport")); err != nil {
-		slog.Warn("Failed to collect SONiC tech-support", "err", err)
+	// Collect SONiC tech-support tarballs for Broadcom vendor escalation
+	// (issue #1760), only on failure paths and only when the env var opts
+	// in. Manual `hhfab vlab switch show-tech` is the unconditional path.
+	if opts.OnFailure && envCollectSonicTechsupport() {
+		if err := c.CollectSonicTechsupport(ctx, vlab, nil, filepath.Join(outDir, "sonic-techsupport")); err != nil {
+			slog.Warn("Failed to collect SONiC tech-support", "err", err)
+		}
 	}
 
 	return nil
@@ -1234,7 +1241,7 @@ func (c *Config) CollectVLABDebug(ctx context.Context, vlab *VLAB, opts VLABRunO
 	}
 
 	if (opts.CollectShowTech && forceShowTech) || opts.ForceCollectShowTech {
-		if err := c.VLABShowTech(ctx, vlab, ShowTechOpts{}); err != nil {
+		if err := c.VLABShowTech(ctx, vlab, ShowTechOpts{OnFailure: forceShowTech}); err != nil {
 			slog.Warn("Failed to collect show-tech diagnostics", "err", err)
 		}
 	}

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -885,6 +885,13 @@ func (c *Config) VLABShowTech(ctx context.Context, vlab *VLAB, opts ShowTechOpts
 
 	slog.Info("Show tech files saved in", "folder", outDir)
 
+	// Phase A: always-on collection of native SONiC tech-support tarballs for
+	// Broadcom vendor escalation (issue #1760). Failures here must not turn
+	// an otherwise-successful run into a failure.
+	if err := c.CollectSonicTechsupport(ctx, vlab, nil, filepath.Join(outDir, "sonic-techsupport")); err != nil {
+		slog.Warn("Failed to collect SONiC tech-support", "err", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- New `pkg/hhfab/sonictechsupport.go`: `CollectSonicTechsupport` SSHes each switch, runs `sonic-cli -c "show tech-support"`, polls status every 15s, and sftp's the resulting `/var/dump/sonic_dump_*.tar.gz` back to `<outDir>/sonic-techsupport/<switch>-sonic-techsupport.tar.gz`. Per-switch goroutines, 45 min hard cap each, best-effort (per-switch failures warn, never propagate).
- New CLI command `hhfab vlab switch show-tech [--switch NAME]...` for manual, unconditional collection (defaults to all switches).
- `VLABShowTech` collects these tarballs only on failure paths (`ShowTechOpts.OnFailure`) and only when `HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT` is truthy, so successful CI runs do not pay the multi-minute dump cost.
- `run-vlab.yaml` gains a `collect_sonic_techsupport` `workflow_call` input (default `false`) wired to that env var, mirroring how `collect_show_tech` drives `HHFAB_VLAB_COLLECT_FORCE`.

## Why
Issue #1760 (server-uplink LLDP missing on breakout subports) is a Broadcom SONiC defect. Vendor escalation needs native `show tech-support` dumps from the affected switches captured at failure time, which the existing show-tech bundle does not produce.

## Activation
Off by default. The input lives only on the reusable `run-vlab.yaml` (`workflow_call`, no input cap), not on the `custom-vlab.yaml` dispatch UI (already at GitHub's 10-input limit). A caller opts a specific env in by passing `collect_sonic_techsupport: true`; lab-ci wiring for the envs of interest is a follow-up.

## Notes
- The manual `hhfab vlab switch show-tech` path is unconditional and unaffected by the env var.
- Collection is identical and harmless on VM switches; Broadcom only accepts hardware dumps, so trigger it on hybrid/hardware envs.