### PR TITLE
bump: hostbgp to v0.4.0 to get roce, vlan alias and arm64

### DIFF
--- a/pkg/fab/versions.go
+++ b/pkg/fab/versions.go
@@ -64,7 +64,7 @@ var Versions = fabapi.Versions{
 		ControlProxy:      "v1.11.2-hh2",
 		ControlProxyChart: FabricatorVersion,
 		BashCompletion:    "v2.16.0",
-		HostBGPContainer:  "v0.3.0",
+		HostBGPContainer:  "v0.4.0",
 	},
 	Fabricator: fabapi.FabricatorVersions{
 		API:            FabricatorVersion,


### PR DESCRIPTION
Part of githedgehog/fabric#1533