### PR TITLE
ci: add Docker readiness check to run-vlab workflow

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -120,6 +120,15 @@ jobs:
         run: |
           echo "$KUBE_NODE"
 
+      - name: Docker readiness check
+        run: |
+          for i in $(seq 1 30); do
+            docker info > /dev/null 2>&1 && echo "Docker ready after ${i}s" && break
+            echo "Waiting for Docker... ${i}s"
+            sleep 1
+          done
+          docker info
+
       - name: Inputs summary
         run: |
           echo "Inputs:"


### PR DESCRIPTION
Polls `docker info` up to 30s at job start and prints the daemon state, so future DinD failures self-report wait duration in the job log.

Related to: https://github.com/githedgehog/fabricator/issues/1742