### PR TITLE
build(deps): bump go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.githedgehog.com/fabricator
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/diskfs/go-diskfs => github.com/Frostman/go-diskfs v1.4.2-hh3
 


### PR DESCRIPTION
Fixes vulns found in https://github.com/githedgehog/fabricator/actions/runs/26898547404/job/79344249853

```
Unexpected vulnerabilities found (not in dismissed list):
GO-2026-5037
GO-2026-5038
GO-2026-5039
```