### PR TITLE
fix(release-test): gate gateway-failover revert probe on datapath convergence

### DIFF
--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -538,6 +538,12 @@ func gatewayFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool,
 			}
 		}
 
+		// Route presence in leaf RIBs does not mean the dataplane is forwarding yet,
+		// so absorb the reconvergence tail before the strict test runs.
+		if err := testCtx.waitForDatapathConverged(ctx); err != nil {
+			return fmt.Errorf("datapath convergence after spine recovery: %w", err)
+		}
+
 		slog.Debug("Testing connectivity after re-enabling spines and agents")
 		if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
 			return fmt.Errorf("connectivity test after re-enabling spines and agents: %w", err)

--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -403,6 +403,42 @@ func (testCtx *VPCPeeringTestCtx) waitForRoutesInSwitches(ctx context.Context, s
 	}
 }
 
+// waitForDatapathConverged polls the standard connectivity test in ping-only
+// mode until one clean round passes or the timeout elapses. Route presence in
+// leaf RIBs does not mean the dataplane (ASIC, neighbor resolution, gateway
+// VTEP) is forwarding yet, so the first packets of the strict probe can hit the
+// reconvergence tail and drop. This gate absorbs that tail by retrying the real
+// test; the strict probe that follows still runs once and tolerates no loss, so
+// steady or intermittent loss is still caught. A path that never converges fails
+// here.
+func (testCtx *VPCPeeringTestCtx) waitForDatapathConverged(ctx context.Context) error {
+	const (
+		convergeTimeout = 90 * time.Second
+		convergePoll    = 5 * time.Second
+	)
+
+	pingOnly := testCtx.tcOpts
+	pingOnly.IPerfsSeconds = 0
+	pingOnly.CurlsCount = 0
+
+	toCtx, cancel := context.WithTimeout(ctx, convergeTimeout)
+	defer cancel()
+
+	slog.Info("Waiting for datapath convergence before strict connectivity test", "timeout", convergeTimeout)
+	for {
+		err := DoVLABTestConnectivity(toCtx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, pingOnly)
+		if err == nil {
+			return nil
+		}
+		slog.Debug("Datapath not converged yet, retrying", "err", err)
+		select {
+		case <-toCtx.Done():
+			return fmt.Errorf("datapath did not converge within %s: %w", convergeTimeout, err)
+		case <-time.After(convergePoll):
+		}
+	}
+}
+
 // check that the DHCP lease is within the expected range.
 func checkDHCPLease(leaseInfo *DHCPLeaseInfo, expectedLease int, tolerance int) error {
 	if leaseInfo == nil {


### PR DESCRIPTION
Fixes githedgehog/internal#432.

The Gateway Failover REVERT step probes connectivity right after re-enabling spines+agents. The existing gates (`WaitReady` + leaf route-presence) return while the dataplane (ASIC, neighbor resolution, gateway VTEP) is still settling and transit leaves are mid-apply, so the strict 5/5 probe's first packet hits the convergence tail and drops (`sent 5, rcvd 4`). The in-`checkPing` warm-up is a single non-gating packet, so it absorbs nothing.

This adds a convergence detector before the strict probe (Gateway Failover revert only): wait until bidirectional ping between the peered servers is clean for 3 consecutive rounds (90s timeout, hard fail on timeout). The strict connectivity test is unchanged and shared `checkPing`/`TestConnectivity` are untouched, so no other test changes.

Does not mask: the detector retries, the assertion does not. Intermittent loss never gets 3 consecutive rounds; steady loss is still caught by the strict probe; a path that never converges fails the detector.