### PR TITLE
chore: disable acpi-pci-hotplug

### DIFF
--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -457,6 +457,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 				"-monitor", fmt.Sprintf("unix:%s,server,nowait", VLABMonSock),
 				"-qmp", fmt.Sprintf("unix:%s,server,nowait", VLABQMPSock),
 				"-global", "ICH9-LPC.disable_s3=1",
+				"-global", "ICH9-LPC.acpi-pci-hotplug-with-bridge-support=off",
 			}
 
 			// TODO fix by copying system OVMF?


### PR DESCRIPTION
Adding this option to qemu will stop qemu from showing all bridges on the system as hotplug. Without hotplug bridges, systemd / udev nic naming policy v257 won't find the firmware_node/sun file in the kernel sysfs, which means the naming policy will fallback to path naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a QEMU `-global` setting to disable ACPI PCI hotplug with bridge support on virtual lab instances. This prevents QEMU from presenting all bridges as hotplug devices, which allows systemd/udev NIC naming policy v257 to fall back to path-based naming instead of relying on the firmware_node/sun file in kernel sysfs.

## Changes

**pkg/hhfab/vlabrunner.go**
- Added QEMU global option `ICH9-LPC.acpi-pci-hotplug-with-bridge-support=off` to the virtual machine startup configuration in the `VLABRun` method

Lines: +1/-0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->