### PR TITLE
fix(hhfab): power-cycle switch on install-failure reinstall retries

### DIFF
--- a/pkg/hhfab/vlabhelpers.go
+++ b/pkg/hhfab/vlabhelpers.go
@@ -515,14 +515,17 @@ func (c *Config) VLABSwitchReinstall(ctx context.Context, opts SwitchReinstallOp
 					}
 
 					var exitErr *exec.ExitError
-					if errors.As(err, &exitErr) && exitErr.ExitCode() == errorConsole {
-						slog.Info("Reinstall attempt failed", "attempt", attempt, "switch", sw.Name, "reason", "console connection error, initiating hard reset")
+					if errors.As(err, &exitErr) && (exitErr.ExitCode() == errorConsole || exitErr.ExitCode() == errorInstall) {
+						reason := "console connection error, initiating hard reset"
+						if exitErr.ExitCode() == errorInstall {
+							reason = "install did not complete, initiating hard reset"
+						}
 						backoffSeconds := baseBackoff * (1 << (attempt - 1))
 
 						slog.Info("Reinstall attempt failed",
 							"attempt", attempt,
 							"switch", sw.Name,
-							"reason", "console connection error, initiating hard reset",
+							"reason", reason,
 							"next_retry_delay", fmt.Sprintf("%ds", backoffSeconds))
 
 						powerOpts := SwitchPowerOpts{
@@ -546,9 +549,10 @@ func (c *Config) VLABSwitchReinstall(ctx context.Context, opts SwitchReinstallOp
 					}
 
 					backoffSeconds := baseBackoff * (1 << (attempt - 1))
-					slog.Info("Reinstall attempt failed with non-console error",
+					slog.Info("Reinstall attempt failed, retrying without hard reset",
 						"attempt", attempt,
 						"switch", sw.Name,
+						"error", err,
 						"next_retry_delay", fmt.Sprintf("%ds", backoffSeconds))
 					time.Sleep(time.Second * time.Duration(backoffSeconds))
 


### PR DESCRIPTION
`VLABSwitchReinstall`'s per-attempt retry loop only re-triggered a PDU power cycle when the previous attempt exited with `errorConsole` (console connection error). A switch that boots but wedges post-boot (syncd fails to create the SAI switch object, orchagent dies) never reaches "System is ready" and exits with `errorInstall` instead, which fell into the generic branch that just sleeps and retries without a power cycle. In hard-reset mode the expect script's next attempt only watches for a GRUB menu that cannot appear without a fresh power cycle, so retries 2 and 3 were guaranteed to fail identically.

This broadens the power-cycle condition to also fire on `errorInstall`, so a switch that wedges post-boot gets a real power cycle before each retry. `errorLogin`, `errorHHFab`, and `errorUnknown` stay on the no-power-cycle path.

The underlying syncd/orchagent crash is a chronic, transient Broadcom SAI issue on Dell S5248F (githedgehog/lab#217, no software-layer fix); this change just makes hhfab's own 3 built-in retries productive against it instead of 2 of the 3 being no-op console watches.

Fixes githedgehog/internal#449
Related githedgehog/lab#217
