### PR TITLE
chore: bump hostbgp container to v0.3.0

### DIFF
--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -64,7 +64,7 @@ var Versions = fabapi.Versions{
 		ControlProxy:      "v1.11.2-hh2",
 		ControlProxyChart: FabricatorVersion,
 		BashCompletion:    "v2.16.0",
-		HostBGPContainer:  "v0.2.2",
+		HostBGPContainer:  "v0.3.0",
 	},
 	Fabricator: fabapi.FabricatorVersions{
 		API:            FabricatorVersion,


### PR DESCRIPTION
which includes static routes at startup config