### PR TITLE
feat(test-connectivity): include lost icmp_seq in ping failure error

### DIFF
--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -1989,13 +1989,57 @@ type PingError struct {
 	Expected    bool
 	Sent        int
 	Received    int
+	Lost        []int
 	CmdOutput   string
 	Msg         string
 }
 
 func (pe *PingError) Error() string {
-	return fmt.Sprintf("ping %s -> %s: %s (sent %d, rcvd %d, expected %v)",
-		pe.Source, pe.Destination, pe.Msg, pe.Sent, pe.Received, pe.Expected)
+	lost := ""
+	if len(pe.Lost) > 0 {
+		lost = fmt.Sprintf(", lost=%v", pe.Lost)
+	}
+
+	return fmt.Sprintf("ping %s -> %s: %s (sent %d, rcvd %d%s, expected %v)",
+		pe.Source, pe.Destination, pe.Msg, pe.Sent, pe.Received, lost, pe.Expected)
+}
+
+// parsePingLostSeqs returns the ICMP sequence numbers in 1..sent that have no
+// reply line in the ping stdout. seq=1 absent points to next-hop resolution
+// (ARP/ND miss); a later seq absent points to mid-flight FIB churn.
+func parsePingLostSeqs(stdout string, sent int) []int {
+	if sent <= 0 {
+		return nil
+	}
+
+	seen := make(map[int]bool, sent)
+	for l := range strings.SplitSeq(stdout, "\n") {
+		// Only count echo replies. ICMP error lines (e.g. "From <gw> icmp_seq=3
+		// Destination Host Unreachable") also carry icmp_seq= but are not replies.
+		if !strings.Contains(l, "bytes from") {
+			continue
+		}
+		i := strings.Index(l, "icmp_seq=")
+		if i < 0 {
+			continue
+		}
+		fields := strings.Fields(l[i+len("icmp_seq="):])
+		if len(fields) == 0 {
+			continue
+		}
+		if n, err := strconv.Atoi(fields[0]); err == nil {
+			seen[n] = true
+		}
+	}
+
+	var lost []int
+	for n := 1; n <= sent; n++ {
+		if !seen[n] {
+			lost = append(lost, n)
+		}
+	}
+
+	return lost
 }
 
 type IperfError struct {
@@ -2832,6 +2876,7 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 			break
 		}
 	}
+	pe.Lost = parsePingLostSeqs(stdout, pe.Sent)
 	if pe.Sent == 0 && err == nil {
 		pe.Msg = "cannot parse ping output to get sent packets"
 

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -2850,7 +2850,10 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 		slog.Warn("Warm-up ping failed, continuing anyway", "err", err, "stdout", stdout, "stderr", stderr)
 	}
 
-	cmd = fmt.Sprintf("ping -i 0.5 -c %d -W 1", pingCount)
+	// -D timestamps each reply line ([unixtime]) so a lost seq can be placed on
+	// the wall clock; it prefixes reply lines only, not the summary line the
+	// sent/received parser and parsePingLostSeqs read.
+	cmd = fmt.Sprintf("ping -i 0.5 -c %d -W 1 -D", pingCount)
 	if sourceIP != nil {
 		cmd += " -I " + sourceIP.String()
 	}
@@ -2876,7 +2879,9 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 			break
 		}
 	}
-	pe.Lost = parsePingLostSeqs(stdout, pe.Sent)
+	if pe.Received > 0 && pe.Sent != pe.Received {
+		pe.Lost = parsePingLostSeqs(stdout, pe.Sent)
+	}
 	if pe.Sent == 0 && err == nil {
 		pe.Msg = "cannot parse ping output to get sent packets"
 
@@ -2889,7 +2894,19 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 	slog.Debug("Ping result", "from", from, "to", to,
 		"expected", expected, "ok", pingOk, "fail", pingFail, "err", err, "stdout", stdout, "stderr", stderr)
 
+	// When a ping that should have succeeded fails, surface the per-packet
+	// (timestamped, via -D) output at warn level so the loss pattern is visible
+	// next to the error without re-running with -v. Negative tests fail pings by
+	// design, so only do this when reachability was expected.
+	logExpectedFailure := func() {
+		if expected {
+			slog.Warn("Ping failed (expected reachable)", "from", from, "to", to,
+				"sent", pe.Sent, "rcvd", pe.Received, "lost", pe.Lost, "stdout", stdout, "stderr", stderr)
+		}
+	}
+
 	if pingOk == pingFail {
+		logExpectedFailure()
 		if err != nil {
 			pe.Msg = err.Error()
 		} else {
@@ -2901,6 +2918,7 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 	}
 
 	if expected && !pingOk {
+		logExpectedFailure()
 		pe.Msg = "should be reachable but ping failed"
 
 		return pe

--- a/pkg/hhfab/testing_test.go
+++ b/pkg/hhfab/testing_test.go
@@ -342,6 +342,18 @@ From 10.20.4.1 icmp_seq=2 Destination Host Unreachable
 3 packets transmitted, 2 received, 33% packet loss, time 2010ms
 `
 
+	// Same first-packet loss but with -D reply timestamps ([unixtime] prefix, real
+	// `ping -D` format from iputils 20240117); the prefix must not confuse parsing.
+	const firstLostTimestamped = `PING 10.20.4.2 (10.20.4.2) 56(84) bytes of data.
+[1782458023.423317] 64 bytes from 10.20.4.2: icmp_seq=2 ttl=61 time=0.611 ms
+[1782458023.927269] 64 bytes from 10.20.4.2: icmp_seq=3 ttl=61 time=0.844 ms
+[1782458024.431201] 64 bytes from 10.20.4.2: icmp_seq=4 ttl=61 time=0.885 ms
+[1782458024.935112] 64 bytes from 10.20.4.2: icmp_seq=5 ttl=61 time=1.31 ms
+--- 10.20.4.2 ping statistics ---
+5 packets transmitted, 4 received, 20% packet loss, time 2010ms
+rtt min/avg/max/mdev = 0.611/0.912/1.308/0.251 ms
+`
+
 	for _, test := range []struct {
 		name     string
 		stdout   string
@@ -350,6 +362,7 @@ From 10.20.4.1 icmp_seq=2 Destination Host Unreachable
 	}{
 		{name: "all received", stdout: allReceived, sent: 5},
 		{name: "first lost (real flake)", stdout: firstLost, sent: 5, expected: []int{1}},
+		{name: "first lost with -D timestamps", stdout: firstLostTimestamped, sent: 5, expected: []int{1}},
 		{name: "middle lost", stdout: middleLost, sent: 5, expected: []int{3}},
 		{name: "last lost", stdout: lastLost, sent: 5, expected: []int{5}},
 		{name: "all lost", stdout: allLost, sent: 5, expected: []int{1, 2, 3, 4, 5}},

--- a/pkg/hhfab/testing_test.go
+++ b/pkg/hhfab/testing_test.go
@@ -277,6 +277,91 @@ func TestCollectN(t *testing.T) {
 	}
 }
 
+func TestParsePingLostSeqs(t *testing.T) {
+	// Fixtures are real `ping -i 0.5 -c N -W 1` stdout captured from CI job
+	// https://github.com/githedgehog/fabricator/actions/runs/28009366936/job/82899549177
+	// (h-gw-iso-l2vni-rt), pasted verbatim from the "Ping result" debug lines.
+
+	// 5/5 clean.
+	const allReceived = `PING 10.20.1.4 (10.20.1.4) 56(84) bytes of data.
+64 bytes from 10.20.1.4: icmp_seq=1 ttl=62 time=0.253 ms
+64 bytes from 10.20.1.4: icmp_seq=2 ttl=62 time=0.400 ms
+64 bytes from 10.20.1.4: icmp_seq=3 ttl=62 time=0.487 ms
+64 bytes from 10.20.1.4: icmp_seq=4 ttl=62 time=0.425 ms
+64 bytes from 10.20.1.4: icmp_seq=5 ttl=62 time=0.478 ms
+--- 10.20.1.4 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 2016ms
+rtt min/avg/max/mdev = 0.253/0.408/0.487/0.084 ms
+`
+
+	// The actual flake: sent 5, rcvd 4, first reply is icmp_seq=2 (seq 1 dropped
+	// during next-hop resolution / convergence tail).
+	const firstLost = `PING 10.20.4.2 (10.20.4.2) 56(84) bytes of data.
+64 bytes from 10.20.4.2: icmp_seq=2 ttl=61 time=0.611 ms
+64 bytes from 10.20.4.2: icmp_seq=3 ttl=61 time=0.844 ms
+64 bytes from 10.20.4.2: icmp_seq=4 ttl=61 time=0.885 ms
+64 bytes from 10.20.4.2: icmp_seq=5 ttl=61 time=1.31 ms
+--- 10.20.4.2 ping statistics ---
+5 packets transmitted, 4 received, 20% packet loss, time 2010ms
+rtt min/avg/max/mdev = 0.611/0.912/1.308/0.251 ms
+`
+
+	// 100% loss (no reply lines at all).
+	const allLost = `PING 10.20.2.3 (10.20.2.3) 56(84) bytes of data.
+--- 10.20.2.3 ping statistics ---
+5 packets transmitted, 0 received, 100% packet loss, time 2014ms
+`
+
+	// Derived from the real reply format above, dropping a middle / last reply.
+	const middleLost = `PING 10.20.1.4 (10.20.1.4) 56(84) bytes of data.
+64 bytes from 10.20.1.4: icmp_seq=1 ttl=62 time=0.253 ms
+64 bytes from 10.20.1.4: icmp_seq=2 ttl=62 time=0.400 ms
+64 bytes from 10.20.1.4: icmp_seq=4 ttl=62 time=0.425 ms
+64 bytes from 10.20.1.4: icmp_seq=5 ttl=62 time=0.478 ms
+--- 10.20.1.4 ping statistics ---
+5 packets transmitted, 4 received, 20% packet loss, time 2016ms
+`
+
+	const lastLost = `PING 10.20.1.4 (10.20.1.4) 56(84) bytes of data.
+64 bytes from 10.20.1.4: icmp_seq=1 ttl=62 time=0.253 ms
+64 bytes from 10.20.1.4: icmp_seq=2 ttl=62 time=0.400 ms
+64 bytes from 10.20.1.4: icmp_seq=3 ttl=62 time=0.487 ms
+64 bytes from 10.20.1.4: icmp_seq=4 ttl=62 time=0.425 ms
+--- 10.20.1.4 ping statistics ---
+5 packets transmitted, 4 received, 20% packet loss, time 2016ms
+`
+
+	// Format guard for the "bytes from" check: an ICMP error line carries
+	// icmp_seq= but is not an echo reply, so that seq must still count as lost.
+	// iputils format; not captured in the run above (no unreachables occurred).
+	const icmpError = `PING 10.20.4.2 (10.20.4.2) 56(84) bytes of data.
+64 bytes from 10.20.4.2: icmp_seq=1 ttl=61 time=0.5 ms
+From 10.20.4.1 icmp_seq=2 Destination Host Unreachable
+64 bytes from 10.20.4.2: icmp_seq=3 ttl=61 time=0.5 ms
+--- 10.20.4.2 ping statistics ---
+3 packets transmitted, 2 received, 33% packet loss, time 2010ms
+`
+
+	for _, test := range []struct {
+		name     string
+		stdout   string
+		sent     int
+		expected []int
+	}{
+		{name: "all received", stdout: allReceived, sent: 5},
+		{name: "first lost (real flake)", stdout: firstLost, sent: 5, expected: []int{1}},
+		{name: "middle lost", stdout: middleLost, sent: 5, expected: []int{3}},
+		{name: "last lost", stdout: lastLost, sent: 5, expected: []int{5}},
+		{name: "all lost", stdout: allLost, sent: 5, expected: []int{1, 2, 3, 4, 5}},
+		{name: "icmp error line is not a reply", stdout: icmpError, sent: 3, expected: []int{2}},
+		{name: "sent zero returns nil", stdout: allReceived, sent: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, parsePingLostSeqs(test.stdout, test.sent))
+		})
+	}
+}
+
 func mapSlice[IN, OUT any](f func(IN) OUT, in []IN) []OUT {
 	out := make([]OUT, len(in))
 	for i, v := range in {


### PR DESCRIPTION
Makes a ping failure in the connectivity tests self-diagnosing instead of a bare `sent 5, rcvd 4`.

- Surfaces the lost ICMP sequence numbers in the error, so `lost=[1]` (next-hop / ARP-ND resolution, the convergence tail) is distinguishable from a later seq (mid-flight FIB churn) at a glance.
- Adds `-D` to the measured ping so each reply line is wall-clock timestamped (`[unixtime]`), letting a dropped seq be placed in time and correlated with fabric events. It prefixes reply lines only, so the sent/received and lost-seq parsers are unaffected.
- On a ping that should have succeeded but didn't, logs the full timestamped output at warn level next to the error (gated on expected-reachable, so negative tests stay quiet).

Before: `ping A -> B: unexpected ping result (sent 5, rcvd 4, expected true)`
After:  `ping A -> B: unexpected ping result (sent 5, rcvd 4, lost=[1], expected true)`

Parsing is covered by unit tests built on real ping output captured from CI.

Closes #1812
