### PR TITLE
fix(show-tech): capture flatcar-install service status in gateway console fallback

### DIFF
--- a/pkg/hhfab/show-tech/gateway-console.exp
+++ b/pkg/hhfab/show-tech/gateway-console.exp
@@ -215,6 +215,10 @@ if {$logged_in} {
     run_cmd "ls -la ~/.ssh/" $prompt_re 10
     run_cmd "cat ~/.ssh/authorized_keys" $prompt_re 10
 
+    # Flatcar installer service (present only during USB install; decisive for install-no-reboot failures)
+    run_cmd "systemctl status flatcar-install.service --no-pager" $prompt_re 30
+    run_cmd "journalctl -u flatcar-install --no-pager -n 100" $prompt_re 60
+
     # K3s agent status
     run_cmd "systemctl status k3s-agent --no-pager" $prompt_re 30
     run_cmd "journalctl -u k3s-agent --no-pager -n 50" $prompt_re 60


### PR DESCRIPTION
Adds `systemctl status flatcar-install.service` and `journalctl -u flatcar-install` to the gateway console fallback probe.

The service is only present during USB install (no-op on installed systems). Without it, a gateway install hang is undiagnosable from the console fallback output — only the disk partition kernel messages and an idle load average are visible, with no indication of where the installer stopped.

Found during triage of run 27566110480 (`v-gw-onie-usb-l2vni-rt`): gateway-2 wrote disk at 168s then went idle for 40 min without rebooting; root cause was indeterminate because the installer service logs were not collected.