### PR TITLE
docs: add RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,6 +44,15 @@ Each job uploads a `release-test.xml`; results are aggregated into a single "Rel
 
 The tag pipeline does not gate on release tests: publishing only requires the build, bundle, and VLAB jobs on the tag itself, and the nightly schedule covers only `master`. A release ref therefore gets its full release-test coverage from a manual CI dispatch on the tag with the `releasetest` input enabled.
 
+The suite can also be run by hand against any deployed VLAB or lab environment with `hhfab vlab release-test`. Useful flags:
+
+- `--list-tests` prints the available tests; `--regex`/`-r` (repeatable) and `--invert-regex` select a subset.
+- `--mode` sets the VPC mode the tests expect: empty means l2vni, `l3vni` for l3vni environments.
+- `--pause-on-failure` stops at each failing scenario so the environment can be inspected live; show-tech diagnostics are collected on failure by default (`--show-tech`).
+- `--fail-fast` stops on the first failure; `--extended` enables the extended tests.
+- `--iperfs-speed` sets the minimum iperf3 speed in Mbit/s for a connectivity check to pass (default 8200; 0 disables speed checks).
+- `--results-file` exports JUnit XML, which is what CI uploads.
+
 ## Gating a release
 
 Release gating happens at the product-release level and takes about two days of work. The process is intentionally lightweight; the tracking issue described below is what makes it accountable.
@@ -90,7 +99,13 @@ Known environment limitations:
 
 ### Gateway performance baseline
 
-Run the gateway performance tests on env-5 each cycle and record the numbers in the internal tracker, compared against the previous cycle's baseline for regressions.
+Each cycle gets a "Baseline YY.MM performance" issue in the internal tracker recording gateway NAT throughput on env-5, compared against the previous cycle's issue:
+
+- Deploy two VPCs peered through the gateway, exposing the iperf3 server both through masquerade NAT and through a TCP port forward, and confirm the endpoints run at the maximum fabric-allowed MTU.
+- From a server in the peering VPC, run iperf3 through the NAT path with increasing parallelism, `toolbox iperf3 -c <exposed IP> -p <forwarded port> -P <1|2|16|128>` (default 10 s runs), for both the masquerade and the port-forward path.
+- Post on the issue: the deployed topology and `GatewayPeering` spec, the endpoint MTU check, each full iperf3 output, and a comparison table of throughput and retransmits per parallelism level against the previous baseline.
+
+A regression in this comparison is a gate failure like any other: it gets investigated, bisecting the intermediate artifacts if needed, and fixed or reverted before the release ships.
 
 ### Go/no-go
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,7 +81,7 @@ The suite currently runs on four topology combinations across two shared lab env
 
 env-5 switches support l3vni mode only, which is why l3vni coverage lives there; ESLAG is incompatible with l3vni, so LAG failover coverage comes from env-1.
 
-The shape of every run, with each environment's fab config and wiring files kept in its home directory (`~/env-1/`, `~/env-5/`):
+The shape of every run (each environment's fab config and wiring files come from the internal lab repository):
 
 ```
 curl -fsSL https://i.hhdev.io/hhfab | USE_SUDO=false INSTALL_DIR=. VERSION=<product release> BINARY_NAME=hhfab-<product release> bash
@@ -111,14 +111,14 @@ A regression in this comparison is a gate failure like any other: it gets invest
 
 The release manager asks QA, usually in a meeting; there is no formal sign-off procedure. Failures found during the gate are investigated and documented on the tracking issue; a problem known to be specific to a test environment does not have to block the release, as long as it is recorded there.
 
-Which product releases the upgrade jobs must pass from is decided by the release manager; a written release support policy is an open gap.
+Which product releases the upgrade jobs must pass from is decided by the release manager; a written release support policy is pending.
 
 ## Pre-release checklist
 
-- Component versions in `pkg/fab/versions.go` are final.
+- A fabricator tag exists and everything below runs against that tag, so the component combination pinned in `pkg/fab/versions.go` is exactly what is tested.
 - The upgrade matrix in `ci.yaml` on `master` tests upgrades from the latest shipped product releases; rotate the `upgradefrom` entries when preparing a release (see the "ci: test upgrades from" commits).
-- CI green on the target ref, including all upgrade jobs.
-- Full release tests pass on the release ref, including upgrade and hardware lab jobs: dispatch CI on the ref with the `releasetest` input, since neither the tag pipeline nor the nightly covers it.
+- CI green on the tag, including all upgrade jobs.
+- Full release tests pass on the tag, including upgrade and hardware lab jobs: dispatch CI on the tag with the `releasetest` input, since neither the tag pipeline nor the nightly covers it.
 
 ## Cutting the release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,6 +44,60 @@ Each job uploads a `release-test.xml`; results are aggregated into a single "Rel
 
 The tag pipeline does not gate on release tests: publishing only requires the build, bundle, and VLAB jobs on the tag itself, and the nightly schedule covers only `master`. A release ref therefore gets its full release-test coverage from a manual CI dispatch on the tag with the `releasetest` input enabled.
 
+## Gating a release
+
+Release gating happens at the product-release level and takes about two days of work. The process is intentionally lightweight; the tracking issue described below is what makes it accountable.
+
+### The tracking issue
+
+For each product release, open a "YY.MM release testing" issue in the internal tracker. It is the evidence record backing the go/no-go decision, structured as:
+
+- a checklist with three sections: the release-test matrix (below), new release tests required for features added in the cycle (with manual testing as a backup while they land), and extra manual checks as the cycle requires (for example input ACLs, host BGP, documentation coverage);
+- one comment per completed run, titled `<topology>@<env> (<fabricator version>)`, containing the exact commands used followed by the full release-test recap. Paste recaps verbatim; the previous cycles' issues are the reference for both format and commands.
+
+Ownership started with the release manager and is shifting to QA; there is no formal procedure beyond this issue.
+
+### CI on the release tag
+
+Dispatch the CI workflow on the release tag with the `releasetest` input enabled: full matrix with the `-rt` suffix, including the upgrade and hardware lab jobs. The release-test suite has no automatic retries, and flaky jobs can block the tag's `publish-release` job, so retry failed jobs until the run is green; chasing and fixing flakes is an ongoing effort.
+
+### Release tests on physical environments
+
+The suite currently runs on four topology combinations across two shared lab environments (reserve the environment via the lab Slack channel topic before starting):
+
+- `sl+l2vni@env-1`: spine-leaf, the only combination exercising MCLAG, ESLAG, bundled, and spine failover.
+- `mesh+l2vni+gw@env-1`: mesh with gateways.
+- `sl+l3vni+gw@env-5`: spine-leaf l3vni with gateways.
+- `mesh+l3vni+gw@env-5`: mesh l3vni with gateways.
+
+env-5 switches support l3vni mode only, which is why l3vni coverage lives there; ESLAG is incompatible with l3vni, so LAG failover coverage comes from env-1.
+
+The shape of every run, with each environment's fab config and wiring files kept in its home directory (`~/env-1/`, `~/env-5/`):
+
+```
+curl -fsSL https://i.hhdev.io/hhfab | USE_SUDO=false INSTALL_DIR=. VERSION=<product release> BINARY_NAME=hhfab-<product release> bash
+./hhfab-<product release> init -f -c <env fab config> -w <env wiring files>
+./hhfab-<product release> vlab up -f -m=manual -r=reinstall -r=inspect
+./hhfab-<product release> vlab release-test
+```
+
+Flags vary per environment and topology (env-5 needs `--vpc-mode=l3vni -r=vpcs --controls-restricted=false` on `vlab up` and `--mode l3vni` on `release-test`); copy the exact command from the same combination in the previous cycle's tracking issue.
+
+Known environment limitations:
+
+- env-1 gateway nodes use NICs that are not officially supported; the Gateway Failover throughput check is inconsistent there.
+- env-4 is not part of the gate: it converges more slowly and some connectivity checks fail on a first attempt and pass on retry.
+
+### Gateway performance baseline
+
+Run the gateway performance tests on env-5 each cycle and record the numbers in the internal tracker, compared against the previous cycle's baseline for regressions.
+
+### Go/no-go
+
+The release manager asks QA, usually in a meeting; there is no formal sign-off procedure. Failures found during the gate are investigated and documented on the tracking issue; a problem known to be specific to a test environment does not have to block the release, as long as it is recorded there.
+
+Which product releases the upgrade jobs must pass from is decided by the release manager; a written release support policy is an open gap.
+
 ## Pre-release checklist
 
 - Component versions in `pkg/fab/versions.go` are final.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,11 +57,13 @@ The suite can also be run by hand against any deployed VLAB or lab environment w
 
 Release gating happens at the product-release level and takes about two days of work. The process is intentionally lightweight; the tracking issue described below is what makes it accountable.
 
+The test plan is iterative, not frozen: besides the fixed release matrix, each cycle adds manual or automated coverage for the features shipping in it, and closes gaps found since the previous cycle, especially issues hit by customers or that escaped earlier rounds of testing. Testing runs continuously through the cycle rather than waiting for a release freeze, supported by existing and in-progress tooling.
+
 ### The tracking issue
 
 For each product release, open a "YY.MM release testing" issue in the internal tracker. It is the evidence record backing the go/no-go decision, structured as:
 
-- a checklist with three sections: the release-test matrix (below), new release tests required for features added in the cycle (with manual testing as a backup while they land), and extra manual checks as the cycle requires (for example input ACLs, host BGP, documentation coverage);
+- a checklist with three sections: the release-test matrix (below), new release tests required for features added in the cycle or for gaps found since the previous one (with manual testing as a backup while they land), and extra manual checks as the cycle requires (for example input ACLs, host BGP, documentation coverage);
 - one comment per completed run, titled `<topology>@<env> (<fabricator version>)`, containing the exact commands used followed by the full release-test recap. Paste recaps verbatim; the previous cycles' issues are the reference for both format and commands.
 
 Ownership started with the release manager and is shifting to QA; there is no formal procedure beyond this issue.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,7 +70,7 @@ Ownership started with the release manager and is shifting to QA; there is no fo
 
 ### CI on the release tag
 
-Dispatch the CI workflow on the release tag with the `releasetest` input enabled: full matrix with the `-rt` suffix, including the upgrade and hardware lab jobs. The release-test suite has no automatic retries, and flaky jobs can block the tag's `publish-release` job, so retry failed jobs until the run is green; chasing and fixing flakes is an ongoing effort.
+Dispatch the CI workflow on the release tag with the `releasetest` input enabled: full matrix with the `-rt` suffix, including the upgrade and hardware lab jobs. The release-test suite has no automatic retries, and flaky jobs can block the tag's `publish-release` job. Failures on the release-test critical path are filed and tracked as known flakes in the internal tracker; retrying a job is backed by that list, not a substitute for filing. Chasing and fixing flakes is an ongoing effort.
 
 ### Release tests on physical environments
 
@@ -114,6 +114,13 @@ A regression in this comparison is a gate failure like any other: it gets invest
 The release manager asks QA, usually in a meeting; there is no formal sign-off procedure. Failures found during the gate are investigated and documented on the tracking issue; a problem known to be specific to a test environment does not have to block the release, as long as it is recorded there.
 
 Which product releases the upgrade jobs must pass from is decided by the release manager; a written release support policy is pending.
+
+### To adopt as the process matures
+
+Not current practice yet; adopt when applicable:
+
+- Turn the recurring tracking-issue structure into an issue template in the internal tracker, so each cycle starts from the same checklist instead of copying the previous issue.
+- At go/no-go, record an explicit decision on the tracking issue for every open issue on the release's critical path: ship with it or block on it, with a one-line reason written by the person deciding. A raised issue then cannot be set aside without a trace, and the reasoning survives for the next cycle.
 
 ## Pre-release checklist
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,77 @@
+# Releasing Fabricator
+
+Runbook for cutting a fabricator release. Release notes for users live in the [docs repository](https://github.com/githedgehog/docs) (published at docs.hedgehog.cloud), not here.
+
+## Release numbering
+
+- Fabricator releases are pre-1.0 SemVer tags: `v0.MINOR.PATCH`. Pushing a tag is what triggers publishing.
+- Releases are rolling: each product release ships the current fabricator line, and patch releases stabilize that line in the run-up to the product release. Going back to patch an already-shipped minor is exceptional.
+- Fabricator versions are independent from Hedgehog product releases, which are named `YY.MM` (for example `26.01`). Each product release pins the single fabricator version it ships, recorded in the release notes in the docs repository (`26.01` shipped fabricator `v0.45.5`).
+- The CI upgrade matrix is keyed on product releases: upgrade jobs (`*-up<release>-*`, for example `v-up26.01-iso-l2vni`) install that product release's hhfab via the public installer (`i.hhdev.io/hhfab` with `VERSION=<product release>`) and upgrade to the current ref.
+
+## Branches
+
+- Minor releases are tagged from `master`; `master` is always the next release candidate.
+- Patch releases for the current minor may be tagged from `master` or, once `master` has diverged, from a `release/vX.Y` branch (for example `release/v0.45`).
+
+## Component versions
+
+Fabricator pins the versions of the components it installs in `pkg/fab/versions.go`. Bump them before tagging, after the corresponding component release exists.
+
+`just bump` covers fabric, dataplane, and FRR:
+
+```
+just bump fabric <version> <ref>   # also updates the Go module and vendor/
+just bump dataplane <version>
+just bump frr <version>
+```
+
+NOS versions (`BCMSONiCVersion`, `CLSSONiCVersion`, `CumulusVersion`) are edited directly in `pkg/fab/versions.go`.
+
+Caveat: `DataplaneVersion` tags both the dataplane and its validator image. The validator is not built for every dataplane commit; a tag without a validator image makes fabric-ctrl crash-loop. Verify both images exist before bumping.
+
+## Release testing
+
+The release test suite is part of the VLAB jobs (`.github/workflows/run-vlab.yaml`). Regular CI runs only the on-ready subset; full release tests run when explicitly enabled, and those jobs carry an `-rt` suffix in their name.
+
+Full release tests run in one of three ways:
+
+- PR labeled `ci:+release` (add `ci:+hlab` to also run the hardware lab `h-*` jobs),
+- manual workflow dispatch with the `releasetest` input (the `releasetest_regex` and `releasetest_regex_invert` inputs select a subset),
+- the nightly scheduled run at 06:00 UTC.
+
+Each job uploads a `release-test.xml`; results are aggregated into a single "Release Tests" check on the run.
+
+The tag pipeline does not gate on release tests: publishing only requires the build, bundle, and VLAB jobs on the tag itself, and the nightly schedule covers only `master`. A release ref therefore gets its full release-test coverage from a manual CI dispatch on the tag with the `releasetest` input enabled.
+
+## Pre-release checklist
+
+- Component versions in `pkg/fab/versions.go` are final.
+- The upgrade matrix in `ci.yaml` on `master` tests upgrades from the latest shipped product releases; rotate the `upgradefrom` entries when preparing a release (see the "ci: test upgrades from" commits).
+- CI green on the target ref, including all upgrade jobs.
+- Full release tests pass on the release ref, including upgrade and hardware lab jobs: dispatch CI on the ref with the `releasetest` input, since neither the tag pipeline nor the nightly covers it.
+
+## Cutting the release
+
+```
+git tag vX.Y.Z <ref>
+git push origin vX.Y.Z
+```
+
+The `publish-release` job in `.github/workflows/ci.yaml` then, gated on the build, bundle, and VLAB jobs passing on the tag:
+
+- publishes images, Helm charts, and multi-arch `hhfab`/`hhfabctl` binaries to ghcr.io,
+- creates the [GitHub release](https://github.com/githedgehog/fabricator/releases) with the binary tarballs attached,
+- opens an automated PR against the docs repository with the regenerated Fabricator API reference.
+
+Note: the workflow currently marks every tag's GitHub release as latest (`make_latest: true`, with a TODO to restrict it to master), including patch tags on older release branches.
+
+## Post-release
+
+- Merge the automated API reference PR in the docs repository; when the tag ships in a product release, record it in the release notes there.
+- Create the `release/vX.Y` branch when the minor needs a patch after `master` has moved on.
+- Verify the published artifacts, e.g. `hhfab init` with the new version and a VLAB bring-up.
+
+## Patch releases
+
+Patch releases stabilize the line being shipped: fixes are cherry-picked from `master` onto `release/vX.Y`, and component bumps on the branch follow the components' own patch releases rather than `master`. Tag the next `vX.Y.Z` from the branch; same checklist and publishing flow as above.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,8 @@ Runbook for cutting a fabricator release. Release notes for users live in the [d
 - Fabricator releases are pre-1.0 SemVer tags: `v0.MINOR.PATCH`. Pushing a tag is what triggers publishing.
 - Releases are rolling: each product release ships the current fabricator line, and patch releases stabilize that line in the run-up to the product release. Going back to patch an already-shipped minor is exceptional.
 - Fabricator versions are independent from Hedgehog product releases, which are named `YY.MM` (for example `26.01`). Each product release pins the single fabricator version it ships, recorded in the release notes in the docs repository (`26.01` shipped fabricator `v0.45.5`).
-- The CI upgrade matrix is keyed on product releases: upgrade jobs (`*-up<release>-*`, for example `v-up26.01-iso-l2vni`) install that product release's hhfab via the public installer (`i.hhdev.io/hhfab` with `VERSION=<product release>`) and upgrade to the current ref.
+- The mapping from a product release to the fabricator version it installs lives in the `hhfab` script in the [installer repository](https://github.com/githedgehog/i.hhdev.io): `VERSION=<product release>` resolves through a `case` entry to a fabricator tag. An entry for the upcoming release is added early in the cycle and re-pointed as new fabricator tags land, so `VERSION=26.02` during gating installs whatever tag is the current candidate.
+- The CI upgrade matrix is keyed on product releases: upgrade jobs (`*-up<release>-*`, for example `v-up26.01-iso-l2vni`) install that product release's hhfab via the public installer (`https://i.hhdev.io/hhfab` with `VERSION=<product release>`) and upgrade to the current ref.
 
 ## Branches
 
@@ -20,7 +21,7 @@ Fabricator pins the versions of the components it installs in `pkg/fab/versions.
 
 `just bump` covers fabric, dataplane, and FRR:
 
-```
+```sh
 just bump fabric <version> <ref>   # also updates the Go module and vendor/
 just bump dataplane <version>
 just bump frr <version>
@@ -32,17 +33,22 @@ Caveat: `DataplaneVersion` tags both the dataplane and its validator image. The 
 
 ## Release testing
 
-The release test suite is part of the VLAB jobs (`.github/workflows/run-vlab.yaml`). Regular CI runs only the on-ready subset; full release tests run when explicitly enabled, and those jobs carry an `-rt` suffix in their name.
+Release testing means the full matrix of the CI workflow (`.github/workflows/ci.yaml`) with release tests turned on. The suite itself lives in the VLAB jobs (`.github/workflows/run-vlab.yaml`, a reusable workflow CI calls per matrix entry). Regular CI runs only the on-ready subset; jobs running the full suite carry an `-rt` suffix in their name.
 
-Full release tests run in one of three ways:
+Release tests and hardware lab jobs are two separate opt-ins, and CI exposes each of them twice, once per trigger:
 
-- PR labeled `ci:+release` (add `ci:+hlab` to also run the hardware lab `h-*` jobs),
-- manual workflow dispatch with the `releasetest` input (the `releasetest_regex` and `releasetest_regex_invert` inputs select a subset),
-- the nightly scheduled run at 06:00 UTC.
+|                        | Full release tests | Hardware lab (`h-*`) jobs |
+|------------------------|--------------------|---------------------------|
+| On a pull request      | `ci:+release` label | `ci:+hlab` label |
+| Run workflow on a ref  | `releasetest` input | `hlab` input |
+
+Checking `releasetest` without `hlab` gives the full VLAB matrix with release tests but no hardware lab coverage. The nightly scheduled run at 06:00 UTC is the third trigger and enables release tests on `master` only.
+
+"Run workflow" here means dispatching the CI workflow itself. A separate "Custom VLAB" workflow (`.github/workflows/custom-vlab.yaml`) dispatches one VLAB configuration instead of the matrix and is the only place with a `releasetest_regex` input; use it to reproduce a single scenario, not to gate a release.
 
 Each job uploads a `release-test.xml`; results are aggregated into a single "Release Tests" check on the run.
 
-The tag pipeline does not gate on release tests: publishing only requires the build, bundle, and VLAB jobs on the tag itself, and the nightly schedule covers only `master`. A release ref therefore gets its full release-test coverage from a manual CI dispatch on the tag with the `releasetest` input enabled.
+The tag pipeline does not gate on release tests: `publish-release` needs only the build, bundle, and VLAB jobs of the tag's own push, and a push never sets `releasetest`. A release tag therefore gets its coverage from a separate run dispatched on that tag.
 
 The suite can also be run by hand against any deployed VLAB or lab environment with `hhfab vlab release-test`. Useful flags:
 
@@ -70,7 +76,7 @@ Ownership started with the release manager and is shifting to QA; there is no fo
 
 ### CI on the release tag
 
-Dispatch the CI workflow on the release tag with the `releasetest` input enabled: full matrix with the `-rt` suffix, including the upgrade and hardware lab jobs. The release-test suite has no automatic retries, and flaky jobs can block the tag's `publish-release` job. Failures on the release-test critical path are filed and tracked as known flakes in the internal tracker; retrying a job is backed by that list, not a substitute for filing. Chasing and fixing flakes is an ongoing effort.
+A tag has no pull request, so the labels are not available: run the CI workflow on the release tag from the Actions tab with both `releasetest` and `hlab` checked. That gives the full matrix with the `-rt` suffix, including the upgrade and hardware lab jobs. This run is the release gate, not a publishing gate: `publish-release` belongs to the tag's push and never carries release tests. The suite has no automatic retries, so a flaky job leaves the gate red until it is rerun. Failures on the release-test critical path are filed and tracked as known flakes in the internal tracker; retrying a job is backed by that list, not a substitute for filing. Chasing and fixing flakes is an ongoing effort.
 
 ### Release tests on physical environments
 
@@ -85,12 +91,14 @@ env-5 switches support l3vni mode only, which is why l3vni coverage lives there;
 
 The shape of every run (each environment's fab config and wiring files come from the internal lab repository):
 
-```
+```sh
 curl -fsSL https://i.hhdev.io/hhfab | USE_SUDO=false INSTALL_DIR=. VERSION=<product release> BINARY_NAME=hhfab-<product release> bash
 ./hhfab-<product release> init -f -c <env fab config> -w <env wiring files>
 ./hhfab-<product release> vlab up -f -m=manual -r=reinstall -r=inspect
 ./hhfab-<product release> vlab release-test
 ```
+
+`VERSION=<product release>` resolves through the installer mapping to whichever fabricator tag is the current candidate, which is why the run comments record the resolved fabricator version rather than the product release name; check the installer output to confirm which tag was installed.
 
 Flags vary per environment and topology (env-5 needs `--vpc-mode=l3vni -r=vpcs --controls-restricted=false` on `vlab up` and `--mode l3vni` on `release-test`); copy the exact command from the same combination in the previous cycle's tracking issue.
 
@@ -124,14 +132,16 @@ Not current practice yet; adopt when applicable:
 
 ## Pre-release checklist
 
+Fabricator tags are cut and published throughout the cycle without gating (see "Cutting the release"). This checklist is what qualifies one of those tags as the version a product release ships.
+
 - A fabricator tag exists and everything below runs against that tag, so the component combination pinned in `pkg/fab/versions.go` is exactly what is tested.
-- The upgrade matrix in `ci.yaml` on `master` tests upgrades from the latest shipped product releases; rotate the `upgradefrom` entries when preparing a release (see the "ci: test upgrades from" commits).
+- The upgrade matrix in `.github/workflows/ci.yaml` on `master` tests upgrades from the latest shipped product releases; rotate the `upgradefrom` entries when preparing a release (see the "ci: test upgrades from" commits).
 - CI green on the tag, including all upgrade jobs.
-- Full release tests pass on the tag, including upgrade and hardware lab jobs: dispatch CI on the tag with the `releasetest` input, since neither the tag pipeline nor the nightly covers it.
+- Full release tests pass on the tag, including upgrade and hardware lab jobs: run the CI workflow on the tag with `releasetest` and `hlab` checked, since neither the tag's own push nor the nightly covers it.
 
 ## Cutting the release
 
-```
+```sh
 git tag vX.Y.Z <ref>
 git push origin vX.Y.Z
 ```
@@ -147,6 +157,7 @@ Note: the workflow currently marks every tag's GitHub release as latest (`make_l
 ## Post-release
 
 - Merge the automated API reference PR in the docs repository; when the tag ships in a product release, record it in the release notes there.
+- Update the installer repository: re-point the product release's `YY.MM` entry at the tag while it is the candidate, and promote `latest` to it once the release passes go/no-go. A new `YY.MM.Z` entry is how a later patch reaches users.
 - Create the `release/vX.Y` branch when the minor needs a patch after `master` has moved on.
 - Verify the published artifacts, e.g. `hhfab init` with the new version and a VLAB bring-up.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@ just bump frr <version>
 
 NOS versions (`BCMSONiCVersion`, `CLSSONiCVersion`, `CumulusVersion`) are edited directly in `pkg/fab/versions.go`.
 
-The same file carries `Release`, the user-facing product release number referenced in the docs (`26.03.0` during the 26.03 cycle). Bump it to the new cycle's number at the start of the cycle, in the same change as the upgrade matrix rotation.
+The same file carries `Release`, the user-facing product release number referenced in the docs (`26.03.0` during the 26.03 cycle). It is bumped after the previous release ships, not during the cycle it names; see Post-release.
 
 Caveat: `DataplaneVersion` tags both the dataplane and its validator image. The validator is not built for every dataplane commit; a tag without a validator image makes fabric-ctrl crash-loop. Verify both images exist before bumping.
 
@@ -136,7 +136,6 @@ Not current practice yet; adopt when applicable:
 
 Fabricator tags are cut and published throughout the cycle without gating (see "Cutting the release"). This checklist is what qualifies one of those tags as the version a product release ships.
 
-- The upgrade matrix in `.github/workflows/ci.yaml` tests upgrades from the two latest shipped product releases, so during the 26.03 cycle it runs from 26.01 and 26.02. Rotation belongs at the start of a cycle rather than at its end: the change that adds the just-shipped release as an `upgradefrom` source is the same one that bumps `Release` in `pkg/fab/versions.go` to the new cycle's number. Landing it that early is what puts it in every tag of the cycle, which matters because a tag's CI uses the `ci.yaml` that tag carries; a late rotation would leave the tag testing the old matrix. Nothing tests upgrading from the release currently being prepared.
 - A fabricator tag exists and everything below runs against that tag, so the component combination pinned in `pkg/fab/versions.go` is what is tested.
 - CI green on the tag, including all upgrade jobs.
 - Full release tests pass on the tag, including upgrade and hardware lab jobs: run the CI workflow on the tag with `releasetest` and `hlab` checked, since neither the tag's own push nor the nightly covers it.
@@ -160,6 +159,7 @@ Note: the workflow currently marks every tag's GitHub release as latest (`make_l
 
 - Merge the automated API reference PR in the docs repository; when the tag ships in a product release, record it in the release notes there.
 - Update the installer repository: re-point the product release's `YY.MM` entry at the tag while it is the candidate, and promote `latest` to it once the release passes go/no-go. A new `YY.MM.Z` entry is how a later patch reaches users.
+- Set up the next cycle in one change on `master`: add the release that just shipped to the `upgradefrom` entries in `.github/workflows/ci.yaml`, and bump `Release` in `pkg/fab/versions.go` to the next cycle's number (see the "ci: test upgrades from" commits). Whether the new entry replaces the oldest or is added alongside it follows the support decision described under Go/no-go; today the matrix runs from both 26.01 and 26.02. Nothing tests upgrading from the release being prepared, so this never gates the cycle it closes.
 - Create the `release/vX.Y` branch when the minor needs a patch after `master` has moved on.
 - Verify the published artifacts, e.g. `hhfab init` with the new version and a VLAB bring-up.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,6 +29,8 @@ just bump frr <version>
 
 NOS versions (`BCMSONiCVersion`, `CLSSONiCVersion`, `CumulusVersion`) are edited directly in `pkg/fab/versions.go`.
 
+The same file carries `Release`, the user-facing product release number referenced in the docs (`26.03.0` during the 26.03 cycle). Bump it to the new cycle's number at the start of the cycle, in the same change as the upgrade matrix rotation.
+
 Caveat: `DataplaneVersion` tags both the dataplane and its validator image. The validator is not built for every dataplane commit; a tag without a validator image makes fabric-ctrl crash-loop. Verify both images exist before bumping.
 
 ## Release testing
@@ -134,7 +136,7 @@ Not current practice yet; adopt when applicable:
 
 Fabricator tags are cut and published throughout the cycle without gating (see "Cutting the release"). This checklist is what qualifies one of those tags as the version a product release ships.
 
-- The upgrade matrix in `.github/workflows/ci.yaml` tests upgrades from the latest shipped product releases and from the release being prepared. Rotate the `upgradefrom` entries on `master` before cutting the tag the gate runs against: a tag's CI uses the `ci.yaml` that tag carries, so rotating afterwards leaves the tag testing the old matrix (see the "ci: test upgrades from" commits). The entry for the cycle's own release resolves only once the installer maps it, so the order is early candidate tag, installer entry, rotation, gate tag.
+- The upgrade matrix in `.github/workflows/ci.yaml` tests upgrades from the two latest shipped product releases, so during the 26.03 cycle it runs from 26.01 and 26.02. Rotation belongs at the start of a cycle rather than at its end: the change that adds the just-shipped release as an `upgradefrom` source is the same one that bumps `Release` in `pkg/fab/versions.go` to the new cycle's number. Landing it that early is what puts it in every tag of the cycle, which matters because a tag's CI uses the `ci.yaml` that tag carries; a late rotation would leave the tag testing the old matrix. Nothing tests upgrading from the release currently being prepared.
 - A fabricator tag exists and everything below runs against that tag, so the component combination pinned in `pkg/fab/versions.go` is what is tested.
 - CI green on the tag, including all upgrade jobs.
 - Full release tests pass on the tag, including upgrade and hardware lab jobs: run the CI workflow on the tag with `releasetest` and `hlab` checked, since neither the tag's own push nor the nightly covers it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -134,8 +134,8 @@ Not current practice yet; adopt when applicable:
 
 Fabricator tags are cut and published throughout the cycle without gating (see "Cutting the release"). This checklist is what qualifies one of those tags as the version a product release ships.
 
-- A fabricator tag exists and everything below runs against that tag, so the component combination pinned in `pkg/fab/versions.go` is exactly what is tested.
-- The upgrade matrix in `.github/workflows/ci.yaml` on `master` tests upgrades from the latest shipped product releases; rotate the `upgradefrom` entries when preparing a release (see the "ci: test upgrades from" commits).
+- The upgrade matrix in `.github/workflows/ci.yaml` tests upgrades from the latest shipped product releases and from the release being prepared. Rotate the `upgradefrom` entries on `master` before cutting the tag the gate runs against: a tag's CI uses the `ci.yaml` that tag carries, so rotating afterwards leaves the tag testing the old matrix (see the "ci: test upgrades from" commits). The entry for the cycle's own release resolves only once the installer maps it, so the order is early candidate tag, installer entry, rotation, gate tag.
+- A fabricator tag exists and everything below runs against that tag, so the component combination pinned in `pkg/fab/versions.go` is what is tested.
 - CI green on the tag, including all upgrade jobs.
 - Full release tests pass on the tag, including upgrade and hardware lab jobs: run the CI workflow on the tag with `releasetest` and `hlab` checked, since neither the tag's own push nor the nightly covers it.
 


### PR DESCRIPTION
Documents the release process: numbering, branches, component bumps, release testing and the gate, publishing, and post-release steps. Written as a handover runbook for the next release cycles.