### PR TITLE
fix(release-test): run all reverts even if one fails

### DIFF
--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -564,7 +564,7 @@ func doRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, ts *JUnitTestSu
 					}
 				}
 
-				break
+				continue
 			}
 		}
 		if testCtx.failFast && err != nil {


### PR DESCRIPTION
Closes #1810

`break` in the LIFO revert loop stopped all remaining cleanup on the first revert error. Change it to `continue` so every revert runs and errors are accumulated, matching standard defer semantics.