### PR TITLE
chore: deny upgrade with deprecated mclag/remote peer

### DIFF
--- a/pkg/fab/recipe/control_upgrade.go
+++ b/pkg/fab/recipe/control_upgrade.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -19,6 +20,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	helmapi "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
 	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
+	"go.githedgehog.com/fabric/api/meta"
 	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 	"go.githedgehog.com/fabric/pkg/util/kubeutil"
@@ -239,6 +241,56 @@ func (c *ControlUpgrade) checkUpgradeConstraints(ctx context.Context, kube kclie
 				return fmt.Errorf("agent %s NOS version %s does not satisfy constraint %s", ag.Name, nosVersion, fabNOSConstr) //nolint:err113
 			}
 		}
+	}
+
+	// refuse upgrade if there is any MCLAG switch or connection
+	var switches wiringapi.SwitchList
+	mclagSwitches := []string{}
+	if err := kube.List(ctx, &switches); err != nil {
+		return fmt.Errorf("listing switches: %w", err)
+	}
+	for _, sw := range switches.Items {
+		if sw.Spec.Redundancy.Type == meta.RedundancyTypeMCLAG {
+			mclagSwitches = append(mclagSwitches, sw.Name)
+		}
+	}
+	if len(mclagSwitches) > 0 {
+		slices.Sort(mclagSwitches)
+
+		return fmt.Errorf("cannot upgrade while there are deprecated mclag switches: %s", strings.Join(mclagSwitches, ",")) //nolint:err113
+	}
+
+	var connections wiringapi.ConnectionList
+	mclagConns := []string{}
+	if err := kube.List(ctx, &connections); err != nil {
+		return fmt.Errorf("listing connections: %w", err)
+	}
+	for _, conn := range connections.Items {
+		if conn.Spec.MCLAG != nil || conn.Spec.MCLAGDomain != nil {
+			mclagConns = append(mclagConns, conn.Name)
+		}
+	}
+	if len(mclagConns) > 0 {
+		slices.Sort(mclagConns)
+
+		return fmt.Errorf("cannot upgrade while there are deprecated mclag connections: %s", strings.Join(mclagConns, ",")) //nolint:err113
+	}
+
+	// refuse upgrade if there is any remote peering
+	var vpcPeerings vpcapi.VPCPeeringList
+	remotePeerings := []string{}
+	if err := kube.List(ctx, &vpcPeerings); err != nil {
+		return fmt.Errorf("listing vpc peerings: %w", err)
+	}
+	for _, peering := range vpcPeerings.Items {
+		if peering.Spec.Remote != "" {
+			remotePeerings = append(remotePeerings, peering.Name)
+		}
+	}
+	if len(remotePeerings) > 0 {
+		slices.Sort(remotePeerings)
+
+		return fmt.Errorf("cannot upgrade while there are deprecated remote peerings: %s", strings.Join(remotePeerings, ",")) //nolint:err113
 	}
 
 	return nil


### PR DESCRIPTION
Part of https://github.com/githedgehog/fabric/issues/1327