### PR TITLE
fix(rt): gate pings on EVPN host-route convergence after DHCP churn

### DIFF
--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -305,6 +305,41 @@ func shutDownLinkAndTest(ctx context.Context, testCtx *VPCPeeringTestCtx, link w
 	return DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts)
 }
 
+// getServerVPCAndVRF returns the VPC name and VRF name for the given server by looking up its
+// VPCAttachment. Returns ("", "", nil) if the server has no VPC attachment or the VPC uses L2VNI
+// mode (where host routes are not installed as /32 entries in the IP route table).
+func getServerVPCAndVRF(ctx context.Context, kube kclient.Client, serverName string) (string, string, error) {
+	conns := &wiringapi.ConnectionList{}
+	if err := kube.List(ctx, conns, wiringapi.MatchingLabelsForListLabelServer(serverName)); err != nil {
+		return "", "", fmt.Errorf("listing connections for server %q: %w", serverName, err)
+	}
+	for _, conn := range conns.Items {
+		attaches := &vpcapi.VPCAttachmentList{}
+		if err := kube.List(ctx, attaches, kclient.MatchingLabels{wiringapi.LabelConnection: conn.Name}); err != nil {
+			return "", "", fmt.Errorf("listing vpc attachments for connection %q: %w", conn.Name, err)
+		}
+		if len(attaches.Items) == 0 {
+			continue
+		}
+		vpcName := attaches.Items[0].Spec.VPCName()
+		vpc := &vpcapi.VPC{}
+		if err := kube.Get(ctx, kclient.ObjectKey{Name: vpcName, Namespace: kmetav1.NamespaceDefault}, vpc); err != nil {
+			return "", "", fmt.Errorf("getting vpc %q: %w", vpcName, err)
+		}
+		if vpc.Spec.Mode == vpcapi.VPCModeL2VNI {
+			return "", "", nil
+		}
+		vrfName := "VrfV" + vpcName
+		if vpc.Spec.Mode == vpcapi.VPCModeL3Flat {
+			vrfName = defaultVRFName
+		}
+
+		return vpcName, vrfName, nil
+	}
+
+	return "", "", nil
+}
+
 // getSwitchesForVPC returns the set of leaf switch names that have VPCAttachments for the given VPC.
 func getSwitchesForVPC(ctx context.Context, kube kclient.Client, vpcName string) (map[string]bool, error) {
 	attachments := &vpcapi.VPCAttachmentList{}

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -2054,6 +2054,105 @@ type TestConnectivityOpts struct {
 	RequireAllServers bool
 }
 
+// waitForServerHostRoutesInLeaves waits up to 60 s for each server's host /32 to appear in the
+// FIB of every leaf attached to that server's VPC. Without this gate, EVPN type-5 propagation
+// may still be in flight when pings start after a DHCP-churning step, causing spurious failures.
+func (c *Config) waitForServerHostRoutesInLeaves(ctx context.Context, vlab *VLAB, kube kclient.Client, serverIDs map[string]uint64, ips *sync.Map) error {
+	const timeout = 60 * time.Second
+
+	type vpcEntry struct {
+		vrfName string
+		leaves  map[string]bool
+		routes  []string
+	}
+	byVPC := map[string]*vpcEntry{}
+
+	for serverName := range serverIDs {
+		ipR, ok := ips.Load(serverName)
+		if !ok {
+			continue
+		}
+		hostRoute := ipR.(netip.Prefix).Addr().String() + "/32"
+
+		vpcName, vrfName, err := getServerVPCAndVRF(ctx, kube, serverName)
+		if err != nil {
+			return err
+		}
+		if vpcName == "" {
+			continue
+		}
+
+		entry, exists := byVPC[vpcName]
+		if !exists {
+			leaves, err := getSwitchesForVPC(ctx, kube, vpcName)
+			if err != nil {
+				return fmt.Errorf("getting switches for vpc %s: %w", vpcName, err)
+			}
+			if len(leaves) == 0 {
+				continue
+			}
+			entry = &vpcEntry{vrfName: vrfName, leaves: leaves}
+			byVPC[vpcName] = entry
+		}
+		entry.routes = append(entry.routes, hostRoute)
+	}
+
+	if len(byVPC) == 0 {
+		return nil
+	}
+
+	sshs := map[string]*sshutil.Config{}
+	for _, entry := range byVPC {
+		for sw := range entry.leaves {
+			if _, exists := sshs[sw]; exists {
+				continue
+			}
+			ssh, err := c.SSH(ctx, vlab, sw)
+			if err != nil {
+				return fmt.Errorf("getting ssh for switch %s: %w", sw, err)
+			}
+			sshs[sw] = ssh
+		}
+	}
+
+	toCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for vpcName, entry := range byVPC {
+		slog.Info("Waiting for host routes in leaves", "vpc", vpcName, "routes", entry.routes, "leaves", entry.leaves)
+		for {
+			allFound := true
+			for sw := range entry.leaves {
+				for _, route := range entry.routes {
+					found, err := checkRouteInSwitch(toCtx, sshs[sw], sw, route, entry.vrfName)
+					if err != nil {
+						return fmt.Errorf("checking route %s in switch %s vrf %s: %w", route, sw, entry.vrfName, err)
+					}
+					if !found {
+						slog.Debug("Host route not yet in leaf", "switch", sw, "route", route, "vrf", entry.vrfName)
+						allFound = false
+						break
+					}
+				}
+				if !allFound {
+					break
+				}
+			}
+			if allFound {
+				slog.Debug("All host routes confirmed in leaves", "vpc", vpcName)
+				break
+			}
+			select {
+			case <-toCtx.Done():
+				return fmt.Errorf("timeout waiting for host routes %v in leaves %v (vpc %s)", entry.routes, entry.leaves, vpcName) //nolint:goerr113
+			case <-time.After(5 * time.Second):
+			}
+		}
+	}
+
+	return nil
+}
+
 func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConnectivityOpts) error {
 	if opts.PingsCount == 0 && opts.IPerfsSeconds == 0 && opts.CurlsCount == 0 {
 		return fmt.Errorf("at least one of pings, iperfs or curls should be enabled")
@@ -2230,6 +2329,10 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("discovering server IPs: %w", err)
+	}
+
+	if err := c.waitForServerHostRoutesInLeaves(ctx, vlab, kube, serverIDs, &ips); err != nil {
+		return fmt.Errorf("waiting for host routes: %w", err)
 	}
 
 	slog.Info("Running pings, iperfs and curls", "servers", len(servers.Items))


### PR DESCRIPTION
Fixes githedgehog/internal#399.

After discovering server IPs, wait up to 60 s for each server's /32 host route to appear in the FIB of every attached leaf before issuing pings. Eliminates the race between DHCP-fresh IPs and EVPN type-5 propagation that caused Bundled/Mesh/MCLAG Failover failures.

See the issue for root cause analysis and evidence.