### PR TITLE
fix(ci): skip on-ready test on hlab runs

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -337,7 +337,7 @@ jobs:
                 HHFAB_TEST_ARGS+=(--release-test-regexes-invert)
               fi
             fi
-          elif [[ -n "${{ inputs.upgradefrom }}" ]]; then
+          elif [[ "${{ inputs.hybrid }}" == "true" || -n "${{ inputs.upgradefrom }}" ]]; then
             HHFAB_TEST_ARGS=(--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity)
           else
             HHFAB_TEST_ARGS+=(--release-test-on-ready-only)


### PR DESCRIPTION
On hlab the topology is a fixed physical wiring that does not match the server/switch layout the on-ready test requires (unbundled non-MCLAG server + two non-MCLAG leaves with disjoint server sets). Fall back to the same setup-vpcs/setup-peerings/test-connectivity path already used for upgrade runs.

Fixes #1795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the CI workflow to skip the on-ready test on hlab runs by modifying the readiness test selection logic in the `test-current` job.

## Changes

**`.github/workflows/run-vlab.yaml`**

Modified the branching condition for selecting readiness test arguments. When `releasetest` is not enabled, the workflow now skips the on-ready test for both upgrade runs and hlab (hybrid) runs, falling back to the `setup-vpcs`, `setup-peerings`, and `test-connectivity` readiness steps.

Previously, this readiness path was only used for upgrade runs. The change adds `hybrid=true` as an additional condition to trigger this path, which is necessary because hlab's fixed physical wiring topology does not support the server/switch layout required by the on-ready test.

**Type:** fix
**References:** Fixes `#1795`

Lines changed: +1/-1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->