### PR TITLE
chore: shrink TH5 workaround VLAN range

### DIFF
--- a/api/fabricator/v1beta1/fabricator_types.go
+++ b/api/fabricator/v1beta1/fabricator_types.go
@@ -531,7 +531,7 @@ func (f *Fabricator) Default() {
 
 	if len(f.Spec.Config.Fabric.TH5WorkaroundVLANs) == 0 {
 		f.Spec.Config.Fabric.TH5WorkaroundVLANs = []fmeta.VLANRange{
-			{From: 3900, To: 3999},
+			{From: 3900, To: 3966},
 		}
 	}
 

--- a/pkg/fab/defaults.go
+++ b/pkg/fab/defaults.go
@@ -49,7 +49,7 @@ var DefaultConfig = fabapi.FabConfig{
 		DefaultSwitchUsers:  map[string]fabapi.SwitchUser{},
 		DefaultAlloyConfig:  fmeta.AlloyConfig{},
 		TH5WorkaroundVLANs: []fmeta.VLANRange{
-			{From: 3900, To: 3999},
+			{From: 3900, To: 3966}, // the 3967-4094 range is reserved in BCM SONiC
 		},
 	},
 	Gateway: fabapi.GatewayConfig{


### PR DESCRIPTION
as it overlaps with a reserved VLAN range in BCM SONiC, which started to be strictly validated in 4.6.0

related to https://github.com/githedgehog/internal/issues/435