### PR TITLE
chore: bump hostbgp container to v0.2.2

### DIFF
--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -64,7 +64,7 @@ var Versions = fabapi.Versions{
 		ControlProxy:      "v1.11.2-hh2",
 		ControlProxyChart: FabricatorVersion,
 		BashCompletion:    "v2.16.0",
-		HostBGPContainer:  "v0.2.0",
+		HostBGPContainer:  "v0.2.2",
 	},
 	Fabricator: fabapi.FabricatorVersions{
 		API:            FabricatorVersion,

--- a/pkg/hhfab/rt_on_ready_suite.go
+++ b/pkg/hhfab/rt_on_ready_suite.go
@@ -20,6 +20,7 @@ import (
 	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 	"go.githedgehog.com/fabric/pkg/hhfctl"
+	"go.githedgehog.com/fabricator/pkg/fab"
 	"golang.org/x/sync/errgroup"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -596,7 +597,8 @@ func newOnReadyTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []Re
 
 				if plan.hostBGP[serverName] {
 					slog.Debug("Starting hostBGP container", "server", serverName, "args", cmd)
-					_, stderr, err := ssh.Run(ctx, "docker run --network=host --privileged --rm --detach --name hostbgp ghcr.io/githedgehog/host-bgp "+cmd)
+					fullCmd := fmt.Sprintf("docker run --network=host --privileged --rm --detach --name hostbgp ghcr.io/githedgehog/host-bgp:%s %s", fab.Versions.Platform.HostBGPContainer, cmd)
+					_, stderr, err := ssh.Run(ctx, fullCmd)
 					if err != nil {
 						return fmt.Errorf("starting hostbgp on %s: %w: %s", serverName, err, stderr)
 					}

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -1057,7 +1057,8 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 					return fmt.Errorf("running hhnet cleanup: %w: out: %s", err, stderr)
 				}
 				if isHostBGP {
-					_, stderr, err := sshCfg.Run(ctx, "docker run --network=host --privileged --rm --detach --name hostbgp ghcr.io/githedgehog/host-bgp "+netconfs[server.Name])
+					cmd := fmt.Sprintf("docker run --network=host --privileged --rm --detach --name hostbgp ghcr.io/githedgehog/host-bgp:%s %s", fab.Versions.Platform.HostBGPContainer, netconfs[server.Name])
+					_, stderr, err := sshCfg.Run(ctx, cmd)
 					if err != nil {
 						return fmt.Errorf("running hostbgp %q: %w: out: %s", netconfs[server.Name], err, stderr)
 					}


### PR DESCRIPTION
which includes defensive ip link up command for parent and vlan interfaces