### PR TITLE
test: LLDP inspect instrumentation on SONiC 4.6.0 (refs #1760)

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -108,6 +108,9 @@ env:
   HHFAB_REG_REPO: 127.0.0.1:30000
   HHFAB_VLAB_COLLECT: true
   HHFAB_VLAB_COLLECT_FORCE: ${{ inputs.collect_show_tech }}
+  # TEMP for #1776 campaign on pau/issue-1776-lldp-instrument: opt the failure
+  # path into Broadcom-grade SONiC tech-support collection. Drop before merge.
+  HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT: "true"
 
 jobs:
   run:

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1843,6 +1843,25 @@ Examples:
 								},
 							},
 							{
+								Name:  "show-tech",
+								Usage: "collect native SONiC tech-support tarballs from switches (if no switches specified, all switches will be targeted)",
+								Flags: flatten(defaultFlags, []cli.Flag{
+									&cli.StringSliceFlag{
+										Name:    "switch",
+										Aliases: []string{"s"},
+										Usage:   "switch name to collect tech-support from (repeatable)",
+									},
+								}),
+								Before: before(false),
+								Action: func(c *cli.Context) error {
+									if err := hhfab.DoSonicShowTech(ctx, workDir, cacheDir, c.StringSlice("switch")); err != nil {
+										return fmt.Errorf("sonic show-tech: %w", err)
+									}
+
+									return nil
+								},
+							},
+							{
 								Name:  "power",
 								Usage: "manage switch power state using the PDU (if no switches specified, all switches will be affected)",
 								Flags: flatten(pduFlags, []cli.Flag{

--- a/pkg/fab/README.md
+++ b/pkg/fab/README.md
@@ -164,7 +164,7 @@ skopeo copy --all docker://cturra/ntp@${UPSTREAM_SHA} docker://ghcr.io/githedgeh
 Run `gzip -dk sonic-vs.img.gz` if needed.
 
 ```bash
-export BCM_SONIC_VERSION="v4.5.2"
+export BCM_SONIC_VERSION="v4.6.0"
 
 oras push ghcr.io/githedgehog/sonic-bcm-private/sonic-bcm-advanced:${BCM_SONIC_VERSION} sonic-broadcom-enterprise-advanced.bin
 oras push ghcr.io/githedgehog/sonic-bcm-private/sonic-bcm-campus:${BCM_SONIC_VERSION} sonic-broadcom-campus.bin

--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -29,7 +29,7 @@ const (
 	FRRVersion = meta.Version("v0.22.0")
 
 	// Broadcom Enterprise SONiC version (including all flavors)
-	BCMSONiCVersion = meta.Version("v4.5.2")
+	BCMSONiCVersion = meta.Version("v4.6.0")
 
 	// Celestica SONiC+ version (including all flavors)
 	CLSSONiCVersion = meta.Version("v4.2.1")

--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -29,7 +29,7 @@ const (
 	FRRVersion = meta.Version("v0.22.0")
 
 	// Broadcom Enterprise SONiC version (including all flavors)
-	BCMSONiCVersion = meta.Version("v4.5.0")
+	BCMSONiCVersion = meta.Version("v4.5.2")
 
 	// Celestica SONiC+ version (including all flavors)
 	CLSSONiCVersion = meta.Version("v4.2.1")

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -183,6 +183,17 @@ func DoShowTech(ctx context.Context, workDir, cacheDir string) error {
 	return c.VLABShowTech(ctx, vlab, ShowTechOpts{})
 }
 
+func DoSonicShowTech(ctx context.Context, workDir, cacheDir string, switches []string) error {
+	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
+	if err != nil {
+		return err
+	}
+
+	outDir := filepath.Join(workDir, "sonic-techsupport")
+
+	return c.CollectSonicTechsupport(ctx, vlab, switches, outDir)
+}
+
 func DoVLABSetupVPCs(ctx context.Context, workDir, cacheDir string, opts SetupVPCsOpts) error {
 	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
 	if err != nil {

--- a/pkg/hhfab/lldpcapture.go
+++ b/pkg/hhfab/lldpcapture.go
@@ -72,7 +72,7 @@ func (c *Config) captureLLDPAtFailure(ctx context.Context, vlab *VLAB, attempt i
 
 // affectedLLDPTargets returns the switches and servers that have a missing
 // non-external expected neighbor. Output is sorted and deduplicated.
-func affectedLLDPTargets(out *inspect.LLDPOut) (switches, servers []string) {
+func affectedLLDPTargets(out *inspect.LLDPOut) ([]string, []string) {
 	swSet := map[string]struct{}{}
 	srvSet := map[string]struct{}{}
 
@@ -92,9 +92,11 @@ func affectedLLDPTargets(out *inspect.LLDPOut) (switches, servers []string) {
 		}
 	}
 
+	switches := make([]string, 0, len(swSet))
 	for name := range swSet {
 		switches = append(switches, name)
 	}
+	servers := make([]string, 0, len(srvSet))
 	for name := range srvSet {
 		servers = append(servers, name)
 	}

--- a/pkg/hhfab/lldpcapture.go
+++ b/pkg/hhfab/lldpcapture.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.githedgehog.com/fabric/pkg/hhfctl/inspect"
+	"go.githedgehog.com/fabric/pkg/util/apiutil"
+	"go.githedgehog.com/fabricator/pkg/util/sshutil"
+)
+
+// LLDPInspectCaptureDir is the subdirectory under show-tech-output where
+// per-attempt LLDP captures land. Lives alongside show-tech logs so the same
+// debug bundle picks them up.
+const LLDPInspectCaptureDir = "lldp-inspect-captures"
+
+const lldpCapturePerTargetTimeout = 20 * time.Second
+
+// captureLLDPAtFailure snapshots detailed LLDP state on each switch (and any
+// server on the far end of a missing neighbor) when an inspect attempt fails.
+// Best-effort: a per-target failure is logged but never propagates. Output
+// lands in <WorkDir>/show-tech-output/lldp-inspect-captures/attempt-N/<host>.log
+// so the standard debug bundle contains it.
+func (c *Config) captureLLDPAtFailure(ctx context.Context, vlab *VLAB, attempt int, lldpOut inspect.Out[inspect.LLDPIn]) {
+	out, ok := lldpOut.(*inspect.LLDPOut)
+	if !ok || out == nil {
+		return
+	}
+
+	switches, servers := affectedLLDPTargets(out)
+	if len(switches) == 0 && len(servers) == 0 {
+		return
+	}
+
+	outDir := filepath.Join(c.WorkDir, ShowTechOutputDir, LLDPInspectCaptureDir, fmt.Sprintf("attempt-%d", attempt))
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		slog.Warn("Failed to create LLDP capture directory; skipping", "dir", outDir, "err", err)
+
+		return
+	}
+
+	slog.Info("Capturing LLDP state at inspect failure",
+		"attempt", attempt, "switches", switches, "servers", servers, "dir", outDir)
+
+	var wg sync.WaitGroup
+	for _, sw := range switches {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.captureSwitchLLDP(ctx, vlab, sw, outDir)
+		}()
+	}
+	for _, srv := range servers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.captureServerLLDP(ctx, vlab, srv, outDir)
+		}()
+	}
+	wg.Wait()
+}
+
+// affectedLLDPTargets returns the switches and servers that have a missing
+// non-external expected neighbor. Output is sorted and deduplicated.
+func affectedLLDPTargets(out *inspect.LLDPOut) (switches, servers []string) {
+	swSet := map[string]struct{}{}
+	srvSet := map[string]struct{}{}
+
+	for swName, ports := range out.Neighbors {
+		for _, status := range ports {
+			if status.Type == apiutil.LLDPNeighborTypeExternal {
+				continue
+			}
+			if neighborPresent(status) {
+				continue
+			}
+
+			swSet[swName] = struct{}{}
+			if status.Type == apiutil.LLDPNeighborTypeServer && status.Expected.Name != "" {
+				srvSet[status.Expected.Name] = struct{}{}
+			}
+		}
+	}
+
+	for name := range swSet {
+		switches = append(switches, name)
+	}
+	for name := range srvSet {
+		servers = append(servers, name)
+	}
+	sort.Strings(switches)
+	sort.Strings(servers)
+
+	return switches, servers
+}
+
+func neighborPresent(status apiutil.LLDPNeighborStatus) bool {
+	for _, actual := range status.Actual {
+		if actual.Name == status.Expected.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *Config) captureSwitchLLDP(ctx context.Context, vlab *VLAB, name, outDir string) {
+	captureCtx, cancel := context.WithTimeout(ctx, lldpCapturePerTargetTimeout)
+	defer cancel()
+
+	ssh, err := c.SSH(captureCtx, vlab, name)
+	if err != nil {
+		slog.Warn("LLDP capture: ssh config unavailable", "switch", name, "err", err)
+
+		return
+	}
+
+	out := &strings.Builder{}
+	fmt.Fprintf(out, "=== LLDP inspect failure capture: switch %s at %s ===\n",
+		name, time.Now().UTC().Format(time.RFC3339Nano))
+
+	runOnTarget(captureCtx, ssh, out, "sonic-cli -c 'show lldp neighbor | no-more'")
+	runOnTarget(captureCtx, ssh, out, "docker exec lldp lldpcli show neighbors detail")
+	runOnTarget(captureCtx, ssh, out, "docker exec lldp lldpcli show statistics")
+	runOnTarget(captureCtx, ssh, out, "docker exec lldp lldpcli show chassis")
+
+	writeCapture(outDir, name, out.String())
+}
+
+func (c *Config) captureServerLLDP(ctx context.Context, vlab *VLAB, name, outDir string) {
+	captureCtx, cancel := context.WithTimeout(ctx, lldpCapturePerTargetTimeout)
+	defer cancel()
+
+	ssh, err := c.SSH(captureCtx, vlab, name)
+	if err != nil {
+		slog.Warn("LLDP capture: ssh config unavailable", "server", name, "err", err)
+
+		return
+	}
+
+	out := &strings.Builder{}
+	fmt.Fprintf(out, "=== LLDP inspect failure capture: server %s at %s ===\n",
+		name, time.Now().UTC().Format(time.RFC3339Nano))
+
+	runOnTarget(captureCtx, ssh, out, "networkctl lldp")
+	runOnTarget(captureCtx, ssh, out, "networkctl status")
+	runOnTarget(captureCtx, ssh, out, "ip -d link show")
+	runOnTarget(captureCtx, ssh, out, "sudo journalctl -u systemd-networkd -n 300 --no-pager")
+
+	writeCapture(outDir, name, out.String())
+}
+
+func runOnTarget(ctx context.Context, ssh *sshutil.Config, out *strings.Builder, cmd string) {
+	fmt.Fprintf(out, "\n=== Executing: %s ===\n", cmd)
+	stdout, stderr, err := ssh.Run(ctx, cmd)
+	out.WriteString(stdout)
+	if stderr != "" {
+		fmt.Fprintf(out, "\n--- stderr ---\n%s", stderr)
+	}
+	if err != nil {
+		fmt.Fprintf(out, "\n--- error: %v ---\n", err)
+	}
+}
+
+func writeCapture(outDir, name, content string) {
+	path := filepath.Join(outDir, name+".log")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		slog.Warn("LLDP capture: failed to write file", "path", path, "err", err)
+	}
+}

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -1093,7 +1093,7 @@ func (testCtx *VPCPeeringTestCtx) collectDiagnosticsOnFailure(ctx context.Contex
 	slog.Info("Collecting diagnostics for failed test", "suite", suiteName, "test", testName, "output", testDir)
 
 	// Collect show-tech from VMs and switches using existing VLABShowTech
-	if err := testCtx.vlabCfg.VLABShowTech(ctx, testCtx.vlab, ShowTechOpts{OutputDir: testDir}); err != nil {
+	if err := testCtx.vlabCfg.VLABShowTech(ctx, testCtx.vlab, ShowTechOpts{OutputDir: testDir, OnFailure: true}); err != nil {
 		slog.Warn("Failed to collect show-tech diagnostics", "err", err)
 	} else {
 		slog.Info("Diagnostics collected successfully", "path", testDir)

--- a/pkg/hhfab/show-tech/switch.sh
+++ b/pkg/hhfab/show-tech/switch.sh
@@ -34,6 +34,11 @@ run_sonic_cmd() {
     run_sonic_cmd "show interface description"
     run_sonic_cmd "show interface counters"
     run_sonic_cmd "show lldp table"
+    run_sonic_cmd "show lldp neighbor"
+    echo -e "\n=== lldpcli show neighbors detail (raw lldpd, TTL/time-remaining) ===" >> "$OUTPUT_FILE"
+    docker exec lldp lldpcli show neighbors detail >> "$OUTPUT_FILE" 2>&1
+    echo -e "\n=== lldpcli show statistics ===" >> "$OUTPUT_FILE"
+    docker exec lldp lldpcli show statistics >> "$OUTPUT_FILE" 2>&1
 } >> "$OUTPUT_FILE" 2>&1
 
 # ---------------------------

--- a/pkg/hhfab/sonictechsupport.go
+++ b/pkg/hhfab/sonictechsupport.go
@@ -10,12 +10,19 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 )
+
+// EnvCollectSonicTechsupport opts the failure-path debug bundle into
+// collecting native SONiC tech-support tarballs. Unset or "false" means the
+// expensive collection is skipped even on failure; the manual CLI
+// `hhfab vlab switch show-tech` is unaffected.
+const EnvCollectSonicTechsupport = "HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT"
 
 const (
 	sonicTechsupportPerSwitchTimeout = 45 * time.Minute
@@ -25,6 +32,12 @@ const (
 	sonicTechsupportStartedMarker    = "tech-support process started"
 	sonicTechsupportInProgressMarker = "in progress"
 )
+
+func envCollectSonicTechsupport() bool {
+	v, _ := strconv.ParseBool(os.Getenv(EnvCollectSonicTechsupport))
+
+	return v
+}
 
 // Matches the tarball path SONiC emits in the status output, for example
 // /var/dump/sonic_dump_ds5000-01_20260530_120000.tar.gz.

--- a/pkg/hhfab/sonictechsupport.go
+++ b/pkg/hhfab/sonictechsupport.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	sonicTechsupportPerSwitchTimeout = 15 * time.Minute
+	sonicTechsupportPerSwitchTimeout = 45 * time.Minute
 	sonicTechsupportPollInterval     = 15 * time.Second
 	sonicTechsupportStartCmd         = `sonic-cli -c "show tech-support"`
 	sonicTechsupportStatusCmd        = `sonic-cli -c "show tech-support status"`

--- a/pkg/hhfab/sonictechsupport.go
+++ b/pkg/hhfab/sonictechsupport.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+)
+
+const (
+	sonicTechsupportPerSwitchTimeout = 15 * time.Minute
+	sonicTechsupportPollInterval     = 15 * time.Second
+	sonicTechsupportStartCmd         = `sonic-cli -c "show tech-support"`
+	sonicTechsupportStatusCmd        = `sonic-cli -c "show tech-support status"`
+	sonicTechsupportStartedMarker    = "tech-support process started"
+	sonicTechsupportInProgressMarker = "in progress"
+)
+
+// Matches the tarball path SONiC emits in the status output, for example
+// /var/dump/sonic_dump_ds5000-01_20260530_120000.tar.gz.
+var sonicTechsupportDumpPathRE = regexp.MustCompile(`/var/dump/sonic_dump_[^\s"']+\.tar\.gz`)
+
+// CollectSonicTechsupport runs the native SONiC `show tech-support` on each
+// target switch, polls until completion, and downloads the resulting tarball
+// to outDir. VM switches accept the same sonic-cli command, but Broadcom
+// vendor support will only accept dumps captured from hardware switches.
+// Per-switch failures are logged as warnings and do not fail the call;
+// only outDir creation or kube listing errors are propagated.
+func (c *Config) CollectSonicTechsupport(
+	ctx context.Context,
+	vlab *VLAB,
+	switchNames []string,
+	outDir string,
+) error {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("creating sonic tech-support output directory: %w", err)
+	}
+
+	targets := switchNames
+	if len(targets) == 0 {
+		switches := wiringapi.SwitchList{}
+		if err := c.Client.List(ctx, &switches); err != nil {
+			return fmt.Errorf("listing switches: %w", err)
+		}
+		targets = make([]string, 0, len(switches.Items))
+		for _, sw := range switches.Items {
+			targets = append(targets, sw.Name)
+		}
+	}
+
+	if len(targets) == 0 {
+		slog.Info("No switches to collect SONiC tech-support from")
+
+		return nil
+	}
+
+	slog.Info("Collecting SONiC tech-support", "switches", targets, "outDir", outDir)
+
+	var wg sync.WaitGroup
+	for _, name := range targets {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.collectSonicTechsupportOne(ctx, vlab, name, outDir)
+		}()
+	}
+	wg.Wait()
+
+	return nil
+}
+
+func (c *Config) collectSonicTechsupportOne(ctx context.Context, vlab *VLAB, name, outDir string) {
+	swCtx, cancel := context.WithTimeout(ctx, sonicTechsupportPerSwitchTimeout)
+	defer cancel()
+
+	ssh, err := c.SSH(swCtx, vlab, name)
+	if err != nil {
+		slog.Warn("SONiC tech-support: ssh config unavailable", "switch", name, "err", err)
+
+		return
+	}
+
+	stdout, stderr, err := ssh.Run(swCtx, sonicTechsupportStartCmd)
+	if err != nil {
+		slog.Warn("SONiC tech-support: start command failed", "switch", name, "err", err, "stderr", stderr)
+
+		return
+	}
+	if !strings.Contains(strings.ToLower(stdout), sonicTechsupportStartedMarker) {
+		slog.Warn("SONiC tech-support: unexpected start response", "switch", name, "stdout", stdout)
+
+		return
+	}
+
+	remotePath, err := pollSonicTechsupportStatus(swCtx, ssh, name)
+	if err != nil {
+		slog.Warn("SONiC tech-support: polling status failed", "switch", name, "err", err)
+
+		return
+	}
+
+	localPath := filepath.Join(outDir, name+"-sonic-techsupport.tar.gz")
+	if err := ssh.DownloadPath(remotePath, localPath); err != nil {
+		slog.Warn("SONiC tech-support: download failed", "switch", name, "remote", remotePath, "err", err)
+
+		return
+	}
+
+	slog.Info("SONiC tech-support collected", "switch", name, "path", localPath)
+}
+
+// pollSonicTechsupportStatus polls until the dump path appears in the status
+// output. It returns the remote tarball path or an error if the context
+// expires, ssh fails, or the status output never advertises the path.
+func pollSonicTechsupportStatus(ctx context.Context, ssh interface {
+	Run(ctx context.Context, cmd string) (string, string, error)
+}, name string,
+) (string, error) {
+	ticker := time.NewTicker(sonicTechsupportPollInterval)
+	defer ticker.Stop()
+
+	for {
+		stdout, stderr, err := ssh.Run(ctx, sonicTechsupportStatusCmd)
+		if err != nil {
+			return "", fmt.Errorf("status command: %w (stderr=%q)", err, stderr)
+		}
+
+		lower := strings.ToLower(stdout)
+		match := sonicTechsupportDumpPathRE.FindString(stdout)
+		if !strings.Contains(lower, sonicTechsupportInProgressMarker) && match != "" {
+			return match, nil
+		}
+
+		slog.Debug("SONiC tech-support still running", "switch", name, "status", strings.TrimSpace(stdout))
+
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("context done while waiting for tech-support: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3364,11 +3364,20 @@ func (c *Config) Inspect(ctx context.Context, vlab *VLAB, opts InspectOpts) erro
 
 	const lldpRetryDelay = 30 * time.Second
 
+	// Per-failed-attempt LLDP captures run detached so they never extend the
+	// retry interval: the snapshot itself does SSH round-trips that, if run
+	// inline, lengthen the inspect window enough for a transient LLDP gap to
+	// self-heal and mask the failure (issue #1776). Joined once after the loop
+	// so the final attempt's snapshot still completes before ctx is cancelled.
+	var captureWG sync.WaitGroup
+
 	for attempt := 0; attempt < opts.Attempts; attempt++ {
 		if attempt > 0 {
 			slog.Info("LLDP inspect retry attempt", "number", attempt+1)
 			select {
 			case <-ctx.Done():
+				captureWG.Wait()
+
 				return fmt.Errorf("context cancelled during retry: %w", ctx.Err())
 			case <-time.After(lldpRetryDelay):
 			}
@@ -3386,11 +3395,14 @@ func (c *Config) Inspect(ctx context.Context, vlab *VLAB, opts InspectOpts) erro
 			}
 		}
 
-		// Snapshot detailed switch/server LLDP state on every failed attempt
-		// so transient failures (issue #1776) don't lose evidence between the
-		// retry loop and the post-inspect show-tech bundle.
-		c.captureLLDPAtFailure(ctx, vlab, attempt+1, lldpOut)
+		captureWG.Add(1)
+		go func(attempt int, lldpOut inspect.Out[inspect.LLDPIn]) {
+			defer captureWG.Done()
+			c.captureLLDPAtFailure(ctx, vlab, attempt+1, lldpOut)
+		}(attempt, lldpOut)
 	}
+
+	captureWG.Wait()
 
 	if lldpErr != nil {
 		slog.Error("Failed to inspect LLDP", "err", lldpErr)

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3385,6 +3385,11 @@ func (c *Config) Inspect(ctx context.Context, vlab *VLAB, opts InspectOpts) erro
 				break
 			}
 		}
+
+		// Snapshot detailed switch/server LLDP state on every failed attempt
+		// so transient failures (issue #1776) don't lose evidence between the
+		// retry loop and the post-inspect show-tech bundle.
+		c.captureLLDPAtFailure(ctx, vlab, attempt+1, lldpOut)
 	}
 
 	if lldpErr != nil {

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -923,6 +923,13 @@ func (c *Config) VLABShowTech(ctx context.Context, vlab *VLAB, opts ShowTechOpts
 
 	slog.Info("Show tech files saved in", "folder", outDir)
 
+	// Phase A: always-on collection of native SONiC tech-support tarballs for
+	// Broadcom vendor escalation (issue #1760). Failures here must not turn
+	// an otherwise-successful run into a failure.
+	if err := c.CollectSonicTechsupport(ctx, vlab, nil, filepath.Join(outDir, "sonic-techsupport")); err != nil {
+		slog.Warn("Failed to collect SONiC tech-support", "err", err)
+	}
+
 	return nil
 }
 

--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -738,6 +738,11 @@ func (c *Config) prepareShowTechVMConsoleScript(vmType, script string) (func(), 
 type ShowTechOpts struct {
 	// If empty, defaults to WorkDir/show-tech-output.
 	OutputDir string
+	// OnFailure marks this invocation as part of failure handling. It gates
+	// auxiliary collection that is too expensive to run on every success
+	// (currently: SONiC tech-support tarballs, additionally gated by env var
+	// HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT).
+	OnFailure bool
 }
 
 func (c *Config) VLABShowTech(ctx context.Context, vlab *VLAB, opts ShowTechOpts) error {
@@ -923,11 +928,13 @@ func (c *Config) VLABShowTech(ctx context.Context, vlab *VLAB, opts ShowTechOpts
 
 	slog.Info("Show tech files saved in", "folder", outDir)
 
-	// Phase A: always-on collection of native SONiC tech-support tarballs for
-	// Broadcom vendor escalation (issue #1760). Failures here must not turn
-	// an otherwise-successful run into a failure.
-	if err := c.CollectSonicTechsupport(ctx, vlab, nil, filepath.Join(outDir, "sonic-techsupport")); err != nil {
-		slog.Warn("Failed to collect SONiC tech-support", "err", err)
+	// Collect SONiC tech-support tarballs for Broadcom vendor escalation
+	// (issue #1760), only on failure paths and only when the env var opts
+	// in. Manual `hhfab vlab switch show-tech` is the unconditional path.
+	if opts.OnFailure && envCollectSonicTechsupport() {
+		if err := c.CollectSonicTechsupport(ctx, vlab, nil, filepath.Join(outDir, "sonic-techsupport")); err != nil {
+			slog.Warn("Failed to collect SONiC tech-support", "err", err)
+		}
 	}
 
 	return nil
@@ -1272,7 +1279,7 @@ func (c *Config) CollectVLABDebug(ctx context.Context, vlab *VLAB, opts VLABRunO
 	}
 
 	if (opts.CollectShowTech && forceShowTech) || opts.ForceCollectShowTech {
-		if err := c.VLABShowTech(ctx, vlab, ShowTechOpts{}); err != nil {
+		if err := c.VLABShowTech(ctx, vlab, ShowTechOpts{OnFailure: forceShowTech}); err != nil {
 			slog.Warn("Failed to collect show-tech diagnostics", "err", err)
 		}
 	}


### PR DESCRIPTION
Cherry-picks the #1777 instrumentation stack onto `dev/frostman/bcm-4.6.0` to capture vendor-grade evidence for the #1760 DPB/lldpd race on SONiC 4.6.0.

Both gateway legs (ds4000-01/02 E1/20/1) failed LLDP inspect in the first 4.6.0 run (PR #1844 / run 28427697963), vs. one leg at a time on 4.5.x. The vendor case needs `lldpcli show statistics` (Tx=0 confirmation) and native `show tech-support` tarballs from both spines at failure time.

What this branch adds on top of `dev/frostman/bcm-4.6.0`:
- Per-attempt `lldp-inspect-captures/attempt-N/<host>.log` with `lldpcli show statistics`
- `hhfab vlab switch show-tech` + native SONiC tech-support tarball collection on failure
- TEMP commit: sets `HHFAB_VLAB_COLLECT_SONIC_TECHSUPPORT=true` in CI so tarballs are collected automatically

Not for merge. Campaign branch; drop TEMP commit and split before any merge consideration.