### PR TITLE
chore: remove mclag from upgrade job wiring

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -190,7 +190,7 @@ jobs:
             --fabric-mode=${{ inputs.fabricmode }} \
             --include-onie=${{ inputs.includeonie }} \
             --gateway=${{ inputs.gateway }}
-          old/hhfab vlab gen -v ${{ inputs.mesh && '--mesh-links-count=3' || '' }}
+          old/hhfab vlab gen -v --eslag-leaf-groups="2,2" --orphan-leafs-count=1 ${{ inputs.mesh && '--mesh-links-count=3' || '' }}
 
       - name: (${{ inputs.upgradefrom }}) Init hhfab for hybrid mode
         if: ${{ inputs.upgradefrom != '' && inputs.hybrid }}


### PR DESCRIPTION
there is no clean way to make the upgrade job not fail if there are mclag switches in the topology; we are ensuring that the fabric can come up so that users can remove the configuration, but CI testing requires more than that. so just remove mclag leaves from the topology in upgrade jobs and replace them with eslag leaves.

Part of #1521 