### PR TITLE
fix(diagrams): replace mclag references with eslag

### DIFF
--- a/hack/README_Test_Diagrams.md
+++ b/hack/README_Test_Diagrams.md
@@ -24,8 +24,8 @@ just test-diagram "/path/to/vlab" "-y"
 The system generates diagrams for these network topologies:
 
 - **Default**: Standard 2-spine, 2-leaf VLAB configuration
-- **3spine**: 3-spine topology with MCLAG and orphan leafs
-- **4mclag2orphan**: 4 MCLAG leafs with 2 orphan leafs
+- **3spine**: 3-spine topology with ESLAG and orphan leafs
+- **4eslag2orphan**: 4 ESLAG leafs (2 groups of 2) with 2 orphan leafs
 - **Mesh**: Mesh topology with inter-leaf connections
 - **Live**: Real-time diagrams from running VLAB (optional)
 
@@ -97,7 +97,7 @@ test-diagram/
 │   └── default.mermaid.svg  # If Mermaid CLI available
 ├── 3spine/
 ├── mesh/
-├── 4mclag2orphan/
+├── 4eslag2orphan/
 ├── live/                    # If vlab_workdir specified
 └── diagram-viewer.html      # Interactive HTML viewer
 ```

--- a/hack/README_Trivy_Scans.md
+++ b/hack/README_Trivy_Scans.md
@@ -104,7 +104,6 @@ classDef gateway fill:#FFF2CC,stroke:#999,stroke-width:1px,color:#000
 classDef spine   fill:#F8CECC,stroke:#B85450,stroke-width:1px,color:#000
 classDef leaf    fill:#DAE8FC,stroke:#6C8EBF,stroke-width:1px,color:#000
 classDef server  fill:#D5E8D4,stroke:#82B366,stroke-width:1px,color:#000
-classDef mclag   fill:#F0F8FF,stroke:#6C8EBF,stroke-width:1px,color:#000
 
 subgraph Gateways
 	direction TB
@@ -144,7 +143,6 @@ class Gateway_1 gateway
 class Spine_01,Spine_02 spine
 class Leaf_01 leaf
 class Server_01 server
-class MCLAG mclag
 linkStyle default stroke:#666,stroke-width:2px
 linkStyle 0,1 stroke:#CC9900,stroke-dasharray: 2 2,stroke-width:2px,color:#CC9900 %% Gateway links
 linkStyle 2,3 stroke:#CC3333,stroke-width:4px %% Fabric links

--- a/hack/diagrams.just
+++ b/hack/diagrams.just
@@ -2,7 +2,7 @@
 
 test-diagram vlab_workdir="" y="": _check-hhfab
   @if [ -n "{{vlab_workdir}}" ]; then mkdir -p test-diagram/live; fi
-  @mkdir -p test-diagram/default test-diagram/3spine test-diagram/mesh test-diagram/4mclag2orphan
+  @mkdir -p test-diagram/default test-diagram/3spine test-diagram/mesh test-diagram/4eslag2orphan
   @echo "==============================================="
   @echo "Diagram generation test - various topologies, formats, and styles"
   @if [ -n "{{vlab_workdir}}" ]; then echo "Live diagrams from vlab workdir: {{vlab_workdir}}"; fi
@@ -60,7 +60,7 @@ test-diagram vlab_workdir="" y="": _check-hhfab
   bin/hhfab diagram --format mermaid --output test-diagram/default/default.mermaid
 
   @echo "=== Generating diagrams for variant 3-spine topology ==="
-  bin/hhfab vlab gen --spines-count 3 --mclag-leafs-count 2 --orphan-leafs-count 1 --eslag-leaf-groups 2
+  bin/hhfab vlab gen --spines-count 3 --orphan-leafs-count 1 --eslag-leaf-groups 2,2
 
   # Generate all formats and styles for 3-spine topology
   bin/hhfab diagram --format drawio --style default --output test-diagram/3spine/default.drawio
@@ -68,16 +68,6 @@ test-diagram vlab_workdir="" y="": _check-hhfab
   bin/hhfab diagram --format drawio --style hedgehog --output test-diagram/3spine/hedgehog.drawio
   bin/hhfab diagram --format dot --output test-diagram/3spine/3spine.dot
   bin/hhfab diagram --format mermaid --output test-diagram/3spine/3spine.mermaid
-
-  @echo "=== Generating diagrams for 4-mclag-2-orphan topology ==="
-  bin/hhfab vlab gen --mclag-leafs-count 4 --orphan-leafs-count 2
-
-  # Generate all formats and styles for 4-mclag-2-orphan topology
-  bin/hhfab diagram --format drawio --style default --output test-diagram/4mclag2orphan/default.drawio
-  bin/hhfab diagram --format drawio --style cisco --output test-diagram/4mclag2orphan/cisco.drawio
-  bin/hhfab diagram --format drawio --style hedgehog --output test-diagram/4mclag2orphan/hedgehog.drawio
-  bin/hhfab diagram --format dot --output test-diagram/4mclag2orphan/4mclag2orphan.dot
-  bin/hhfab diagram --format mermaid --output test-diagram/4mclag2orphan/4mclag2orphan.mermaid
 
   @echo "=== Generating diagrams for mesh topology ==="
   bin/hhfab vlab gen --mesh-links-count 2
@@ -88,6 +78,16 @@ test-diagram vlab_workdir="" y="": _check-hhfab
   bin/hhfab diagram --format drawio --style hedgehog --output test-diagram/mesh/hedgehog.drawio
   bin/hhfab diagram --format dot --output test-diagram/mesh/mesh.dot
   bin/hhfab diagram --format mermaid --output test-diagram/mesh/mesh.mermaid
+
+  @echo "=== Generating diagrams for 4-eslag-2-orphan topology ==="
+  bin/hhfab vlab gen --eslag-leaf-groups 2,2 --orphan-leafs-count 2
+
+  # Generate all formats and styles for 4-eslag-2-orphan topology
+  bin/hhfab diagram --format drawio --style default --output test-diagram/4eslag2orphan/default.drawio
+  bin/hhfab diagram --format drawio --style cisco --output test-diagram/4eslag2orphan/cisco.drawio
+  bin/hhfab diagram --format drawio --style hedgehog --output test-diagram/4eslag2orphan/hedgehog.drawio
+  bin/hhfab diagram --format dot --output test-diagram/4eslag2orphan/4eslag2orphan.dot
+  bin/hhfab diagram --format mermaid --output test-diagram/4eslag2orphan/4eslag2orphan.mermaid
 
   # Convert DRAWIO files to SVG
   @echo "=== Converting DRAWIO files to SVG ==="
@@ -134,7 +134,7 @@ test-diagram vlab_workdir="" y="": _check-hhfab
   @echo "Summary of generated topology directories:"
   @echo "- Default VLAB topology: test-diagram/default/"
   @echo "- 3-spine VLAB topology: test-diagram/3spine/"
-  @echo "- 4-mclag-2-orphan topology: test-diagram/4mclag2orphan/"
+  @echo "- 4-eslag-2-orphan topology: test-diagram/4eslag2orphan/"
   @echo "- Mesh topology: test-diagram/mesh/"
   @if [ -n "{{vlab_workdir}}" ]; then echo "- Live diagrams (if VLAB in {{vlab_workdir}}): test-diagram/live/"; fi
 

--- a/hack/generate_viewer.go
+++ b/hack/generate_viewer.go
@@ -49,7 +49,7 @@ var (
 			"live":          "🔴 Live",
 			"default":       "🏠 Default",
 			"3spine":        "🌐 Multi-Spine",
-			"4mclag2orphan": "🔗 MCLAG",
+			"4eslag2orphan": "🔗 ESLAG",
 			"mesh":          "🕸️ Mesh",
 			"spine-leaf":    "🌿 Spine-Leaf",
 			"gateway":       "🌐 Gateway",

--- a/hack/vlab-trivy-runner.sh
+++ b/hack/vlab-trivy-runner.sh
@@ -233,7 +233,7 @@ if [ "$USE_EXISTING_VLAB" = false ]; then
         # Generate topology if switch scanning is enabled
         if [ "$RUN_SWITCH" = true ]; then
             echo -e "${YELLOW}Generating VLAB topology for switch scanning...${NC}"
-            $HHFAB_BIN vlab gen --spines-count 2 --fabric-links-count 1 --orphan-leafs-count 1 --mclag-leafs-count 0 --unbundled-servers 1 --bundled-servers 0 --mclag-servers 0 --eslag-servers 0
+            $HHFAB_BIN vlab gen --spines-count 2 --fabric-links-count 1 --orphan-leafs-count 1 --unbundled-servers 1 --bundled-servers 0 --eslag-servers 0
         fi
     fi
 

--- a/pkg/fab/recipe/control_upgrade.go
+++ b/pkg/fab/recipe/control_upgrade.go
@@ -266,7 +266,7 @@ func (c *ControlUpgrade) checkUpgradeConstraints(ctx context.Context, kube kclie
 		return fmt.Errorf("listing connections: %w", err)
 	}
 	for _, conn := range connections.Items {
-		if conn.Spec.MCLAG != nil || conn.Spec.MCLAGDomain != nil {
+		if conn.Spec.MCLAG != nil || conn.Spec.MCLAGDomain != nil { //nolint:staticcheck // deprecated on purpose: we're looking for leftover MCLAG to refuse the upgrade
 			mclagConns = append(mclagConns, conn.Name)
 		}
 	}

--- a/pkg/hhfab/diagram/drawio.go
+++ b/pkg/hhfab/diagram/drawio.go
@@ -647,14 +647,7 @@ func createLegend(links []Link, style Style) []MxCell {
 	linkTypesMap := make(map[string]bool)
 
 	for _, link := range links {
-		// First check for MCLAG links which use "mclagType" property
-		if mclagType, ok := link.Properties[PropMCLAGType]; ok {
-			if mclagType == MCLAGTypePeer {
-				linkTypesMap[LegendKeyMCLAGPeer] = true
-			} else if mclagType == MCLAGTypeSession {
-				linkTypesMap[LegendKeyMCLAGSession] = true
-			}
-		} else if _, ok := link.Properties[PropBundled]; ok {
+		if _, ok := link.Properties[PropBundled]; ok {
 			linkTypesMap[LegendKeyBundled] = true
 		} else if _, ok := link.Properties[PropESLAGServer]; ok {
 			linkTypesMap[LegendKeyESLAGServer] = true
@@ -662,9 +655,6 @@ func createLegend(links []Link, style Style) []MxCell {
 			linkTypesMap[LegendKeyGateway] = true
 		} else {
 			switch link.Type {
-			case EdgeTypeMCLAG:
-				// If it's an MCLAG link without a specific type, it's a server link
-				linkTypesMap[LegendKeyMCLAGServer] = true
 			case EdgeTypeBundled:
 				linkTypesMap[LegendKeyBundled] = true
 			case EdgeTypeESLAG:
@@ -740,9 +730,6 @@ func createLegend(links []Link, style Style) []MxCell {
 	}{
 		{LegendKeyFabric, style.FabricLinkStyle, "Fabric Links"},
 		{LegendKeyMesh, style.MeshLinkStyle, "Mesh Links"},
-		{LegendKeyMCLAGPeer, style.MCLAGPeerStyle, "MCLAG Peer Links"},
-		{LegendKeyMCLAGSession, style.MCLAGSessionStyle, "MCLAG Session Links"},
-		{LegendKeyMCLAGServer, style.MCLAGServerStyle, "MCLAG Server Links"},
 		{LegendKeyBundled, style.BundledServerStyle, "Bundled Server Links"},
 		{LegendKeyUnbundled, style.UnbundledStyle, "Unbundled Server Links"},
 		{LegendKeyESLAGServer, style.ESLAGServerStyle, "ESLAG Server Links"},
@@ -1453,7 +1440,7 @@ func createRedundancyGroupLayer(model *MxGraphModel, redundancyGroups map[string
 		minX, minY := float64(9999), float64(9999)
 		maxX, maxY := float64(-9999), float64(-9999)
 
-		redundancyType := "mclag"
+		redundancyType := ""
 		for _, switchNode := range switches {
 			if redType, ok := switchNode.Properties[PropRedundancyType]; ok {
 				redundancyType = redType
@@ -1531,9 +1518,6 @@ func createRedundancyGroupLayer(model *MxGraphModel, redundancyGroups map[string
 
 		var strokeColor, strokeStyle string
 		switch redundancyType {
-		case RedundancyTypeMCLAG:
-			strokeColor = "#9cc1f7"
-			strokeStyle = "dashed=1;dashPattern=5 5;"
 		case RedundancyTypeESLAG:
 			strokeColor = "#d79b00"
 			strokeStyle = "dashed=1;dashPattern=5 5;"

--- a/pkg/hhfab/diagram/graphviz.go
+++ b/pkg/hhfab/diagram/graphviz.go
@@ -16,7 +16,6 @@ const (
 
 	ColorFabric    = "red"
 	ColorMesh      = "blue"
-	ColorMCLAG     = "blue"
 	ColorBundled   = "green"
 	ColorUnbundled = "gray"
 	ColorESLAG     = "orange"
@@ -137,14 +136,7 @@ func generateDOT(topo Topology) string {
 		}
 
 		// Track link types for legend
-		// Check for MCLAG links which use "mclagType" property
-		if mclagType, ok := link.Properties[PropMCLAGType]; ok {
-			if mclagType == MCLAGTypePeer {
-				linkTypesPresent["mclag_peer"] = true
-			} else if mclagType == MCLAGTypeSession {
-				linkTypesPresent["mclag_session"] = true
-			}
-		} else if _, ok := link.Properties[PropBundled]; ok {
+		if _, ok := link.Properties[PropBundled]; ok {
 			linkTypesPresent["bundled"] = true
 		} else if _, ok := link.Properties[PropESLAGServer]; ok {
 			linkTypesPresent["eslag_server"] = true
@@ -152,8 +144,6 @@ func generateDOT(topo Topology) string {
 			linkTypesPresent["gateway"] = true
 		} else {
 			switch link.Type {
-			case EdgeTypeMCLAG:
-				linkTypesPresent["mclag_server"] = true
 			case EdgeTypeBundled:
 				linkTypesPresent["bundled"] = true
 			case EdgeTypeESLAG:
@@ -267,24 +257,6 @@ func generateDOT(topo Topology) string {
 		b.WriteString("\t\t\t<TR>\n")
 		b.WriteString("\t\t\t<TD ALIGN=\"LEFT\" VALIGN=\"MIDDLE\"><FONT COLOR=\"blue\">────</FONT></TD>\n")
 		b.WriteString(fmt.Sprintf("\t\t\t<TD ALIGN=\"LEFT\">%s</TD>\n", meshLabel))
-		b.WriteString("\t\t\t</TR>\n")
-	}
-	if linkTypesPresent["mclag_peer"] {
-		b.WriteString("\t\t\t<TR>\n")
-		b.WriteString("\t\t\t<TD ALIGN=\"LEFT\" VALIGN=\"MIDDLE\"><FONT COLOR=\"purple\">- - - -</FONT></TD>\n")
-		b.WriteString("\t\t\t<TD ALIGN=\"LEFT\">MCLAG Peer Links</TD>\n")
-		b.WriteString("\t\t\t</TR>\n")
-	}
-	if linkTypesPresent["mclag_session"] {
-		b.WriteString("\t\t\t<TR>\n")
-		b.WriteString("\t\t\t<TD ALIGN=\"LEFT\" VALIGN=\"MIDDLE\"><FONT COLOR=\"purple\">────</FONT></TD>\n")
-		b.WriteString("\t\t\t<TD ALIGN=\"LEFT\">MCLAG Session Links</TD>\n")
-		b.WriteString("\t\t\t</TR>\n")
-	}
-	if linkTypesPresent["mclag_server"] {
-		b.WriteString("\t\t\t<TR>\n")
-		b.WriteString("\t\t\t<TD ALIGN=\"LEFT\" VALIGN=\"MIDDLE\"><FONT COLOR=\"purple\">────</FONT></TD>\n")
-		b.WriteString("\t\t\t<TD ALIGN=\"LEFT\">MCLAG Server Links</TD>\n")
 		b.WriteString("\t\t\t</TR>\n")
 	}
 	if linkTypesPresent["bundled"] {
@@ -623,9 +595,6 @@ func generateDOT(topo Topology) string {
 		case EdgeTypeMesh:
 			color = ColorMesh
 			style = StyleSolid
-		case EdgeTypeMCLAG:
-			color = ColorMCLAG
-			style = StyleDashed
 		case EdgeTypeBundled:
 			color = ColorBundled
 			style = StyleSolid

--- a/pkg/hhfab/diagram/mermaid.go
+++ b/pkg/hhfab/diagram/mermaid.go
@@ -43,7 +43,6 @@ func generateMermaid(topo Topology) string {
 	b.WriteString("classDef spine   fill:#F8CECC,stroke:#B85450,stroke-width:1px,color:#000\n")
 	b.WriteString("classDef leaf    fill:#DAE8FC,stroke:#6C8EBF,stroke-width:1px,color:#000\n")
 	b.WriteString("classDef server  fill:#D5E8D4,stroke:#82B366,stroke-width:1px,color:#000\n")
-	b.WriteString("classDef mclag   fill:#F0F8FF,stroke:#6C8EBF,stroke-width:1px,color:#000\n")
 	b.WriteString("classDef eslag   fill:#FFF8E8,stroke:#CC9900,stroke-width:1px,color:#000\n")
 	b.WriteString("classDef external fill:#FFCC99,stroke:#D79B00,stroke-width:1px,color:#000\n")
 	b.WriteString("classDef hidden fill:none,stroke:none\n")
@@ -213,28 +212,6 @@ func generateMermaid(topo Topology) string {
 	bundledConnections := make(map[string]map[string]int) // Track bundled connections
 
 	for _, link := range topo.Links {
-		if link.Type == EdgeTypeMCLAG {
-			sourceIsLeaf := false
-			targetIsLeaf := false
-
-			for _, node := range topo.Nodes {
-				if node.ID == link.Source && node.Type == NodeTypeSwitch {
-					if role, ok := node.Properties[PropRole]; ok && role != SwitchRoleSpine {
-						sourceIsLeaf = true
-					}
-				}
-				if node.ID == link.Target && node.Type == NodeTypeSwitch {
-					if role, ok := node.Properties[PropRole]; ok && role != SwitchRoleSpine {
-						targetIsLeaf = true
-					}
-				}
-			}
-
-			if sourceIsLeaf && targetIsLeaf {
-				continue
-			}
-		}
-
 		// Track bundled connections for aggregation
 		if link.Type == EdgeTypeBundled {
 			var leaf, server string
@@ -289,8 +266,6 @@ func generateMermaid(topo Topology) string {
 				connType = EdgeTypeFabric
 			case EdgeTypeMesh:
 				connType = EdgeTypeMesh
-			case EdgeTypeMCLAG:
-				connType = EdgeTypeMCLAG
 			case EdgeTypeBundled:
 				connType = EdgeTypeBundled
 			case EdgeTypeUnbundled:
@@ -324,7 +299,6 @@ func generateMermaid(topo Topology) string {
 	gatewayLinks := []int{}
 	spineLeafLinks := []int{}
 	meshLinks := []int{}
-	mclagLinks := []int{}
 	bundledLinks := []int{}
 	eslagLinks := []int{}
 	unbundledLinks := []int{}
@@ -560,8 +534,6 @@ func generateMermaid(topo Topology) string {
 
 			connType := leafServerTypes[connectionKey]
 			switch connType {
-			case EdgeTypeMCLAG:
-				mclagLinks = append(mclagLinks, linkIndex)
 			case EdgeTypeBundled:
 				bundledLinks = append(bundledLinks, linkIndex)
 			case EdgeTypeESLAG:
@@ -781,10 +753,6 @@ func generateMermaid(topo Topology) string {
 		b.WriteString("\tL15(( )) --- |\"Mesh Links\"| L16(( ))\n")
 	}
 
-	if len(mclagLinks) > 0 {
-		b.WriteString("\tL3(( )) --- |\"MCLAG Server Links\"| L4(( ))\n")
-	}
-
 	if len(bundledLinks) > 0 {
 		bundledLabel := "Bundled Server Links"
 		if maxParallelConnections["bundled"] > 1 {
@@ -859,14 +827,8 @@ func generateMermaid(topo Topology) string {
 
 	// Use actual redundancy group names in subgraphs
 	for groupName := range redundancySubgraphs {
-		redundancyType := redundancyTypes[groupName]
-		cleanGroupName := cleanID(groupName)
-
-		switch redundancyType {
-		case RedundancyTypeMCLAG:
-			b.WriteString(fmt.Sprintf("class %s mclag\n", cleanGroupName))
-		case RedundancyTypeESLAG:
-			b.WriteString(fmt.Sprintf("class %s eslag\n", cleanGroupName))
+		if redundancyTypes[groupName] == RedundancyTypeESLAG {
+			b.WriteString(fmt.Sprintf("class %s eslag\n", cleanID(groupName)))
 		}
 	}
 
@@ -912,10 +874,6 @@ func generateMermaid(topo Topology) string {
 		b.WriteString(fmt.Sprintf("linkStyle %s stroke:#0078D4,stroke-width:4px\n", formatIndices(meshLinks)))
 	}
 
-	if len(mclagLinks) > 0 {
-		b.WriteString(fmt.Sprintf("linkStyle %s stroke:#99CCFF,stroke-width:4px,stroke-dasharray:5 5\n", formatIndices(mclagLinks)))
-	}
-
 	if len(bundledLinks) > 0 {
 		b.WriteString(fmt.Sprintf("linkStyle %s stroke:#66CC66,stroke-width:4px\n", formatIndices(bundledLinks)))
 	}
@@ -948,11 +906,6 @@ func generateMermaid(topo Topology) string {
 
 	if len(meshLinks) > 0 {
 		b.WriteString(fmt.Sprintf("linkStyle %d stroke:#0078D4,stroke-width:2px\n", legendLinkStart+legendLinkIndex))
-		legendLinkIndex++
-	}
-
-	if len(mclagLinks) > 0 {
-		b.WriteString(fmt.Sprintf("linkStyle %d stroke:#6C8EBF,stroke-width:2px,stroke-dasharray:5 5\n", legendLinkStart+legendLinkIndex))
 		legendLinkIndex++
 	}
 

--- a/pkg/hhfab/diagram/styles.go
+++ b/pkg/hhfab/diagram/styles.go
@@ -30,9 +30,6 @@ type Style struct {
 	ExternalNodeStyle       string
 	FabricLinkStyle         string
 	MeshLinkStyle           string
-	MCLAGPeerStyle          string
-	MCLAGSessionStyle       string
-	MCLAGServerStyle        string
 	BundledServerStyle      string
 	UnbundledStyle          string
 	ESLAGServerStyle        string
@@ -64,9 +61,6 @@ func getDefaultStyle() Style {
 		ExternalNodeStyle:       "shape=rectangle;rounded=1;whiteSpace=wrap;html=1;fontSize=11;fillColor=#ffcc99;strokeColor=#d79b00;",
 		FabricLinkStyle:         "endArrow=none;html=1;strokeWidth=3;strokeColor=#b85450;",
 		MeshLinkStyle:           "endArrow=none;html=1;strokeWidth=3;strokeColor=#6c8ebf;",
-		MCLAGPeerStyle:          "endArrow=none;html=1;strokeWidth=2;strokeColor=#2f5597;dashed=1;",
-		MCLAGSessionStyle:       "endArrow=none;html=1;strokeWidth=2;strokeColor=#4472c4;dashed=1;",
-		MCLAGServerStyle:        "endArrow=none;html=1;strokeWidth=2;strokeColor=#9cc1f7;dashed=1;",
 		BundledServerStyle:      "endArrow=none;html=1;strokeWidth=2;strokeColor=#82b366;",
 		UnbundledStyle:          "endArrow=none;html=1;strokeWidth=2;strokeColor=#666666;",
 		ESLAGServerStyle:        "endArrow=none;html=1;strokeWidth=2;strokeColor=#d79b00;dashed=1;",
@@ -103,9 +97,6 @@ func getCiscoStyle() Style {
 			"perimeter=ellipsePerimeter;",
 		FabricLinkStyle:         "endArrow=none;html=1;strokeWidth=3;strokeColor=#4F95D0;",
 		MeshLinkStyle:           "endArrow=none;html=1;strokeWidth=3;strokeColor=#0078D4;",
-		MCLAGPeerStyle:          "endArrow=none;html=1;strokeWidth=2;strokeColor=#2f5597;dashed=1;",
-		MCLAGSessionStyle:       "endArrow=none;html=1;strokeWidth=2;strokeColor=#4472c4;dashed=1;",
-		MCLAGServerStyle:        "endArrow=none;html=1;strokeWidth=2;strokeColor=#9cc1f7;dashed=1;",
 		BundledServerStyle:      "endArrow=none;html=1;strokeWidth=2;strokeColor=#82b366;",
 		UnbundledStyle:          "endArrow=none;html=1;strokeWidth=2;strokeColor=#666666;",
 		ESLAGServerStyle:        "endArrow=none;html=1;strokeWidth=2;strokeColor=#d79b00;dashed=1;",
@@ -142,9 +133,6 @@ func getHedgehogStyle() Style {
 			"perimeter=ellipsePerimeter;",
 		FabricLinkStyle:         "endArrow=none;html=1;strokeWidth=3;strokeColor=#8D6E4F;",
 		MeshLinkStyle:           "endArrow=none;html=1;strokeWidth=3;strokeColor=#A1887F;",
-		MCLAGPeerStyle:          "endArrow=none;html=1;strokeWidth=2;strokeColor=#8D6E63;dashed=1;",
-		MCLAGSessionStyle:       "endArrow=none;html=1;strokeWidth=2;strokeColor=#A1887F;dashed=1;",
-		MCLAGServerStyle:        "endArrow=none;html=1;strokeWidth=2;strokeColor=#BCAAA4;dashed=1;",
 		BundledServerStyle:      "endArrow=none;html=1;strokeWidth=2;strokeColor=#82b366;",
 		UnbundledStyle:          "endArrow=none;html=1;strokeWidth=2;strokeColor=#666666;",
 		ESLAGServerStyle:        "endArrow=none;html=1;strokeWidth=2;strokeColor=#d79b00;dashed=1;",
@@ -189,19 +177,6 @@ func GetLinkStyleFromTheme(link Link, style Style) string {
 		return ExtractStyleParameters(style.FabricLinkStyle)
 	case EdgeTypeMesh:
 		return ExtractStyleParameters(style.MeshLinkStyle)
-	case EdgeTypeMCLAG:
-		if mclagType, ok := link.Properties["mclagType"]; ok {
-			switch mclagType {
-			case "peer":
-				return ExtractStyleParameters(style.MCLAGPeerStyle)
-			case "session":
-				return ExtractStyleParameters(style.MCLAGSessionStyle)
-			default:
-				return ExtractStyleParameters(style.MCLAGServerStyle)
-			}
-		} else {
-			return ExtractStyleParameters(style.MCLAGServerStyle)
-		}
 	case EdgeTypeBundled:
 		return ExtractStyleParameters(style.BundledServerStyle)
 	case EdgeTypeUnbundled:

--- a/pkg/hhfab/diagram/topology.go
+++ b/pkg/hhfab/diagram/topology.go
@@ -108,9 +108,9 @@ func findConnectionTypes(links []Link) map[string]*serverConnection {
 		conn.connTypes[leaf] = append(conn.connTypes[leaf], link.Type)
 	}
 
-	// Find MCLAG/ESLAG pairs
+	// Find ESLAG pairs
 	for s1, conn1 := range serverConns {
-		if conn1.mclagPair != "" || conn1.eslagPair != "" {
+		if conn1.eslagPair != "" {
 			continue
 		}
 
@@ -125,7 +125,7 @@ func findConnectionTypes(links []Link) map[string]*serverConnection {
 
 			// Check if connection patterns match
 			match := true
-			pairType := ""
+			eslag := false
 			for leaf, types1 := range conn1.connTypes {
 				types2, exists := conn2.connTypes[leaf]
 				if !exists || len(types1) != len(types2) {
@@ -142,22 +142,15 @@ func findConnectionTypes(links []Link) map[string]*serverConnection {
 
 						break
 					}
-					if types1[i] == EdgeTypeMCLAG {
-						pairType = EdgeTypeMCLAG
-					} else if types1[i] == EdgeTypeESLAG && pairType == "" {
-						pairType = EdgeTypeESLAG
+					if types1[i] == EdgeTypeESLAG {
+						eslag = true
 					}
 				}
 			}
 
-			if match && pairType != "" {
-				if pairType == EdgeTypeMCLAG {
-					conn1.mclagPair = s2
-					conn2.mclagPair = s1
-				} else {
-					conn1.eslagPair = s2
-					conn2.eslagPair = s1
-				}
+			if match && eslag {
+				conn1.eslagPair = s2
+				conn2.eslagPair = s1
 			}
 		}
 	}
@@ -371,12 +364,6 @@ func sortNodes(nodes []Node, links []Link) TieredNodes {
 			c1, c2 := serverConns[s1], serverConns[s2]
 
 			// Keep pairs together
-			if c1.mclagPair == s2 {
-				return s1 < s2 // Smaller ID first in MCLAG pair
-			}
-			if c2.mclagPair == s1 {
-				return s2 < s1 // Smaller ID first in MCLAG pair
-			}
 			if c1.eslagPair == s2 {
 				return s1 < s2 // Smaller ID first in ESLAG pair
 			}
@@ -420,10 +407,6 @@ func sortNodes(nodes []Node, links []Link) TieredNodes {
 
 				// Add pair immediately after if not yet seen
 				conn := serverConns[server]
-				if conn.mclagPair != "" && !seenServers[conn.mclagPair] {
-					orderedServers = append(orderedServers, conn.mclagPair)
-					seenServers[conn.mclagPair] = true
-				}
 				if conn.eslagPair != "" && !seenServers[conn.eslagPair] {
 					orderedServers = append(orderedServers, conn.eslagPair)
 					seenServers[conn.eslagPair] = true
@@ -700,8 +683,6 @@ func GetTopologyFor(ctx context.Context, client kclient.Reader) (Topology, error
 			serverPort = conn.Spec.Unbundled.Link.Server.Port
 		case conn.Spec.Bundled != nil && len(conn.Spec.Bundled.Links) > 0 && conn.Spec.Bundled.Links[0].Server.Port != "":
 			serverPort = conn.Spec.Bundled.Links[0].Server.Port
-		case conn.Spec.MCLAG != nil && len(conn.Spec.MCLAG.Links) > 0 && conn.Spec.MCLAG.Links[0].Server.Port != "":
-			serverPort = conn.Spec.MCLAG.Links[0].Server.Port
 		case conn.Spec.ESLAG != nil && len(conn.Spec.ESLAG.Links) > 0 && conn.Spec.ESLAG.Links[0].Server.Port != "":
 			serverPort = conn.Spec.ESLAG.Links[0].Server.Port
 		}
@@ -748,9 +729,8 @@ func GetTopologyFor(ctx context.Context, client kclient.Reader) (Topology, error
 		}
 
 		// Handle standard (non-external) connections
-		if conn.Spec.Fabric != nil || conn.Spec.Mesh != nil || conn.Spec.Gateway != nil || conn.Spec.MCLAGDomain != nil ||
-			conn.Spec.Unbundled != nil || conn.Spec.MCLAG != nil || conn.Spec.Bundled != nil ||
-			conn.Spec.ESLAG != nil {
+		if conn.Spec.Fabric != nil || conn.Spec.Mesh != nil || conn.Spec.Gateway != nil ||
+			conn.Spec.Unbundled != nil || conn.Spec.Bundled != nil || conn.Spec.ESLAG != nil {
 			// Build per-port-pair IP map for underlay (fabric/mesh/gateway connections only)
 			type pairIPs struct{ src, dst string }
 			portPairIPs := map[string]pairIPs{}
@@ -794,21 +774,6 @@ func GetTopologyFor(ctx context.Context, client kclient.Reader) (Topology, error
 					if stateMap, ok := bgpNeighborStateMap[link.Source]; ok {
 						if state, ok := stateMap[dstIPOnly]; ok && state != "" {
 							link.Properties[PropBGPState] = string(state)
-						}
-					}
-				}
-
-				if conn.Spec.MCLAGDomain != nil {
-					link.Type = EdgeTypeMCLAG // just to keep compat with current diagram impl
-
-					for _, connLink := range conn.Spec.MCLAGDomain.PeerLinks {
-						if connLink.Switch1.Port == source && connLink.Switch2.Port == target {
-							link.Properties[PropMCLAGType] = MCLAGTypePeer
-						}
-					}
-					for _, connLink := range conn.Spec.MCLAGDomain.SessionLinks {
-						if connLink.Switch1.Port == source && connLink.Switch2.Port == target {
-							link.Properties[PropMCLAGType] = MCLAGTypeSession
 						}
 					}
 				}

--- a/pkg/hhfab/diagram/types.go
+++ b/pkg/hhfab/diagram/types.go
@@ -56,7 +56,6 @@ type SubnetInfo struct {
 const (
 	EdgeTypeFabric         = wiringapi.ConnectionTypeFabric
 	EdgeTypeMesh           = wiringapi.ConnectionTypeMesh
-	EdgeTypeMCLAG          = wiringapi.ConnectionTypeMCLAG
 	EdgeTypeSpine          = "spine" // TODO
 	EdgeTypeBundled        = wiringapi.ConnectionTypeBundled
 	EdgeTypeUnbundled      = wiringapi.ConnectionTypeUnbundled
@@ -94,7 +93,6 @@ type serverConnection struct {
 	primaryLeaf   string
 	secondaryLeaf string
 	connTypes     map[string][]string // leaf -> connection types
-	mclagPair     string
 	eslagPair     string
 }
 
@@ -106,7 +104,6 @@ type NodeMetrics struct {
 }
 
 const (
-	PropMCLAGType        = "mclagType"
 	PropSourcePort       = "sourcePort"
 	PropTargetPort       = "targetPort"
 	PropSourcePortStatus = "sourcePortStatus"
@@ -135,16 +132,8 @@ const (
 )
 
 const (
-	MCLAGTypePeer    = "peer"
-	MCLAGTypeSession = "session"
-)
-
-const (
 	LegendKeyFabric         = "fabric"
 	LegendKeyMesh           = "mesh"
-	LegendKeyMCLAGPeer      = "mclag_peer"
-	LegendKeyMCLAGSession   = "mclag_session"
-	LegendKeyMCLAGServer    = "mclag_server"
 	LegendKeyBundled        = "bundled"
 	LegendKeyUnbundled      = "unbundled"
 	LegendKeyESLAGServer    = "eslag_server"
@@ -170,6 +159,5 @@ const (
 )
 
 const (
-	RedundancyTypeMCLAG = "mclag"
 	RedundancyTypeESLAG = "eslag"
 )

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -35,7 +35,6 @@ const (
 
 var (
 	errNoExternals       = errors.New("no external peers found")
-	errNoMclags          = errors.New("no MCLAG connections found")
 	errNoEslags          = errors.New("no ESLAG connections found")
 	errNoBundled         = errors.New("no bundled connections found")
 	errNoUnbundled       = errors.New("no unbundled connections found")

--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -60,14 +60,6 @@ func makeSingleVPCSuite() *JUnitTestSuite {
 			F:    dhcpStaticLeaseTest,
 		},
 		{
-			Name: "MCLAG Failover",
-			F:    mclagTest,
-			SkipFlags: SkipFlags{
-				VirtualSwitch: true,
-				NoServers:     true,
-			},
-		},
-		{
 			Name: "ESLAG Failover",
 			F:    eslagTest,
 			SkipFlags: SkipFlags{
@@ -121,41 +113,6 @@ func makeSingleVPCSuite() *JUnitTestSuite {
 	suite.Tests = len(suite.TestCases)
 
 	return suite
-}
-
-// Basic test for mclag failover.
-// For each mclag connection, set one of the links down by shutting down the port on the switch,
-// then test connectivity. Repeat for the other link.
-func mclagTest(ctx context.Context, testCtx *VPCPeeringTestCtx) (bool, []RevertFunc, error) {
-	// list connections in the fabric, filter by MC-LAG connection type
-	conns := &wiringapi.ConnectionList{}
-	if err := testCtx.kube.List(ctx, conns, kclient.MatchingLabels{wiringapi.LabelConnectionType: wiringapi.ConnectionTypeMCLAG}); err != nil {
-		return false, nil, fmt.Errorf("listing connections: %w", err)
-	}
-	if len(conns.Items) == 0 {
-		slog.Info("No MCLAG connections found, skipping test")
-
-		return true, nil, errNoMclags
-	}
-	for _, conn := range conns.Items {
-		slog.Debug("Testing MCLAG connection", "connection", conn.Name)
-		if len(conn.Spec.MCLAG.Links) != 2 {
-			return false, nil, fmt.Errorf("MCLAG connection %s has %d links, expected 2", conn.Name, len(conn.Spec.MCLAG.Links)) //nolint:goerr113
-		}
-		for _, link := range conn.Spec.MCLAG.Links {
-			if err := shutDownLinkAndTest(ctx, testCtx, link); err != nil {
-				return false, nil, err
-			}
-			// TODO: set other link down too and make sure that connectivity is lost
-			if !testCtx.extended {
-				slog.Debug("Skipping other link, set extended=true to iterate over all links")
-
-				break
-			}
-		}
-	}
-
-	return false, nil, nil
 }
 
 // Basic test for eslag failover.

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -407,10 +407,6 @@ func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (st
 			for _, link := range conn.Spec.Bundled.Links {
 				netconfCmd += " " + link.Server.LocalPortName()
 			}
-		} else if conn.Spec.MCLAG != nil {
-			for _, link := range conn.Spec.MCLAG.Links {
-				netconfCmd += " " + link.Server.LocalPortName()
-			}
 		} else if conn.Spec.ESLAG != nil {
 			for _, link := range conn.Spec.ESLAG.Links {
 				netconfCmd += " " + link.Server.LocalPortName()
@@ -440,10 +436,6 @@ func getServerHostBGPCmd(conn *wiringapi.Connection, vlan uint16, subnet netip.P
 		interfaces = append(interfaces, conn.Spec.Unbundled.Link.Server.LocalPortName())
 	case conn.Spec.Bundled != nil:
 		for _, link := range conn.Spec.Bundled.Links {
-			interfaces = append(interfaces, link.Server.LocalPortName())
-		}
-	case conn.Spec.MCLAG != nil:
-		for _, link := range conn.Spec.MCLAG.Links {
 			interfaces = append(interfaces, link.Server.LocalPortName())
 		}
 	case conn.Spec.ESLAG != nil:

--- a/pkg/hhfab/vlabconfig.go
+++ b/pkg/hhfab/vlabconfig.go
@@ -693,7 +693,7 @@ func createVLABConfig(ctx context.Context, controls []fabapi.ControlNode, nodes 
 	}
 
 	for _, conn := range conns.Items {
-		if conn.Spec.Fabric != nil { //nolint:gocritic
+		if conn.Spec.Fabric != nil {
 			for _, link := range conn.Spec.Fabric.Links {
 				if err := addLink(link.Spine.Port, link.Leaf.Port); err != nil {
 					return nil, fmt.Errorf("failed to add link for fabric connection %s: %w", conn.Name, err)
@@ -721,8 +721,8 @@ func createVLABConfig(ctx context.Context, controls []fabapi.ControlNode, nodes 
 					return nil, fmt.Errorf("failed to add link for bundled connection %s: %w", conn.Name, err)
 				}
 			}
-		} else if conn.Spec.MCLAG != nil {
-			for _, link := range conn.Spec.MCLAG.Links {
+		} else if mclag := conn.Spec.MCLAG; mclag != nil { //nolint:staticcheck // deprecated, but VLAB should still bring up pre-existing MCLAG wiring
+			for _, link := range mclag.Links {
 				if err := addLink(link.Server.Port, link.Switch.Port); err != nil {
 					return nil, fmt.Errorf("failed to add link for MCLAG connection %s: %w", conn.Name, err)
 				}
@@ -739,13 +739,13 @@ func createVLABConfig(ctx context.Context, controls []fabapi.ControlNode, nodes 
 					return nil, fmt.Errorf("failed to add link for VPC loopback connection %s: %w", conn.Name, err)
 				}
 			}
-		} else if conn.Spec.MCLAGDomain != nil {
-			for _, link := range conn.Spec.MCLAGDomain.SessionLinks {
+		} else if mclagDomain := conn.Spec.MCLAGDomain; mclagDomain != nil { //nolint:staticcheck // deprecated, but VLAB should still bring up pre-existing MCLAG wiring
+			for _, link := range mclagDomain.SessionLinks {
 				if err := addLink(link.Switch1.Port, link.Switch2.Port); err != nil {
 					return nil, fmt.Errorf("failed to add session link for MCLAG domain connection %s: %w", conn.Name, err)
 				}
 			}
-			for _, link := range conn.Spec.MCLAGDomain.PeerLinks {
+			for _, link := range mclagDomain.PeerLinks {
 				if err := addLink(link.Switch1.Port, link.Switch2.Port); err != nil {
 					return nil, fmt.Errorf("failed to add peer link for MCLAG domain connection %s: %w", conn.Name, err)
 				}


### PR DESCRIPTION
Follow-up to the MCLAG removal from https://github.com/githedgehog/fabricator/pull/1899: hhfab vlab generate no longer has --mclag-leafs-count, but hack/diagrams.just and hack/vlab-trivy-runner.sh still passed it.

- hack/diagrams.just: the old 4-mclag-2-orphan test-diagram scenario relied on that flag. Replaced it with a 4-eslag-2-orphan scenario (--eslag-leaf-groups 2,2 --orphan-leafs-count 2) instead of just deleting it, for richer diagram coverage. Tested locally with `just test-diagram "" -y`.
- hack/vlab-trivy-runner.sh: dropped the dead --mclag-leafs-count 0 / --mclag-servers 0 flags (both already zero, no behavior change).
- Updated hack/README_Test_Diagrams.md, hack/generate_viewer.go and hack/README_Trivy_Scans.md accordingly.