### PR TITLE
fix(testing): don't count deny checks when the probe never ran

### DIFF
--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -2883,6 +2883,19 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 	if pe.Received > 0 && pe.Sent != pe.Received {
 		pe.Lost = parsePingLostSeqs(stdout, pe.Sent)
 	}
+	if err != nil {
+		// Exit 126/127 means the shell never handed off to ping (missing binary,
+		// permission denied); any other non-ExitError means the command never
+		// completed on the remote end (SSH/session failure, ctx timeout). Neither
+		// tells us anything about reachability, so don't let it pass as a deny.
+		// Ping's own exit codes (e.g. 1 for no reply, 2 for no route) fall through
+		// to the existing sent/received classification below.
+		if status, ok := sshutil.ExitStatus(err); !ok || status == 126 || status == 127 {
+			pe.Msg = fmt.Sprintf("ping did not execute: %s", err)
+
+			return pe
+		}
+	}
 	if pe.Sent == 0 && err == nil {
 		pe.Msg = "cannot parse ping output to get sent packets"
 
@@ -3183,6 +3196,18 @@ func checkCurl(ctx context.Context, opts TestConnectivityOpts, curls *semaphore.
 		cmd := fmt.Sprintf("timeout -v 5 curl --insecure --connect-timeout 3 --silent http://%s", toIP)
 		stdout, stderr, err := retrySSHCmd(ctx, fromSSH, cmd, from)
 		ce.Output = stdout
+
+		if err != nil {
+			// Exit 126/127 means the shell never handed off to timeout/curl (missing
+			// binary, permission denied); any other non-ExitError means the command
+			// never completed on the remote end (SSH/session failure, ctx timeout).
+			// Neither is a curl-level deny signal, so don't let it pass as one.
+			if status, ok := sshutil.ExitStatus(err); !ok || status == 126 || status == 127 {
+				ce.Msg = fmt.Sprintf("curl did not execute: %s", err)
+
+				return ce
+			}
+		}
 
 		curlOk := err == nil && strings.Contains(stdout, "301 Moved")
 		curlFail := err != nil && !strings.Contains(stdout, "301 Moved")

--- a/pkg/util/sshutil/ssh.go
+++ b/pkg/util/sshutil/ssh.go
@@ -5,6 +5,7 @@ package sshutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/appleboy/easyssh-proxy"
 	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
 )
 
 var ErrTimeout = fmt.Errorf("timeout")
@@ -103,6 +105,19 @@ func (c *Config) Run(ctx context.Context, cmd string) (string, string, error) {
 	}
 
 	return outStr, errStr, nil
+}
+
+// ExitStatus reports the remote process's exit code from an error returned by
+// Run, if the command actually started on the remote end and exited. It
+// returns false for connect/session-setup failures and context
+// cancellation/timeout, where the command may never have run.
+func ExitStatus(err error) (int, bool) {
+	var exitErr *ssh.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitStatus(), true
+	}
+
+	return 0, false
 }
 
 func (c *Config) StreamLog(ctx context.Context, cmd string, logName string, log func(msg string, args ...any)) error {


### PR DESCRIPTION
## Summary

`checkPing` and `checkCurl` (pkg/hhfab/testing.go) classify an expected-deny check as passing whenever the remote probe command returns a non-nil error with no received packets/output. But that same signal shape also occurs when the probe never actually executed (exec failure, SSH session loss after discovery, context timeout). No traffic is ever sent, yet the deny assertion counts as verified.

## Fix

- `checkPing`: broadens the existing parse guard to fire whenever `pe.Sent == 0`, regardless of `err`. Ping always prints its `N packets transmitted` summary line when it actually runs, even at 100% loss, so a genuine deny still parses `Sent > 0`; exec failures/timeouts/SSH loss never produce that line.
- `checkCurl`: has no equivalent stdout signal (a genuine deny, exit 28/7 with empty stdout, is shape-identical to an exec failure). Added `sshutil.ExitStatus(err)`, which extracts the remote exit code via `errors.As` against `*ssh.ExitError`. Exit 126/127 (POSIX "not executable"/"not found") or a non-`ExitError` failure (connect/session failure, ctx timeout) now short-circuits to an unconditional failure before the expected/actual classification runs.

Both `checkPing` and `checkCurl` are shared by the release-test suites (rt_nat_tests.go, rt_nat_external_tests.go, rt_multi_vpc_multi_subnet_suite.go), not just `hhfab vlab test-connectivity`, so this closes the same hole in negative assertions there too.

Closes #1893