### PR TITLE
fix: more remote peering deprecation

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1461,11 +1461,11 @@ Examples:
 
 							Example command:
 
-							$ hhfab vlab setup-peerings 1+2 2+4:r=border 1~as5835 2~as5835:subnets=sub1,sub2:prefixes=0.0.0.0/0,22.22.22.0/24
+							$ hhfab vlab setup-peerings 1+2 2+4 1~as5835 2~as5835:subnets=sub1,sub2:prefixes=0.0.0.0/0,22.22.22.0/24
 
 							Which will produce:
 							1. VPC peering between vpc-01 and vpc-02
-							2. Remote VPC peering between vpc-02 and vpc-04 on switch group named border
+							2. VPC peering between vpc-02 and vpc-04
 							3. External peering for vpc-01 with External as5835 with default vpc subnet and any routes from external permitted
 							4. External peering for vpc-02 with External as5835 with subnets sub1 and sub2 exposed from vpc-02 and default route
 							   from external permitted as well any route that belongs to 22.22.22.0/24
@@ -1475,9 +1475,6 @@ Examples:
 							1+2 -- VPC peering between vpc-01 and vpc-02
 							1+2:gw -- same as above but using gateway peering, only valid if gateway is present
 							demo-1+demo-2 -- VPC peering between vpc-demo-1 and vpc-demo-2
-							1+2:r -- remote VPC peering between vpc-01 and vpc-02 on switch group if only one switch group is present
-							1+2:r=border -- remote VPC peering between vpc-01 and vpc-02 on switch group named border
-							1+2:remote=border -- same as above
 
 							External Peerings:
 

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -1177,11 +1177,6 @@ func (c *Config) SetupPeerings(ctx context.Context, vlab *VLAB, opts SetupPeerin
 		externals[ext.Name] = &ext
 	}
 
-	switchGroupList := &wiringapi.SwitchGroupList{}
-	if err := kube.List(ctx, switchGroupList); err != nil {
-		return fmt.Errorf("listing switch groups: %w", err)
-	}
-
 	// NAT parsing helpers. These options are only meaningful for gateway peerings.
 	type natType string
 	const (
@@ -1407,7 +1402,6 @@ func (c *Config) SetupPeerings(ctx context.Context, vlab *VLAB, opts SetupPeerin
 				vpc2 = "vpc-" + vpc2
 			}
 
-			remote := ""
 			gw := false
 			vpc1Subnets := []string{}
 			vpc2Subnets := []string{}
@@ -1423,17 +1417,7 @@ func (c *Config) SetupPeerings(ctx context.Context, vlab *VLAB, opts SetupPeerin
 					optValue = parts[1]
 				}
 
-				if optName == "r" || optName == "remote" {
-					if optValue == "" {
-						if len(switchGroupList.Items) != 1 {
-							return fmt.Errorf("invalid VPC peering option #%d %s, auto switch group only supported when it's exactly one switch group", idx, option)
-						}
-
-						remote = switchGroupList.Items[0].Name
-					} else {
-						remote = optValue
-					}
-				} else if optName == "gw" || optName == "gateway" {
+				if optName == "gw" || optName == "gateway" {
 					gw = true
 				} else if optName == "vpc1" || optName == "vpc1-subnets" {
 					vpc1Subnets = strings.Split(optValue, ",")
@@ -1513,13 +1497,8 @@ func (c *Config) SetupPeerings(ctx context.Context, vlab *VLAB, opts SetupPeerin
 							},
 						},
 					},
-					Remote: remote,
 				}
 			} else {
-				if remote != "" {
-					return fmt.Errorf("gateway peering cannot be remote")
-				}
-
 				// Build each side's expose for the "real" VPC prefixes.
 				vpc1Expose := gwapi.PeeringEntryExpose{}
 				if vpc, ok := vpcs[vpc1]; ok {
@@ -1904,7 +1883,7 @@ func DoSetupPeerings(ctx context.Context, kube client.Client, vpcPeerings map[st
 		}
 
 		slog.Info("Enforcing VPCPeering", "name", name,
-			"vpc1", vpc1, "vpc2", vpc2, "remote", vpcPeeringSpec.Remote)
+			"vpc1", vpc1, "vpc2", vpc2)
 
 		vpcPeering := &vpcapi.VPCPeering{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2643,17 +2622,6 @@ func IsSubnetReachableWithSwitchPeering(ctx context.Context, kube kclient.Reader
 	}
 
 	for _, vpcPeering := range vpcPeerings.Items {
-		if vpcPeering.Spec.Remote != "" {
-			notEmpty, err := apiutil.IsVPCPeeringRemoteNotEmpty(ctx, kube, &vpcPeering)
-			if err != nil {
-				return Reachability{}, fmt.Errorf("failed to check if VPC peering %s has non-empty remote: %w", vpcPeering.Name, err)
-			}
-
-			if !notEmpty {
-				continue
-			}
-		}
-
 		for _, permit := range vpcPeering.Spec.Permit {
 			vpc1Permit, exist := permit[vpc1Name]
 			if !exist {


### PR DESCRIPTION
remove some extra things that I missed on the first pass

part of https://github.com/githedgehog/fabric/issues/1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## fix: more remote peering deprecation

Remove additional remote peering references missed in the initial deprecation pass.

### Changes

- **cmd/hhfab/main.go**: Updated `hhfab vlab setup-peerings` command help text to remove remote VPC peering examples and the documentation section listing remote VPC peering syntax variants (e.g., `:r` / `remote=` like `2+4:r=border`). The example now shows only standard VPC peering between `vpc-02` and `vpc-04` and gateway peerings with `:gw`.

- **pkg/hhfab/testing.go**: Removed remote peering handling from testing utilities:
  - Eliminated parsing of `remote`/`r` request option in `SetupPeerings`.
  - Removed assignment of `Remote` on `VPCPeeringSpec`.
  - Updated `DoSetupPeerings` logging to exclude the `remote` value.
  - Simplified `IsSubnetReachableWithSwitchPeering` by removing early filtering for peering specs with a non-empty `Remote`; reachability is now determined only by `Permit` entries.

Part of https://github.com/githedgehog/fabric/issues/1327
<!-- end of auto-generated comment: release notes by coderabbit.ai -->