### PR TITLE
test(rt): deterministic cross-leaf convergence after DHCP IP change

### DIFF
--- a/.github/workflows/custom-vlab.yaml
+++ b/.github/workflows/custom-vlab.yaml
@@ -1,5 +1,5 @@
 name: Custom VLAB
-run-name: "${{ inputs.hybrid && 'h' || 'v' }}-${{ inputs.upgradefrom }}${{ inputs.upgradefrom && '-' || '' }}${{ inputs.mesh && 'mesh-' || '' }}${{ inputs.gateway && 'gw-' || '' }}${{ inputs.buildmode }}-${{ inputs.vpcmode }}${{ inputs.releasetest && '-rt' || '' }}${{ inputs.releasetest_regex != '' && 'r' || '' }}"
+run-name: "${{ inputs.hybrid && 'h' || 'v' }}-${{ inputs.upgradefrom }}${{ inputs.upgradefrom && '-' || '' }}${{ inputs.mesh && 'mesh-' || '' }}${{ inputs.gateway && 'gw-' || '' }}${{ inputs.buildmode }}-${{ inputs.vpcmode }}${{ inputs.releasetest != 'off' && '-rt' || '' }}${{ inputs.releasetest == 'extended' && 'e' || '' }}${{ inputs.releasetest_regex != '' && 'r' || '' }}"
 
 on:
   workflow_dispatch:
@@ -43,10 +43,14 @@ on:
         required: false
         default: ""
       releasetest:
-        description: "Run Release tests"
-        type: boolean
+        description: "Run Release tests (extended also includes extended-only tests)"
+        type: choice
         required: false
-        default: false
+        default: "off"
+        options:
+          - "off"
+          - standard
+          - extended
       releasetest_regex:
         description: "Run only release tests matched by regex"
         type: string
@@ -68,7 +72,7 @@ permissions:
 
 jobs:
   vlab:
-    name: "${{ inputs.hybrid && 'h' || 'v' }}-${{ inputs.upgradefrom && 'up' || '' }}${{ inputs.upgradefrom }}${{ inputs.upgradefrom && '-' || '' }}${{ inputs.mesh && 'mesh-' || '' }}${{ inputs.gateway && 'gw-' || '' }}${{ inputs.buildmode }}-${{ inputs.vpcmode }}${{ inputs.releasetest && '-rt' || '' }}${{ inputs.releasetest_regex != '' && 'r' || '' }}"
+    name: "${{ inputs.hybrid && 'h' || 'v' }}-${{ inputs.upgradefrom && 'up' || '' }}${{ inputs.upgradefrom }}${{ inputs.upgradefrom && '-' || '' }}${{ inputs.mesh && 'mesh-' || '' }}${{ inputs.gateway && 'gw-' || '' }}${{ inputs.buildmode }}-${{ inputs.vpcmode }}${{ inputs.releasetest != 'off' && '-rt' || '' }}${{ inputs.releasetest == 'extended' && 'e' || '' }}${{ inputs.releasetest_regex != '' && 'r' || '' }}"
     uses: ./.github/workflows/run-vlab.yaml
     with:
       fabricatorref: ${{ github.ref }}
@@ -80,14 +84,15 @@ jobs:
       vpcmode: ${{ inputs.vpcmode }}
       hybrid: ${{ inputs.hybrid }}
       upgradefrom: ${{ inputs.upgradefrom }}
-      releasetest: ${{ inputs.releasetest }}
+      releasetest: ${{ inputs.releasetest != 'off' }}
       releasetest_regex: ${{ inputs.releasetest_regex }}
+      releasetest_extended: ${{ inputs.releasetest == 'extended' }}
       debug: ${{ inputs.pause_on_failure }}
       pause_on_failure: ${{ inputs.pause_on_failure }}
       collect_show_tech: ${{ inputs.collect_show_tech }}
 
   publish-test-results:
-    if: ${{ inputs.releasetest && !cancelled() }}
+    if: ${{ inputs.releasetest != 'off' && !cancelled() }}
     runs-on: lab
     needs:
       - vlab

--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -72,6 +72,11 @@ on:
         type: boolean
         required: false
         default: false
+      releasetest_extended:
+        description: "Include extended-only release tests"
+        type: boolean
+        required: false
+        default: false
       debug:
         description: "Enable tmate debugging"
         type: boolean
@@ -349,6 +354,9 @@ jobs:
               if [[ "${{ inputs.releasetest_regex_invert }}" == "true" ]]; then
                 HHFAB_TEST_ARGS+=(--release-test-regexes-invert)
               fi
+            fi
+            if [[ "${{ inputs.releasetest_extended }}" == "true" ]]; then
+              HHFAB_TEST_ARGS+=(--release-test-extended)
             fi
           elif [[ "${{ inputs.hybrid }}" == "true" || -n "${{ inputs.upgradefrom }}" ]]; then
             HHFAB_TEST_ARGS=(--ready=setup-vpcs --ready=setup-peerings --ready=test-connectivity)

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -92,6 +92,7 @@ const (
 	FlagShowTech                  = "show-tech"
 	FlagIPerfsSpeed               = "iperfs-speed"
 	FlagReleaseTestOnReadyOnly    = "release-test-on-ready-only"
+	FlagReleaseTestExtended       = "release-test-extended"
 	FlagOnReadyOnly               = "on-ready-only"
 )
 
@@ -1137,6 +1138,11 @@ func Run(ctx context.Context) error {
 								Aliases: []string{"rt-or"},
 								Usage:   "run only the special on-ready suite (used when --ready=release-test)",
 							},
+							&cli.BoolFlag{
+								Name:    FlagReleaseTestExtended,
+								Aliases: []string{"rt-extended"},
+								Usage:   "include extended-only release tests (used when --ready=release-test)",
+							},
 							&cli.UintFlag{
 								Category: FlagCatVMSizes,
 								Name:     "control-cpus",
@@ -1248,6 +1254,7 @@ func Run(ctx context.Context) error {
 									ReleaseTestRegexes:       c.StringSlice(FlagReleaseTestRegexes),
 									ReleaseTestRegexesInvert: c.Bool(FlagReleaseTestRegexesInvert),
 									ReleaseTestOnReadyOnly:   c.Bool(FlagReleaseTestOnReadyOnly),
+									ReleaseTestExtended:      c.Bool(FlagReleaseTestExtended),
 									InterfaceMTU:             ifMTU,
 								},
 							}); err != nil {

--- a/pkg/hhfab/rt_dhcp_ip_change_convergence.go
+++ b/pkg/hhfab/rt_dhcp_ip_change_convergence.go
@@ -1,0 +1,323 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"time"
+
+	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabricator/pkg/util/sshutil"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// dhcpIPChangeRecoveryThreshold is the maximum time a cross-leaf peer should take to
+	// regain connectivity to a host after that host changes its DHCP IP within an L3VNI
+	// anycast-gateway subnet. Healthy EVPN type-5 convergence is well under this. The
+	// threshold sits between healthy convergence and the failure floor; calibrate it
+	// against a known-good build for the target platform.
+	dhcpIPChangeRecoveryThreshold = 30 * time.Second
+	// dhcpIPChangeMaxWait bounds how long the test polls for recovery before declaring a
+	// hard failure.
+	dhcpIPChangeMaxWait = 4 * time.Minute
+	// dhcpIPChangePrimingPings is the number of pings sent to the not-yet-assigned target
+	// IP so the prober's leaf installs a failed neighbor on the SVI before the host appears.
+	dhcpIPChangePrimingPings = 3
+	// dhcpIPChangeStaticOffset is added to the subnet base address to pick an unused IP.
+	dhcpIPChangeStaticOffset = 111
+	// dhcpIPChangeReleaseWait bounds how long the revert waits for the victim to give up the
+	// static IP and take a regular lease again.
+	dhcpIPChangeReleaseWait = 90 * time.Second
+)
+
+var (
+	errNotL3VNI        = errors.New("test requires L3VNI VPC mode")
+	errNoCrossLeafPair = errors.New("no two servers in the same subnet on different leaves")
+)
+
+// ipChangeServer is a single-homed server attached to a subnet, with its access interface
+// and the leaf switch it connects to.
+type ipChangeServer struct {
+	name  string
+	iface string
+	leaf  string
+}
+
+// findCrossLeafSubnetPair finds two single-homed servers attached to the same VPC subnet but
+// on different leaf switches. Returns the VPC, the subnet name, and the two servers. Returns a
+// nil VPC (no error) when no such pair exists. Multi-homed connections (MCLAG/ESLAG) and
+// hostBGP subnets are skipped.
+func findCrossLeafSubnetPair(ctx context.Context, kube kclient.Client) (*vpcapi.VPC, string, *ipChangeServer, *ipChangeServer, error) {
+	attaches := &vpcapi.VPCAttachmentList{}
+	if err := kube.List(ctx, attaches); err != nil {
+		return nil, "", nil, nil, fmt.Errorf("listing VPCAttachments: %w", err)
+	}
+
+	type subnetKey struct {
+		vpc    string
+		subnet string
+	}
+	bySubnet := map[subnetKey][]ipChangeServer{}
+	vpcs := map[string]*vpcapi.VPC{}
+
+	for _, attach := range attaches.Items {
+		conn := &wiringapi.Connection{}
+		if err := kube.Get(ctx, kclient.ObjectKey{Namespace: kmetav1.NamespaceDefault, Name: attach.Spec.Connection}, conn); err != nil {
+			continue
+		}
+		switches, serverNames, _, _, err := conn.Spec.Endpoints()
+		if err != nil || len(serverNames) != 1 || len(switches) != 1 {
+			continue
+		}
+
+		vpcName := attach.Spec.VPCName()
+		vpc, ok := vpcs[vpcName]
+		if !ok {
+			vpc = &vpcapi.VPC{}
+			if err := kube.Get(ctx, kclient.ObjectKey{Namespace: kmetav1.NamespaceDefault, Name: vpcName}, vpc); err != nil {
+				continue
+			}
+			vpcs[vpcName] = vpc
+		}
+
+		subnetName := attach.Spec.SubnetName()
+		subnet := vpc.Spec.Subnets[subnetName]
+		// The trigger drives a real DHCP cycle, so the subnet must have DHCP enabled and must
+		// not be a hostBGP subnet (which behaves differently).
+		if subnet == nil || subnet.HostBGP || !subnet.DHCP.Enable {
+			continue
+		}
+
+		var iface string
+		if conn.Spec.Unbundled != nil {
+			iface = fmt.Sprintf("%s.%d", conn.Spec.Unbundled.Link.Server.LocalPortName(), subnet.VLAN)
+		} else {
+			iface = fmt.Sprintf("bond0.%d", subnet.VLAN)
+		}
+
+		key := subnetKey{vpc: vpcName, subnet: subnetName}
+		bySubnet[key] = append(bySubnet[key], ipChangeServer{name: serverNames[0], iface: iface, leaf: switches[0]})
+	}
+
+	for key, servers := range bySubnet {
+		for i := range servers {
+			for j := i + 1; j < len(servers); j++ {
+				if servers[i].leaf != servers[j].leaf {
+					return vpcs[key.vpc], key.subnet, &servers[i], &servers[j], nil
+				}
+			}
+		}
+	}
+
+	return nil, "", nil, nil, nil
+}
+
+// waitForInterfaceIPv4Change polls until the interface holds an IPv4 address other than avoid.
+func waitForInterfaceIPv4Change(ctx context.Context, ssh *sshutil.Config, ifName, avoid string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		cur, err := getInterfaceIPv4(ctx, ssh, ifName)
+		if err == nil && cur != "" && cur != avoid {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("%s still holds %s after %s", ifName, avoid, timeout) //nolint:goerr113
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for %s to change address: %w", ifName, ctx.Err())
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// dhcpIPChangeConvergenceTest verifies that when a host changes its DHCP IP within an L3VNI
+// anycast-gateway subnet, a host in the same subnet on a different leaf regains connectivity to
+// the new IP promptly. It deterministically induces the convergence race: pin the target host to
+// a fresh static IP, make the cross-leaf prober send traffic to that IP before the host claims it
+// (so the prober's leaf installs a failed neighbor on the SVI), then force the host onto the new
+// IP and measure how long the prober takes to reach it.
+func dhcpIPChangeConvergenceTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	// The race lives in the L3VNI symmetric IRB path (per-VPC VRF, EVPN type-5 host routes);
+	// it does not exist in L2VNI mode.
+	if testCtx.setupOpts.VPCMode != vpcapi.VPCModeL3VNI {
+		slog.Info("Skipping DHCP IP change convergence test, requires L3VNI mode", "mode", testCtx.setupOpts.VPCMode)
+
+		return true, nil, errNotL3VNI
+	}
+
+	vpc, subnetName, victim, prober, err := findCrossLeafSubnetPair(ctx, testCtx.kube)
+	if err != nil {
+		return false, nil, err
+	}
+	if vpc == nil {
+		slog.Info("No same-subnet servers on different leaves, skipping DHCP IP change convergence test")
+
+		return true, nil, errNoCrossLeafPair
+	}
+
+	slog.Info("Testing DHCP IP change convergence",
+		"vpc", vpc.Name, "subnet", subnetName,
+		"victim", victim.name, "victimLeaf", victim.leaf,
+		"prober", prober.name, "proberLeaf", prober.leaf)
+
+	// Derive a fresh, unused static IP in the subnet.
+	subnet := vpc.Spec.Subnets[subnetName]
+	_, subnetCIDR, err := net.ParseCIDR(subnet.Subnet)
+	if err != nil {
+		return false, nil, fmt.Errorf("parsing subnet CIDR %s: %w", subnet.Subnet, err)
+	}
+	base := subnetCIDR.IP.To4()
+	if base == nil {
+		return false, nil, fmt.Errorf("subnet %s is not IPv4", subnet.Subnet) //nolint:goerr113
+	}
+	newIP := make(net.IP, 4)
+	binary.BigEndian.PutUint32(newIP, binary.BigEndian.Uint32(base)+dhcpIPChangeStaticOffset)
+	if !subnetCIDR.Contains(newIP) {
+		return false, nil, fmt.Errorf("static offset %d puts %s outside subnet %s", dhcpIPChangeStaticOffset, newIP, subnet.Subnet) //nolint:goerr113
+	}
+	newIPStr := newIP.String()
+	newAddr, err := netip.ParseAddr(newIPStr)
+	if err != nil {
+		return false, nil, fmt.Errorf("parsing new IP %s: %w", newIPStr, err)
+	}
+
+	victimSSH, err := testCtx.getSSH(ctx, victim.name)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting ssh for %s: %w", victim.name, err)
+	}
+	proberSSH, err := testCtx.getSSH(ctx, prober.name)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting ssh for %s: %w", prober.name, err)
+	}
+
+	proberIPStr, err := getInterfaceIPv4(ctx, proberSSH, prober.iface)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting prober %s IP: %w", prober.name, err)
+	}
+	proberAddr, err := netip.ParseAddr(proberIPStr)
+	if err != nil {
+		return false, nil, fmt.Errorf("parsing prober IP %s: %w", proberIPStr, err)
+	}
+
+	victimMAC, err := getInterfaceMAC(ctx, victimSSH, victim.iface)
+	if err != nil || victimMAC == "" {
+		return false, nil, fmt.Errorf("getting MAC for %s %s: %w", victim.name, victim.iface, err)
+	}
+
+	// Pin the victim's MAC to the fresh IP via a static DHCP lease, preserving the rest of the
+	// subnet's DHCP config so the other servers are undisturbed.
+	savedStatic := map[string]vpcapi.VPCDHCPStatic{}
+	for k, v := range subnet.DHCP.Static {
+		savedStatic[k] = v
+	}
+	if subnet.DHCP.Static == nil {
+		subnet.DHCP.Static = map[string]vpcapi.VPCDHCPStatic{}
+	}
+	subnet.DHCP.Static[victimMAC] = vpcapi.VPCDHCPStatic{IP: newIPStr}
+
+	if _, err := CreateOrUpdateVpc(ctx, testCtx.kube, vpc); err != nil {
+		return false, nil, fmt.Errorf("adding static lease to VPC %s: %w", vpc.Name, err)
+	}
+	if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+		return false, nil, fmt.Errorf("waiting ready after static lease: %w", err)
+	}
+
+	reverts := []RevertFunc{
+		func(ctx context.Context) error {
+			subnet := vpc.Spec.Subnets[subnetName]
+			if len(savedStatic) == 0 {
+				subnet.DHCP.Static = nil
+			} else {
+				subnet.DHCP.Static = savedStatic
+			}
+			if _, err := CreateOrUpdateVpc(ctx, testCtx.kube, vpc); err != nil {
+				return fmt.Errorf("restoring DHCP config on VPC %s: %w", vpc.Name, err)
+			}
+			if err := WaitReady(ctx, testCtx.kube, testCtx.wrOpts); err != nil {
+				return fmt.Errorf("waiting ready after restoring DHCP config: %w", err)
+			}
+			if _, _, err := victimSSH.Run(ctx, fmt.Sprintf("sudo networkctl reconfigure %s", victim.iface)); err != nil {
+				return fmt.Errorf("reconfiguring %s after revert: %w", victim.name, err)
+			}
+			if err := waitForInterfaceIPv4Change(ctx, victimSSH, victim.iface, newIPStr, dhcpIPChangeReleaseWait); err != nil {
+				return fmt.Errorf("waiting for %s to drop %s: %w", victim.name, newIPStr, err)
+			}
+			// The victim's IP changed twice, so follow-up tests would probe the stale
+			// matrix address.
+			if err := testCtx.rebindMatrixServerEndpoint(ctx, matrix, victim.name); err != nil {
+				return fmt.Errorf("refreshing matrix endpoint for %s: %w", victim.name, err)
+			}
+
+			return nil
+		},
+	}
+
+	// Prime the prober's leaf: send traffic to the new IP before the victim claims it, so the
+	// leaf installs a failed neighbor on the SVI. These pings are expected to fail.
+	if pe := checkPing(ctx, dhcpIPChangePrimingPings, nil, prober.name, newIPStr, proberSSH, newAddr, &proberAddr, false); pe != nil {
+		slog.Warn("Priming traffic to the new IP unexpectedly succeeded before assignment", "detail", pe.Error())
+	}
+
+	// Force the victim onto the new IP.
+	if _, stderr, err := victimSSH.Run(ctx, fmt.Sprintf("sudo networkctl reconfigure %s", victim.iface)); err != nil {
+		return false, reverts, fmt.Errorf("reconfiguring %s: %w (stderr: %s)", victim.name, err, stderr)
+	}
+
+	// Probe the new IP continuously so the prober's leaf keeps its neighbor entry hot across the
+	// transition, while waiting for the victim to claim the IP. Once it is assigned, measure how
+	// long the prober takes to reach it.
+	var assignedAt time.Time
+	var recovery time.Duration
+	recovered := false
+	deadline := time.Now().Add(dhcpIPChangeMaxWait)
+	for time.Now().Before(deadline) {
+		reachable := checkPing(ctx, 1, nil, prober.name, newIPStr, proberSSH, newAddr, &proberAddr, true) == nil
+
+		if assignedAt.IsZero() {
+			if cur, err := getInterfaceIPv4(ctx, victimSSH, victim.iface); err == nil && cur == newIPStr {
+				assignedAt = time.Now()
+				slog.Info("Victim acquired the new IP", "victim", victim.name, "newIP", newIPStr)
+			}
+		}
+		if !assignedAt.IsZero() && reachable {
+			recovery = time.Since(assignedAt)
+			recovered = true
+
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, reverts, fmt.Errorf("waiting for connectivity recovery: %w", ctx.Err())
+		case <-time.After(1 * time.Second):
+		}
+	}
+
+	if assignedAt.IsZero() {
+		return false, reverts, fmt.Errorf("%s did not acquire new IP %s after reconfigure", victim.name, newIPStr) //nolint:goerr113
+	}
+	if !recovered {
+		return false, reverts, fmt.Errorf("%s never regained connectivity to %s within %s after the DHCP IP change", prober.name, newIPStr, dhcpIPChangeMaxWait) //nolint:goerr113
+	}
+
+	slog.Info("Cross-leaf connectivity recovered after DHCP IP change",
+		"prober", prober.name, "victim", victim.name, "newIP", newIPStr, "recovery", recovery.Round(time.Second))
+
+	if recovery > dhcpIPChangeRecoveryThreshold {
+		return false, reverts, fmt.Errorf("%s took %s to reach %s after the DHCP IP change, exceeding the %s threshold", prober.name, recovery.Round(time.Second), newIPStr, dhcpIPChangeRecoveryThreshold) //nolint:goerr113
+	}
+
+	return false, reverts, nil
+}

--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -60,6 +60,15 @@ func makeSingleVPCSuite() *JUnitTestSuite {
 			F:    dhcpStaticLeaseTest,
 		},
 		{
+			Name: "DHCP IP change cross-leaf convergence",
+			F:    dhcpIPChangeConvergenceTest,
+			SkipFlags: SkipFlags{
+				VirtualSwitch: true,
+				NoServers:     true,
+				ExtendedOnly:  true,
+			},
+		},
+		{
 			Name: "ESLAG Failover",
 			F:    eslagTest,
 			SkipFlags: SkipFlags{

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -109,6 +109,7 @@ type VLABRunOpts struct {
 	ReleaseTestRegexes       []string
 	ReleaseTestRegexesInvert bool
 	ReleaseTestOnReadyOnly   bool
+	ReleaseTestExtended      bool
 	InterfaceMTU             uint16
 }
 
@@ -764,6 +765,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						ShowTechDump:   true,
 						IPerfsMinSpeed: 8200,
 						OnReadyTest:    opts.ReleaseTestOnReadyOnly,
+						Extended:       opts.ReleaseTestExtended,
 					}
 					slog.Debug("Running release-test", "opts", releaseTestOpts)
 					if err := ReleaseTest(ctx, c, vlab, releaseTestOpts); err != nil {


### PR DESCRIPTION
Adds a release test that deterministically reproduces the post-DHCP-IP-change connectivity stall in L3VNI anycast-gateway subnets (githedgehog/internal#399).

It pins a host to a fresh static IP, primes the cross-leaf peer's SVI neighbor before the host claims that IP, forces the host onto it via a real DHCP cycle, then measures how long the peer takes to reach the new IP and asserts it stays under a threshold. The measured recovery is always logged.

**This test is expected to fail.** internal#399 is not fixed. githedgehog/fabric#1496 is a defensive mitigation, not a fix: it sets the drop-neighbor aging time to 60s, the lowest value the platform allows, which bounds the worst case at about 60s instead of the default 5 minutes. The underlying defect is in BCM SONiC and the fix is on Broadcom. Latest run: https://github.com/githedgehog/fabricator/actions/runs/30830834797

- L3VNI-only and hardware-only: skips in L2VNI mode and on virtual switches.
- Extended-only: gated behind `--release-test-extended`, so it does not run in the default gating release suite. Dispatch Custom VLAB with `releasetest: extended` to run it.
- `dhcpIPChangeRecoveryThreshold` cannot be calibrated against a known-good build, because there is no build in which this passes. The useful output is the recovery time the test logs on every run: it should track the configured drop-neighbor aging time, and a SONiC bump that moves it is the signal the defect has been addressed.
- Users are documented a workaround in the public known limitations page: static DHCP leases, so a host always receives the same IP and never triggers the path.

Second commit wires `--extended` end to end so extended-only tests are reachable from CI: a new `--release-test-extended` flag on `hhfab vlab up`, threaded into the release-test run, plus a `releasetest_extended` input on `run-vlab.yaml`. The Custom VLAB dispatch `releasetest` input becomes a dropdown (off / standard / extended) to stay within GitHub's 10-input limit.
