### PR TITLE
test-connectivity follow-up + multihomed unbundled + ACLs

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1440,7 +1440,7 @@ Examples:
 								return err
 							}
 
-							if _, err := hhfab.DoVLABSetupVPCs(ctx, workDir, cacheDir, hhfab.SetupVPCsOpts{
+							if _, _, err := hhfab.DoVLABSetupVPCs(ctx, workDir, cacheDir, hhfab.SetupVPCsOpts{
 								WaitSwitchesReady: c.Bool("wait-switches-ready"),
 								ForceCleanup:      c.Bool("force-cleanup"),
 								VLANNamespace:     c.String("vlanns"),

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -183,10 +183,10 @@ func DoShowTech(ctx context.Context, workDir, cacheDir string) error {
 	return c.VLABShowTech(ctx, vlab, ShowTechOpts{})
 }
 
-func DoVLABSetupVPCs(ctx context.Context, workDir, cacheDir string, opts SetupVPCsOpts) ([]*Endpoint, error) {
+func DoVLABSetupVPCs(ctx context.Context, workDir, cacheDir string, opts SetupVPCsOpts) ([]*Endpoint, []DroppedEndpoint, error) {
 	c, vlab, err := loadVLABForHelpers(ctx, workDir, cacheDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return c.SetupVPCs(ctx, vlab, opts)

--- a/pkg/hhfab/endpoints.go
+++ b/pkg/hhfab/endpoints.go
@@ -20,14 +20,8 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// SSHResolver returns the SSH config for a server. The collector and per-
-// server refresh helpers take one of these instead of a pre-built
-// map[string]*sshutil.Config so callers can share whatever SSH plumbing
-// they already have (SetupVPCs builds a map keyed by VM name; rt_* tests
-// resolve lazily through testCtx.getSSH).
 type SSHResolver func(server string) (*sshutil.Config, error)
 
-// SSHResolverFromMap adapts a pre-built map into an SSHResolver.
 func SSHResolverFromMap(m map[string]*sshutil.Config) SSHResolver {
 	return func(server string) (*sshutil.Config, error) {
 		cfg, ok := m[server]
@@ -39,9 +33,6 @@ func SSHResolverFromMap(m map[string]*sshutil.Config) SSHResolver {
 	}
 }
 
-// discoveredIP pairs a server-side interface name with the address found
-// on it. The interface tells us whether the address is a hostBGP /32 VIP
-// (on `lo`) or a regular subnet address (on the bond/VLAN interface).
 type discoveredIP struct {
 	iface  string
 	prefix netip.Prefix
@@ -78,12 +69,8 @@ func discoverServerIPs(ctx context.Context, sshCfg *sshutil.Config, server strin
 }
 
 // DroppedEndpoint records an attachment or address that endpoint discovery
-// could not turn into a testable *Endpoint. A drop is not an error on its
-// own — plain `hhfab vlab setup-vpcs` tolerates it — but it does mean some
-// part of the topology is invisible to the connectivity matrix, and
-// ConnectivityMatrix.Validate refuses to run a test against a matrix that
-// carries any. VPC/Subnet are empty when the drop is about an address that
-// matched no attachment.
+// could not turn into a testable *Endpoint. ConnectivityMatrix.Validate()
+// refuses to run a test against a matrix that carries any of these.
 type DroppedEndpoint struct {
 	Server string
 	VPC    string
@@ -99,8 +86,6 @@ func (d DroppedEndpoint) String() string {
 	return fmt.Sprintf("%s (%s/%s): %s", d.Server, d.VPC, d.Subnet, d.Reason)
 }
 
-// serverAttachment is the (vpc, subnet) information the collector resolves
-// from a VPCAttachment + its referenced VPC CRD.
 type serverAttachment struct {
 	vpcName    string
 	subnetName string
@@ -112,25 +97,6 @@ type serverAttachment struct {
 // CollectServerEndpoints observes the live cluster and produces one
 // *Endpoint per (server, vpc, subnet) attachment for each server in the
 // `servers` filter (nil → all servers attached to at least one VPC).
-//
-// Algorithm: list VPCAttachments → group by server (resolved via each
-// attachment's Connection); for each candidate server, SSH it and read all
-// IPv4 addresses; match each address to one of its attachments by CIDR
-// containment (narrowest prefix wins on ties). HostBGP is derived from
-// VPCSubnet.HostBGP.
-//
-// The second return value lists everything discovery could not represent as
-// an endpoint. Two conditions are reported there: an attachment with no
-// matching address on a server that did report addresses, and an address
-// matching none of its server's attachments. Both mean something in the
-// topology would go untested, so ConnectivityMatrix.Validate rejects them.
-// A server with no configured addresses at all is only warned about and is
-// not reported as a drop — this matches today's SetupVPCs behavior, where
-// ESLAG servers in L3VNI mode are skipped before hhnet runs and therefore
-// legitimately have no IPs.
-//
-// Returns an error only when SSH itself fails on a queried server or when a
-// VPCAttachment cannot be resolved to a Connection.
 func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHResolver, servers []string) ([]*Endpoint, []DroppedEndpoint, error) {
 	attaches := &vpcapi.VPCAttachmentList{}
 	if err := kube.List(ctx, attaches); err != nil {
@@ -181,10 +147,6 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 			return nil, nil, fmt.Errorf("getting endpoints of connection %q: %w", conn.Name, err)
 		}
 		if len(srvs) != 1 {
-			// VPCAttachments only reference server-facing connections; if a
-			// connection has no server endpoint we skip it as a malformed
-			// attachment rather than erroring out, since fabric webhooks
-			// already gate this.
 			continue
 		}
 		serverName := srvs[0]
@@ -215,8 +177,6 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 		})
 	}
 
-	// Probe every candidate server in parallel; errgroup mirrors what
-	// SetupVPCs does for the hhnet config loop.
 	type collected struct {
 		serverName string
 		ips        []discoveredIP
@@ -253,10 +213,7 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 	}
 
 	// Build endpoints by matching each discovered IP against the server's
-	// candidate attachments (already narrowed by VPCAttachment list). When
-	// multiple attachments contain the IP, the narrowest-prefix attachment
-	// wins (handles the P2P /31 case where a /31 sits inside the parent
-	// /24).
+	// candidate attachments; narrowest-prefix attachment wins
 	slices.SortFunc(probed, func(a, b collected) int { return strings.Compare(a.serverName, b.serverName) })
 	out := []*Endpoint{}
 	dropped := []DroppedEndpoint{}
@@ -264,8 +221,7 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 		atts := serverAttachments[p.serverName]
 		used := make([]bool, len(atts))
 		if len(p.ips) == 0 {
-			// Expected for ESLAG servers in L3VNI mode, which never run
-			// hhnet; not recorded as a drop (see the function doc).
+			// Expected for ESLAG servers in L3VNI mode, which never run hhnet; not recorded as a drop
 			slog.Warn("Server has no configured IPs, skipping endpoints", "server", p.serverName, "attachments", len(atts))
 
 			continue
@@ -292,8 +248,6 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 				continue
 			}
 			if used[bestIdx] {
-				// The attachment still has an endpoint (the first matching
-				// address won), so nothing goes untested — warn only.
 				slog.Warn("Multiple server IPs match the same attachment, keeping the first one",
 					"server", p.serverName, "iface", ip.iface, "addr", ip.prefix.String(),
 					"vpc", atts[bestIdx].vpcName, "subnet", atts[bestIdx].subnetName)
@@ -332,26 +286,10 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 
 // ReplaceServerEndpoints reconciles the matrix's endpoints for one
 // server against newEPs:
-//
 //   - Existing endpoints whose (vpc, subnet) match an entry in newEPs
-//     are updated in place — the IP and HostBGP fields are copied
-//     across, but the *Endpoint pointer stays the same. Matrix entries
-//     keyed on that pointer remain valid, so suite setups that don't
-//     wipe between tests keep their verdicts.
-//   - Existing endpoints with no (vpc, subnet) match in newEPs are
-//     dropped from AllEndpoints; entries referencing them are deleted
-//     (the topology those verdicts assumed no longer holds).
-//   - newEPs that don't match any existing endpoint are appended; the
-//     matrix has no entries for them until the next Repopulate or
-//     overlay.
-//
-// Use after a runtime topology change (server moved to a different VPC,
-// or DHCP lease refreshed) to bring the matrix back in sync with the
-// cluster while preserving entries for attachments that didn't change.
-//
-// Entries in newEPs whose Server.Name != name are appended as-is, so
-// mixing External endpoints into the slice is a no-op for the matching
-// pass.
+//     are updated in place
+//   - Existing endpoints with no (vpc, subnet) match in newEPs are dropped
+//   - newEPs that don't match any existing endpoint are appended
 func (m *ConnectivityMatrix) ReplaceServerEndpoints(name string, newEPs []*Endpoint) {
 	if m == nil {
 		return
@@ -409,10 +347,6 @@ func (m *ConnectivityMatrix) ReplaceServerEndpoints(name string, newEPs []*Endpo
 	}
 }
 
-// ReplaceServerDrops swaps the matrix's recorded discovery drops for one
-// server with the ones from a fresh CollectServerEndpoints sweep. Pair it
-// with ReplaceServerEndpoints so a rebind can't leave the matrix carrying
-// drops from a topology the server no longer has (or hide new ones).
 func (m *ConnectivityMatrix) ReplaceServerDrops(name string, dropped []DroppedEndpoint) {
 	if m == nil {
 		return

--- a/pkg/hhfab/endpoints.go
+++ b/pkg/hhfab/endpoints.go
@@ -172,7 +172,7 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 		// same (vpc, subnet) — one per connection — but a single /32 VIP. Collapse
 		// them to one candidate attachment so the server yields exactly one
 		// endpoint instead of dropping the duplicates with misleading warnings.
-		if slices.ContainsFunc(serverAttachments[serverName], func(a serverAttachment) bool {
+		if subnet.HostBGP && slices.ContainsFunc(serverAttachments[serverName], func(a serverAttachment) bool {
 			return a.vpcName == vpc.Name && a.subnetName == subnetName
 		}) {
 			continue

--- a/pkg/hhfab/endpoints.go
+++ b/pkg/hhfab/endpoints.go
@@ -77,6 +77,28 @@ func discoverServerIPs(ctx context.Context, sshCfg *sshutil.Config, server strin
 	return out, nil
 }
 
+// DroppedEndpoint records an attachment or address that endpoint discovery
+// could not turn into a testable *Endpoint. A drop is not an error on its
+// own — plain `hhfab vlab setup-vpcs` tolerates it — but it does mean some
+// part of the topology is invisible to the connectivity matrix, and
+// ConnectivityMatrix.Validate refuses to run a test against a matrix that
+// carries any. VPC/Subnet are empty when the drop is about an address that
+// matched no attachment.
+type DroppedEndpoint struct {
+	Server string
+	VPC    string
+	Subnet string
+	Reason string
+}
+
+func (d DroppedEndpoint) String() string {
+	if d.VPC == "" {
+		return fmt.Sprintf("%s: %s", d.Server, d.Reason)
+	}
+
+	return fmt.Sprintf("%s (%s/%s): %s", d.Server, d.VPC, d.Subnet, d.Reason)
+}
+
 // serverAttachment is the (vpc, subnet) information the collector resolves
 // from a VPCAttachment + its referenced VPC CRD.
 type serverAttachment struct {
@@ -95,17 +117,24 @@ type serverAttachment struct {
 // attachment's Connection); for each candidate server, SSH it and read all
 // IPv4 addresses; match each address to one of its attachments by CIDR
 // containment (narrowest prefix wins on ties). HostBGP is derived from
-// VPCSubnet.HostBGP. An attachment with no matching configured address is
-// dropped with a warning; a server with no configured addresses contributes
-// nothing — this matches today's SetupVPCs behavior, where ESLAG servers
-// in L3VNI mode are skipped before hhnet runs and therefore have no IPs.
+// VPCSubnet.HostBGP.
+//
+// The second return value lists everything discovery could not represent as
+// an endpoint. Two conditions are reported there: an attachment with no
+// matching address on a server that did report addresses, and an address
+// matching none of its server's attachments. Both mean something in the
+// topology would go untested, so ConnectivityMatrix.Validate rejects them.
+// A server with no configured addresses at all is only warned about and is
+// not reported as a drop — this matches today's SetupVPCs behavior, where
+// ESLAG servers in L3VNI mode are skipped before hhnet runs and therefore
+// legitimately have no IPs.
 //
 // Returns an error only when SSH itself fails on a queried server or when a
 // VPCAttachment cannot be resolved to a Connection.
-func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHResolver, servers []string) ([]*Endpoint, error) {
+func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHResolver, servers []string) ([]*Endpoint, []DroppedEndpoint, error) {
 	attaches := &vpcapi.VPCAttachmentList{}
 	if err := kube.List(ctx, attaches); err != nil {
-		return nil, fmt.Errorf("listing VPCAttachments: %w", err)
+		return nil, nil, fmt.Errorf("listing VPCAttachments: %w", err)
 	}
 
 	connCache := map[string]*wiringapi.Connection{}
@@ -145,11 +174,11 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 	for _, attach := range attaches.Items {
 		conn, err := getConn(attach.Spec.Connection)
 		if err != nil {
-			return nil, fmt.Errorf("resolving attachment %q: %w", attach.Name, err)
+			return nil, nil, fmt.Errorf("resolving attachment %q: %w", attach.Name, err)
 		}
 		_, srvs, _, _, err := conn.Spec.Endpoints()
 		if err != nil {
-			return nil, fmt.Errorf("getting endpoints of connection %q: %w", conn.Name, err)
+			return nil, nil, fmt.Errorf("getting endpoints of connection %q: %w", conn.Name, err)
 		}
 		if len(srvs) != 1 {
 			// VPCAttachments only reference server-facing connections; if a
@@ -165,16 +194,16 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 
 		vpc, err := getVPC(attach.Spec.VPCName())
 		if err != nil {
-			return nil, fmt.Errorf("resolving attachment %q: %w", attach.Name, err)
+			return nil, nil, fmt.Errorf("resolving attachment %q: %w", attach.Name, err)
 		}
 		subnetName := attach.Spec.SubnetName()
 		subnet, ok := vpc.Spec.Subnets[subnetName]
 		if !ok {
-			return nil, fmt.Errorf("attachment %q references missing subnet %s/%s", attach.Name, vpc.Name, subnetName) //nolint:goerr113
+			return nil, nil, fmt.Errorf("attachment %q references missing subnet %s/%s", attach.Name, vpc.Name, subnetName) //nolint:goerr113
 		}
 		cidr, err := netip.ParsePrefix(subnet.Subnet)
 		if err != nil {
-			return nil, fmt.Errorf("parsing VPC %s/%s subnet CIDR %q: %w", vpc.Name, subnetName, subnet.Subnet, err)
+			return nil, nil, fmt.Errorf("parsing VPC %s/%s subnet CIDR %q: %w", vpc.Name, subnetName, subnet.Subnet, err)
 		}
 
 		serverAttachments[serverName] = append(serverAttachments[serverName], serverAttachment{
@@ -220,7 +249,7 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return nil, fmt.Errorf("probing servers for IPs: %w", err)
+		return nil, nil, fmt.Errorf("probing servers for IPs: %w", err)
 	}
 
 	// Build endpoints by matching each discovered IP against the server's
@@ -230,10 +259,13 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 	// /24).
 	slices.SortFunc(probed, func(a, b collected) int { return strings.Compare(a.serverName, b.serverName) })
 	out := []*Endpoint{}
+	dropped := []DroppedEndpoint{}
 	for _, p := range probed {
 		atts := serverAttachments[p.serverName]
 		used := make([]bool, len(atts))
 		if len(p.ips) == 0 {
+			// Expected for ESLAG servers in L3VNI mode, which never run
+			// hhnet; not recorded as a drop (see the function doc).
 			slog.Warn("Server has no configured IPs, skipping endpoints", "server", p.serverName, "attachments", len(atts))
 
 			continue
@@ -252,10 +284,16 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 			}
 			if bestIdx < 0 {
 				slog.Warn("Server IP does not match any attachment subnet", "server", p.serverName, "iface", ip.iface, "addr", ip.prefix.String())
+				dropped = append(dropped, DroppedEndpoint{
+					Server: p.serverName,
+					Reason: fmt.Sprintf("address %s on %s matches none of the server's %d attachment subnets", ip.prefix.String(), ip.iface, len(atts)),
+				})
 
 				continue
 			}
 			if used[bestIdx] {
+				// The attachment still has an endpoint (the first matching
+				// address won), so nothing goes untested — warn only.
 				slog.Warn("Multiple server IPs match the same attachment, keeping the first one",
 					"server", p.serverName, "iface", ip.iface, "addr", ip.prefix.String(),
 					"vpc", atts[bestIdx].vpcName, "subnet", atts[bestIdx].subnetName)
@@ -279,11 +317,17 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 			if !used[i] {
 				slog.Warn("Attachment has no matching IP on server, dropping endpoint",
 					"server", p.serverName, "vpc", att.vpcName, "subnet", att.subnetName, "attachment", att.attachName)
+				dropped = append(dropped, DroppedEndpoint{
+					Server: p.serverName,
+					VPC:    att.vpcName,
+					Subnet: att.subnetName,
+					Reason: fmt.Sprintf("attachment %s has no matching address among the server's %d configured addresses", att.attachName, len(p.ips)),
+				})
 			}
 		}
 	}
 
-	return out, nil
+	return out, dropped, nil
 }
 
 // ReplaceServerEndpoints reconciles the matrix's endpoints for one
@@ -363,4 +407,27 @@ func (m *ConnectivityMatrix) ReplaceServerEndpoints(name string, newEPs []*Endpo
 			delete(m.entries, pair)
 		}
 	}
+}
+
+// ReplaceServerDrops swaps the matrix's recorded discovery drops for one
+// server with the ones from a fresh CollectServerEndpoints sweep. Pair it
+// with ReplaceServerEndpoints so a rebind can't leave the matrix carrying
+// drops from a topology the server no longer has (or hide new ones).
+func (m *ConnectivityMatrix) ReplaceServerDrops(name string, dropped []DroppedEndpoint) {
+	if m == nil {
+		return
+	}
+
+	kept := make([]DroppedEndpoint, 0, len(m.dropped)+len(dropped))
+	for _, d := range m.dropped {
+		if d.Server != name {
+			kept = append(kept, d)
+		}
+	}
+	for _, d := range dropped {
+		if d.Server == name {
+			kept = append(kept, d)
+		}
+	}
+	m.dropped = kept
 }

--- a/pkg/hhfab/endpoints.go
+++ b/pkg/hhfab/endpoints.go
@@ -168,6 +168,16 @@ func CollectServerEndpoints(ctx context.Context, kube kclient.Client, ssh SSHRes
 			return nil, nil, fmt.Errorf("parsing VPC %s/%s subnet CIDR %q: %w", vpc.Name, subnetName, subnet.Subnet, err)
 		}
 
+		// A multihomed hostBGP server has several VPCAttachments pointing at the
+		// same (vpc, subnet) — one per connection — but a single /32 VIP. Collapse
+		// them to one candidate attachment so the server yields exactly one
+		// endpoint instead of dropping the duplicates with misleading warnings.
+		if slices.ContainsFunc(serverAttachments[serverName], func(a serverAttachment) bool {
+			return a.vpcName == vpc.Name && a.subnetName == subnetName
+		}) {
+			continue
+		}
+
 		serverAttachments[serverName] = append(serverAttachments[serverName], serverAttachment{
 			vpcName:    vpc.Name,
 			subnetName: subnetName,

--- a/pkg/hhfab/endpoints_test.go
+++ b/pkg/hhfab/endpoints_test.go
@@ -167,6 +167,104 @@ func TestReplaceServerEndpoints_IgnoresOtherServerNamesInNewEPs(t *testing.T) {
 	require.Contains(t, m.AllEndpoints, stray)
 }
 
+func TestReplaceServerDrops(t *testing.T) {
+	m := NewConnectivityMatrix()
+	m.dropped = []DroppedEndpoint{
+		{Server: "server-1", VPC: "vpc-old", Subnet: "default", Reason: "stale"},
+		{Server: "server-2", VPC: "vpc-x", Subnet: "default", Reason: "other server's drop"},
+	}
+
+	// Rebind of server-1 finds no drops → only server-2's survives.
+	m.ReplaceServerDrops("server-1", nil)
+	require.Len(t, m.dropped, 1)
+	require.Equal(t, "server-2", m.dropped[0].Server)
+
+	// A fresh drop for server-1 is recorded; entries for other servers in
+	// the passed slice are ignored (they belong to their own sweep).
+	m.ReplaceServerDrops("server-1", []DroppedEndpoint{
+		{Server: "server-1", VPC: "vpc-new", Subnet: "default", Reason: "fresh"},
+		{Server: "server-3", VPC: "vpc-y", Subnet: "default", Reason: "not ours"},
+	})
+	require.Len(t, m.dropped, 2)
+	require.Equal(t, "vpc-new", m.dropped[1].VPC)
+}
+
+func TestValidate(t *testing.T) {
+	a := serverEP("server-1", "vpc-1", "default", "10.0.1.1")
+	b := serverEP("server-2", "vpc-2", "default", "10.0.2.1")
+	ext := &Endpoint{External: &ExternalEndpoint{ExternalName: "ext-1"}}
+	ext2 := &Endpoint{External: &ExternalEndpoint{ExternalName: "ext-2"}}
+
+	newMatrix := func() *ConnectivityMatrix {
+		m := NewConnectivityMatrix()
+		m.AllEndpoints = []*Endpoint{a, b, ext, ext2}
+
+		return m
+	}
+
+	t.Run("all-deny topology is valid", func(t *testing.T) {
+		// Isolated VPCs with no peerings: no Allow entry anywhere is a
+		// legitimate thing to assert, not a degenerate matrix.
+		require.NoError(t, newMatrix().Validate())
+	})
+
+	t.Run("no endpoints", func(t *testing.T) {
+		require.ErrorContains(t, NewConnectivityMatrix().Validate(), "no endpoints")
+	})
+
+	t.Run("nil matrix", func(t *testing.T) {
+		var m *ConnectivityMatrix
+		require.Error(t, m.Validate())
+	})
+
+	t.Run("discovery drop", func(t *testing.T) {
+		m := newMatrix()
+		m.dropped = []DroppedEndpoint{{
+			Server: "server-3", VPC: "vpc-3", Subnet: "default", Reason: "attachment has no matching address",
+		}}
+		require.ErrorContains(t, m.Validate(), "server-3 (vpc-3/default): attachment has no matching address")
+	})
+
+	t.Run("unevaluated server pair", func(t *testing.T) {
+		m := newMatrix()
+		m.Add(ConnectivityExpectation{
+			Pair:    EndpointPair{Source: a, Destination: b},
+			Verdict: VerdictUnknown,
+			Detail:  "gw peering with non-empty expose 'As'",
+		})
+		err := m.Validate()
+		require.ErrorContains(t, err, "server-1(vpc-1/default) → server-2(vpc-2/default)")
+		require.ErrorContains(t, err, "non-empty expose 'As'")
+
+		// A test that overlays the real expectation clears it.
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: a, Destination: b}, Verdict: VerdictAllow,
+		})
+		require.NoError(t, m.Validate())
+	})
+
+	t.Run("unevaluated external is settled by another external's allow", func(t *testing.T) {
+		// The external oracle ORs over every External in the cluster, so
+		// one Allow decides the source's expectation for all of them.
+		m := newMatrix()
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: a, Destination: ext}, Verdict: VerdictUnknown, Detail: "unsupported",
+		})
+		require.ErrorContains(t, m.Validate(), "external:ext-1")
+
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: a, Destination: ext2}, Verdict: VerdictAllow,
+		})
+		require.NoError(t, m.Validate())
+
+		// ...but only for that source.
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: b, Destination: ext}, Verdict: VerdictUnknown, Detail: "unsupported",
+		})
+		require.ErrorContains(t, m.Validate(), "server-2(vpc-2/default) → external:ext-1")
+	})
+}
+
 func TestReplaceServerEndpoints_PreservesHostBGP(t *testing.T) {
 	m := NewConnectivityMatrix()
 	ep := &Endpoint{Server: &ServerEndpoint{

--- a/pkg/hhfab/endpoints_test.go
+++ b/pkg/hhfab/endpoints_test.go
@@ -262,6 +262,26 @@ func TestValidate(t *testing.T) {
 			Pair: EndpointPair{Source: b, Destination: ext}, Verdict: VerdictUnknown, Detail: "unsupported",
 		})
 		require.ErrorContains(t, m.Validate(), "server-2(vpc-2/default) → external:ext-1")
+
+		// A DNAT-only Allow grants no egress, and an Allow scoped to one
+		// proto/port isn't seen by the untargeted curl probe. Neither settles
+		// the Unknown, or Validate would wave through an entry the curl phase
+		// goes on to assert as denied.
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: b, Destination: ext2}, Verdict: VerdictAllow,
+			NAT: &TranslatedAddress{DestinationIP: netip.MustParseAddr("10.0.2.1"), DestinationPort: 8080},
+		})
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: b, Destination: ext2}, Verdict: VerdictAllow,
+			ProtoPort: ProtoPort{Protocol: "tcp", Port: 8080},
+		})
+		require.ErrorContains(t, m.Validate(), "server-2(vpc-2/default) → external:ext-1")
+
+		// An unscoped, non-DNAT Allow does.
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: b, Destination: ext2}, Verdict: VerdictAllow,
+		})
+		require.NoError(t, m.Validate())
 	})
 }
 

--- a/pkg/hhfab/endpoints_test.go
+++ b/pkg/hhfab/endpoints_test.go
@@ -243,6 +243,31 @@ func TestValidate(t *testing.T) {
 		require.NoError(t, m.Validate())
 	})
 
+	t.Run("unevaluated default entry shadowed by proto-port entries", func(t *testing.T) {
+		// Proto-scoped pairs are probed only by runMatrixProtoPortPhase, which
+		// never reads the default entry, so an ACL test overlaying just the
+		// proto verdicts leaves nothing unasserted.
+		m := newMatrix()
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: a, Destination: b}, Verdict: VerdictUnknown, Detail: "unsupported",
+		})
+		require.ErrorContains(t, m.Validate(), "server-1(vpc-1/default) → server-2(vpc-2/default)")
+
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: a, Destination: b}, Verdict: VerdictAllow,
+			ProtoPort: ProtoPort{Protocol: "tcp", Port: 5301},
+		})
+		require.NoError(t, m.Validate())
+
+		// ...unless the default entry is a port-forward, which the
+		// port-forward phase does read.
+		m.Add(ConnectivityExpectation{
+			Pair: EndpointPair{Source: a, Destination: b}, Verdict: VerdictUnknown, Detail: "unsupported",
+			NAT: &TranslatedAddress{DestinationIP: netip.MustParseAddr("10.0.2.1"), DestinationPort: 15201},
+		})
+		require.ErrorContains(t, m.Validate(), "server-1(vpc-1/default) → server-2(vpc-2/default)")
+	})
+
 	t.Run("unevaluated external is settled by another external's allow", func(t *testing.T) {
 		// The external oracle ORs over every External in the cluster, so
 		// one Allow decides the source's expectation for all of them.

--- a/pkg/hhfab/matrix.go
+++ b/pkg/hhfab/matrix.go
@@ -333,6 +333,29 @@ func describeUnknownEntry(pair EndpointPair, pp ProtoPort, e ConnectivityExpecta
 	return out
 }
 
+func (m *ConnectivityMatrix) ProtoPortEntries(src, dst *Endpoint) []ConnectivityExpectation {
+	byPP, ok := m.entries[EndpointPair{Source: src, Destination: dst}]
+	if !ok {
+		return nil
+	}
+	out := make([]ConnectivityExpectation, 0, len(byPP))
+	for pp, e := range byPP {
+		if pp == (ProtoPort{}) {
+			continue
+		}
+		out = append(out, e)
+	}
+	slices.SortFunc(out, func(a, b ConnectivityExpectation) int {
+		if a.ProtoPort.Protocol != b.ProtoPort.Protocol {
+			return strings.Compare(a.ProtoPort.Protocol, b.ProtoPort.Protocol)
+		}
+
+		return int(a.ProtoPort.Port) - int(b.ProtoPort.Port)
+	})
+
+	return out
+}
+
 func endpointLabel(ep *Endpoint) string {
 	switch {
 	case ep == nil:
@@ -344,6 +367,20 @@ func endpointLabel(ep *Endpoint) string {
 	default:
 		return "<empty>"
 	}
+}
+
+func (m *ConnectivityMatrix) HasProtoPortEntries(src, dst *Endpoint) bool {
+	byPP, ok := m.entries[EndpointPair{Source: src, Destination: dst}]
+	if !ok {
+		return false
+	}
+	for pp := range byPP {
+		if pp != (ProtoPort{}) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func reachabilityFromExpectation(e ConnectivityExpectation) Reachability {
@@ -390,6 +427,11 @@ func runMatrixServerServerPhase(ctx context.Context, opts TestConnectivityOpts, 
 				continue
 			}
 			if !deps.inDestinations(dst.Server.Name) {
+				continue
+			}
+
+			// Protocol/port-scoped pairs are owned entirely by runMatrixProtoPortPhase
+			if matrix.HasProtoPortEntries(src, dst) {
 				continue
 			}
 
@@ -566,6 +608,136 @@ func runMatrixPortForwardPhase(ctx context.Context, opts TestConnectivityOpts, m
 	}
 }
 
+// persistentIperf3Port is the port the always-on iperf3 -s daemon serves (TCP+UDP).
+const persistentIperf3Port = 5201
+
+func startMatrixProtoPortListeners(ctx context.Context, matrix *ConnectivityMatrix, deps *matrixTestDeps) (func(), error) {
+	type hostPort struct {
+		host string
+		port uint16
+	}
+	wanted := map[hostPort]struct{}{}
+	for _, src := range matrix.AllEndpoints {
+		if src.Server == nil {
+			continue
+		}
+		for _, dst := range matrix.AllEndpoints {
+			if dst.Server == nil || src == dst {
+				continue
+			}
+			for _, e := range matrix.ProtoPortEntries(src, dst) {
+				pp := e.ProtoPort
+				if pp.Protocol != "tcp" && pp.Protocol != "udp" {
+					continue
+				}
+				if pp.Port == 0 || pp.Port == persistentIperf3Port {
+					continue
+				}
+				wanted[hostPort{host: dst.Server.Name, port: pp.Port}] = struct{}{}
+			}
+		}
+	}
+
+	started := make([]hostPort, 0, len(wanted))
+	teardown := func() {
+		// Teardown must run even when the caller's ctx has been canceled
+		tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		for _, hp := range started {
+			ssh := deps.sshByServer[hp.host]
+			if ssh == nil {
+				continue
+			}
+			cmd := fmt.Sprintf("sudo docker exec iperf3 pkill -f 'iperf3 -s -p %d'", hp.port)
+			if _, stderr, err := retrySSHCmd(tctx, ssh, cmd, hp.host); err != nil {
+				slog.Warn("Failed to stop proto-port iperf3 listener", "host", hp.host, "port", hp.port, "err", err, "stderr", stderr)
+			}
+		}
+	}
+
+	for hp := range wanted {
+		ssh := deps.sshByServer[hp.host]
+		if ssh == nil {
+			teardown()
+
+			return nil, fmt.Errorf("no ssh config for server %q needed as proto-port listener", hp.host) //nolint:goerr113
+		}
+		cmd := fmt.Sprintf("sudo docker exec -d iperf3 iperf3 -s -p %d", hp.port)
+		if _, stderr, err := retrySSHCmd(ctx, ssh, cmd, hp.host); err != nil {
+			teardown()
+
+			return nil, fmt.Errorf("starting proto-port iperf3 listener on %s:%d: %w: %s", hp.host, hp.port, err, stderr)
+		}
+		started = append(started, hp)
+		slog.Debug("Started proto-port iperf3 listener", "host", hp.host, "port", hp.port)
+	}
+
+	return teardown, nil
+}
+
+// runMatrixProtoPortPhase exercises every non-zero ProtoPort matrix entry with a
+// protocol-specific probe: "icmp" → ping, "tcp" → nc connect, "udp" → iperf3 -u
+// loss check.
+func runMatrixProtoPortPhase(ctx context.Context, opts TestConnectivityOpts, matrix *ConnectivityMatrix, deps *matrixTestDeps) {
+	for _, src := range matrix.AllEndpoints {
+		if src.Server == nil || !deps.inSources(src.Server.Name) {
+			continue
+		}
+		for _, dst := range matrix.AllEndpoints {
+			if dst.Server == nil || src == dst {
+				continue
+			}
+			if IsSameEndpointNode(src, dst) {
+				continue
+			}
+			if !deps.inDestinations(dst.Server.Name) {
+				continue
+			}
+			for _, entry := range matrix.ProtoPortEntries(src, dst) {
+				expected := reachabilityFromExpectation(entry)
+				pp := entry.ProtoPort
+				fromName := src.Server.Name
+				toName := dst.Server.Name
+				fromSSH := deps.sshByServer[fromName]
+				toIP := dst.Server.IP
+				if entry.NAT != nil && entry.NAT.DestinationIP.IsValid() {
+					toIP = entry.NAT.DestinationIP
+				}
+				if !toIP.IsValid() {
+					deps.errChan <- fmt.Errorf("matrix proto entry %s→%s (%s/%d) has no valid target IP", fromName, toName, pp.Protocol, pp.Port) //nolint:goerr113
+
+					continue
+				}
+
+				switch pp.Protocol {
+				case "icmp":
+					deps.wg.Go(func() {
+						if pe := checkPing(ctx, opts.PingsCount, deps.pings, fromName, toName, fromSSH, toIP, nil, expected); pe != nil {
+							deps.errChan <- pe
+						}
+					})
+				case "tcp":
+					port := pp.Port
+					deps.wg.Go(func() {
+						if ie := checkTCPPort(ctx, deps.iperfs, fromName, fromSSH, toIP, port, expected.Reachable); ie != nil {
+							deps.errChan <- ie
+						}
+					})
+				case "udp":
+					port := pp.Port
+					deps.wg.Go(func() {
+						if ie := checkUDPPort(ctx, opts, deps.iperfs, fromName, fromSSH, toIP, port, expected.Reachable); ie != nil {
+							deps.errChan <- ie
+						}
+					})
+				default:
+					deps.errChan <- fmt.Errorf("matrix proto entry %s→%s has unsupported protocol %q", fromName, toName, pp.Protocol) //nolint:goerr113
+				}
+			}
+		}
+	}
+}
+
 func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opts TestConnectivityOpts, matrix *ConnectivityMatrix) error {
 	if matrix == nil {
 		return fmt.Errorf("connectivity matrix must be non-nil") //nolint:goerr113
@@ -613,7 +785,16 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	}
 
 	n := len(matrix.AllEndpoints)
-	errChan := make(chan error, 2*n*n+n)
+	protoEntries := 0
+	for _, src := range matrix.AllEndpoints {
+		for _, dst := range matrix.AllEndpoints {
+			if src == dst {
+				continue
+			}
+			protoEntries += len(matrix.ProtoPortEntries(src, dst))
+		}
+	}
+	errChan := make(chan error, 2*n*n+n+protoEntries)
 	deps := &matrixTestDeps{
 		sshByServer: sshByServer,
 		pings:       semaphore.NewWeighted(opts.PingsParallel),
@@ -629,6 +810,16 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 		errChan: errChan,
 	}
 
+	teardownListeners := func() {}
+	if opts.PingsCount > 0 || opts.IPerfsSeconds > 0 {
+		td, err := startMatrixProtoPortListeners(ctx, matrix, deps)
+		if err != nil {
+			return err
+		}
+		teardownListeners = td
+	}
+	defer teardownListeners()
+
 	if opts.PingsCount > 0 || opts.IPerfsSeconds > 0 {
 		if err := runMatrixServerServerPhase(ctx, opts, matrix, deps); err != nil {
 			return err
@@ -639,6 +830,9 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	}
 	if opts.IPerfsSeconds > 0 {
 		runMatrixPortForwardPhase(ctx, opts, matrix, deps)
+	}
+	if opts.PingsCount > 0 || opts.IPerfsSeconds > 0 {
+		runMatrixProtoPortPhase(ctx, opts, matrix, deps)
 	}
 
 	deps.wg.Wait()

--- a/pkg/hhfab/matrix.go
+++ b/pkg/hhfab/matrix.go
@@ -22,48 +22,26 @@ import (
 )
 
 // The connectivity matrix models the expected traffic behavior between every
-// pair of test endpoints in a topology. It is populated by generators
-// (typically setup-vpcs / setup-peerings) and consumed by a runner that
-// exercises each pair.
-//
+// pair of test endpoints in a topology.
 // Design assumptions:
-//   - A single matrix represents one steady-state topology. Dynamic changes
-//     (overlap-NAT, gateway failover, peering churn) are modeled as a
-//     sequence of distinct matrices, not as mutations to one.
-//   - Endpoints are canonical: generators allocate one *Endpoint per
-//     (server, vpc, subnet) attachment and one per External CRD; the matrix
-//     references those pointers from AllEndpoints and as EndpointPair keys.
 //   - A server with multiple IPs (attached to several subnets or VPCs) is
 //     represented as multiple endpoints, one per (vpc, subnet). The verdict
-//     depends on which address is used, so collapsing them is not safe.
+//     depends on which address is used.
 //   - Absence of an entry for a pair means default DENY (isolation).
-//     Generators may emit explicit Verdict=Deny entries when a Reason aids
-//     diagnostics.
 
 // gwNATPortForwardProbeTimeout is the maximum time to wait for the gateway's
 // port-forward NAT rule to become active in the dataplane after a peering is
-// applied. Unlike fabric route propagation (which waitForNATPoolInLeaves gates
-// on), the gateway's DNAT rule programming has its own latency that no
-// Kubernetes condition signals.
+// applied.
 const gwNATPortForwardProbeTimeout = 2 * time.Minute
 
 // gwNATPortForwardProbeInterval is the polling interval between TCP-reachability probes.
 const gwNATPortForwardProbeInterval = 5 * time.Second
 
-// ConnectivityVerdict describes what should happen to traffic on a path.
 type ConnectivityVerdict string
 
 const (
-	VerdictAllow ConnectivityVerdict = "allow"
-	VerdictDeny  ConnectivityVerdict = "deny"
-
-	// VerdictUnknown marks a pair the generator could not evaluate — today
-	// only peering shapes the reachability helpers don't model (see
-	// reachCheckUnsupported). It exists so that "we can't tell" is
-	// distinguishable from "must not work": a missing entry reads as Deny
-	// and would quietly pass by proving unreachability, while Validate
-	// refuses to run a test against a matrix that still holds one. Tests
-	// that know the real answer overlay it explicitly.
+	VerdictAllow   ConnectivityVerdict = "allow"
+	VerdictDeny    ConnectivityVerdict = "deny"
 	VerdictUnknown ConnectivityVerdict = "unknown"
 )
 
@@ -71,80 +49,51 @@ const (
 // is optional; an unset field means "no translation on that axis".
 type TranslatedAddress struct {
 	// SourcePool: CIDR from which the destination may observe any source IP
-	// (masquerade SNAT — the runtime pool selection is not predictable, only
-	// the containing range is).
 	SourcePool netip.Prefix
 
 	// DestinationIP: IP the source must target to reach the destination
-	// (DNAT). Unset means use the destination's real IP.
 	DestinationIP netip.Addr
 
 	// DestinationPort: port the destination actually listens on, when
-	// different from the source-facing port in
-	// ConnectivityExpectation.ProtoPort (port-forward DNAT). Zero means no
-	// port translation.
+	// different from the source-facing port. Zero means no port translation.
 	DestinationPort uint16
 }
 
-// ProtoPort is a protocol + port tuple. The zero value (empty protocol,
-// port 0) is the sentinel for "applies to the default connectivity check
-// the runner performs" (today: ICMP + TCP/any).
 type ProtoPort struct {
 	Protocol string // "tcp", "udp", "icmp"
 	Port     uint16
 }
 
 // ConnectivityExpectation describes what should happen on a directional path.
-// To express bidirectional behavior, emit two entries with swapped pairs.
 type ConnectivityExpectation struct {
 	Pair EndpointPair
 
-	// Verdict: should traffic be allowed or denied on this path?
 	Verdict ConnectivityVerdict
 
-	// NAT: optional address translation expected on this path.
 	NAT *TranslatedAddress
 
-	// Reason: why this expectation exists (diagnostic; the ReachabilityReason
-	// enum may be extended with NAT, isolation, and permit-list values as
-	// new generators land).
 	Reason ReachabilityReason
 
-	// Peering: name of the CRD that produced this expectation (diagnostic).
 	Peering string
 
-	// Detail: free-form context for Reason, currently only set on
-	// VerdictUnknown entries to carry why the pair could not be evaluated
-	// (diagnostic; surfaced by Validate).
+	// free-form context for Reason, currently only set on VerdictUnknown entries
 	Detail string
 
-	// ProtoPort scopes this expectation to a specific protocol/port. The
-	// zero value applies to the runner's default check.
 	ProtoPort ProtoPort
 }
 
-// ServerEndpoint identifies one (server, vpc, subnet) attachment. A server
-// attached to multiple subnets is represented by multiple endpoints.
 type ServerEndpoint struct {
-	Name   string // e.g. "server-1"
-	VPC    string // e.g. "vpc-01"
-	Subnet string // e.g. "default"
-
-	// HostBGP: if true, this attachment uses BGP to advertise a /32 VIP on
-	// the loopback; IP holds that VIP (discovered at runtime). Otherwise IP
-	// is the DHCP/static address on the subnet interface.
+	Name    string // e.g. "server-1"
+	VPC     string // e.g. "vpc-01"
+	Subnet  string // e.g. "default"
 	HostBGP bool
 	IP      netip.Addr
 }
 
-// ExternalEndpoint identifies an External CRD.
 type ExternalEndpoint struct {
 	ExternalName string
 	Prefixes     []netip.Prefix
-
-	// SourceIP: optional address used when this external originates traffic.
-	// Empty means the external is destination-only in the matrix.
-	SourceIP netip.Addr
+	SourceIP     netip.Addr
 }
 
 // Endpoint is a tagged union; exactly one of Server, External is non-nil.
@@ -153,49 +102,37 @@ type Endpoint struct {
 	External *ExternalEndpoint
 }
 
-// EndpointPair is a directional (source → destination) key. Both fields must
-// be non-nil and must point to endpoints listed in the owning matrix's
-// AllEndpoints (the matrix uses pointer identity for lookups).
 type EndpointPair struct {
 	Source      *Endpoint
 	Destination *Endpoint
 }
 
-// ConnectivityMatrix holds the complete set of expectations for a topology.
 type ConnectivityMatrix struct {
-	// AllEndpoints: canonical, ordered list of all endpoints in the matrix.
+	// Canonical, ordered list of all endpoints in the matrix.
 	AllEndpoints []*Endpoint
 
-	// entries[pair][protoPort] = expectation. The zero ProtoPort{} key holds
-	// the default-check expectation for the pair.
+	// The zero ProtoPort{} key holds the default-check expectation for the pair.
 	entries map[EndpointPair]map[ProtoPort]ConnectivityExpectation
 
-	// dropped: attachments/addresses endpoint discovery could not turn into
-	// endpoints. Not testable, so not in AllEndpoints — kept here so
-	// Validate can refuse to test a topology it only partially sees.
+	// Attachments/addresses endpoint discovery could not turn into endpoints.
+	// Kept here so Validate can refuse to test a topology it only partially sees.
 	dropped []DroppedEndpoint
 }
 
-// NewConnectivityMatrix returns an empty matrix. AllEndpoints should be set
-// by the caller before adding expectations that reference them.
 func NewConnectivityMatrix() *ConnectivityMatrix {
 	return &ConnectivityMatrix{
 		entries: map[EndpointPair]map[ProtoPort]ConnectivityExpectation{},
 	}
 }
 
-// EndpointPredicate selects endpoints during matrix overlays. Composable
-// with the helpers below (ServerInVPC, ExternalNamed).
 type EndpointPredicate func(*Endpoint) bool
 
-// ServerInVPC matches server endpoints attached to the given VPC.
 func ServerInVPC(vpc string) EndpointPredicate {
 	return func(ep *Endpoint) bool {
 		return ep.Server != nil && ep.Server.VPC == vpc
 	}
 }
 
-// ExternalNamed matches external endpoints with the given External CRD name.
 func ExternalNamed(name string) EndpointPredicate {
 	return func(ep *Endpoint) bool {
 		return ep.External != nil && ep.External.ExternalName == name
@@ -215,18 +152,8 @@ func overlayReason(existing ReachabilityReason) ReachabilityReason {
 	return ReachabilityReasonGatewayPeering
 }
 
-// NATMutator updates a TranslatedAddress for a specific (src, dst) pair.
-// The passed-in nat is seeded from any existing entry's NAT (or zero
-// value if none) and is the value the helper writes back via matrix.Add.
 type NATMutator func(src, dst *Endpoint, nat *TranslatedAddress) error
 
-// OverlayMatrixNAT marks every (src, dst) pair whose endpoints satisfy
-// both predicates as Allow, then runs mutator to set NAT info on the
-// resulting entry.
-//
-// Returns an error if no pair matched the predicates, which almost
-// always indicates mismatched predicates relative to the matrix's
-// AllEndpoints set.
 func OverlayMatrixNAT(
 	matrix *ConnectivityMatrix,
 	srcPred, dstPred EndpointPredicate,
@@ -266,18 +193,6 @@ func OverlayMatrixNAT(
 	return nil
 }
 
-// BuildConnectivityMatrix assembles a matrix from a pre-discovered set of
-// server endpoints (typically returned by SetupVPCs), enumerates external
-// endpoints from the live cluster, and populates Allow entries by querying
-// IsServerReachable / IsExternalSubnetReachable for every endpoint pair.
-// The gatewayEnabled flag is auto-derived from the current Fabricator
-// config. NAT translations are not modeled here — callers overlay them on
-// the returned matrix before running connectivity tests.
-//
-// hhfab's CLI / vlabrunner paths don't build a matrix at all; this is
-// strictly a test-side opt-in. setupTest calls it once at suite startup;
-// matrix-driven tests call Repopulate on the existing matrix after
-// DoSetupPeerings to refresh verdicts to the post-peering state.
 func BuildConnectivityMatrix(ctx context.Context, kube kclient.Client, serverEndpoints []*Endpoint, dropped []DroppedEndpoint) (*ConnectivityMatrix, error) {
 	matrix := NewConnectivityMatrix()
 	matrix.AllEndpoints = append(matrix.AllEndpoints, serverEndpoints...)
@@ -296,11 +211,6 @@ func BuildConnectivityMatrix(ctx context.Context, kube kclient.Client, serverEnd
 	return matrix, nil
 }
 
-// BuildConnectivityMatrixFromCluster discovers server endpoints by
-// observing the live cluster (via CollectServerEndpoints) rather than
-// taking a pre-built slice, then assembles a matrix the same way as
-// BuildConnectivityMatrix. Used when a caller needs to build a matrix
-// against a pre-existing topology without re-running SetupVPCs.
 func BuildConnectivityMatrixFromCluster(ctx context.Context, kube kclient.Client, ssh SSHResolver) (*ConnectivityMatrix, error) {
 	endpoints, dropped, err := CollectServerEndpoints(ctx, kube, ssh, nil)
 	if err != nil {
@@ -312,9 +222,7 @@ func BuildConnectivityMatrixFromCluster(ctx context.Context, kube kclient.Client
 
 // Repopulate clears the matrix's expectation entries and refills Allow
 // entries by querying the live cluster for reachability between every
-// (src, dst) endpoint pair in AllEndpoints. The gatewayEnabled flag is
-// derived from the current Fabricator config. NAT translations are
-// reset; callers re-apply any overlays after a Repopulate.
+// (src, dst) endpoint pair in AllEndpoints.
 func (m *ConnectivityMatrix) Repopulate(ctx context.Context, kube kclient.Client) error {
 	f, _, _, err := fab.GetFabAndNodes(ctx, kube, fab.GetFabAndNodesOpts{AllowNotHydrated: true})
 	if err != nil {
@@ -327,9 +235,7 @@ func (m *ConnectivityMatrix) Repopulate(ctx context.Context, kube kclient.Client
 	return nil
 }
 
-// Add inserts or replaces the expectation for (Pair, ProtoPort). Generators
-// call this to populate the matrix; tests may also call it to override
-// individual entries for advanced scenarios.
+// Add inserts or replaces the expectation for (Pair, ProtoPort).
 func (m *ConnectivityMatrix) Add(e ConnectivityExpectation) {
 	if m.entries == nil {
 		m.entries = map[EndpointPair]map[ProtoPort]ConnectivityExpectation{}
@@ -342,10 +248,6 @@ func (m *ConnectivityMatrix) Add(e ConnectivityExpectation) {
 	byPP[e.ProtoPort] = e
 }
 
-// Lookup returns the expectation for (src, dst, pp). If pp is non-zero and
-// no protocol-specific entry exists, falls back to the default ProtoPort{}
-// entry. If no entry exists at all, returns a synthetic Verdict=Deny
-// expectation (default isolation).
 func (m *ConnectivityMatrix) Lookup(src, dst *Endpoint, pp ProtoPort) ConnectivityExpectation {
 	pair := EndpointPair{Source: src, Destination: dst}
 	if byPP, ok := m.entries[pair]; ok {
@@ -366,30 +268,6 @@ func (m *ConnectivityMatrix) Lookup(src, dst *Endpoint, pp ProtoPort) Connectivi
 	}
 }
 
-// Validate reports whether the matrix is a sound oracle for a connectivity
-// run. Lookup answers Deny for every pair it has no entry for, so a matrix
-// that silently lost endpoints or could not evaluate a peering would assert
-// unreachability it never established — and pass. Validate is the single
-// gate in front of that: it runs at the top of TestConnectivityWithMatrix,
-// after generators have populated and tests have applied their overlays.
-//
-// It rejects:
-//   - an empty endpoint set (nothing to test, e.g. a matrix built with
-//     noSetup against a topology that was never discovered);
-//   - discovery drops (an attachment or address that never became an
-//     endpoint, so a slice of the topology goes untested);
-//   - leftover VerdictUnknown entries, which mean populate could not
-//     evaluate the pair and no test overlaid the real expectation.
-//
-// It deliberately does not require any Allow entry: a topology of mutually
-// isolated VPCs with no peerings is a legitimate thing to assert.
-//
-// Unknown on a server→external pair is only fatal when that source has no
-// Allow to any external. The reachability helper behind external
-// destinations ORs over every External in the cluster rather than
-// answering per-destination, and runMatrixCurlPhase consumes it the same
-// way, so one Allow settles the source's expectation regardless of the
-// other externals' entries.
 func (m *ConnectivityMatrix) Validate() error {
 	if m == nil {
 		return fmt.Errorf("connectivity matrix is nil") //nolint:goerr113
@@ -441,7 +319,6 @@ func (m *ConnectivityMatrix) Validate() error {
 	return errors.Join(errs...)
 }
 
-// describeUnknownEntry renders a pair for Validate's diagnostics.
 func describeUnknownEntry(pair EndpointPair, pp ProtoPort, e ConnectivityExpectation) string {
 	out := fmt.Sprintf("%s → %s", endpointLabel(pair.Source), endpointLabel(pair.Destination))
 	if pp != (ProtoPort{}) {
@@ -456,7 +333,6 @@ func describeUnknownEntry(pair EndpointPair, pp ProtoPort, e ConnectivityExpecta
 	return out
 }
 
-// endpointLabel renders an endpoint for diagnostics.
 func endpointLabel(ep *Endpoint) string {
 	switch {
 	case ep == nil:
@@ -470,9 +346,6 @@ func endpointLabel(ep *Endpoint) string {
 	}
 }
 
-// reachabilityFromExpectation projects a matrix expectation onto the
-// Reachability struct used by the ping/iperf helpers. The matrix's
-// Verdict, Reason, and Peering map directly.
 func reachabilityFromExpectation(e ConnectivityExpectation) Reachability {
 	return Reachability{
 		Reachable: e.Verdict == VerdictAllow,
@@ -481,8 +354,6 @@ func reachabilityFromExpectation(e ConnectivityExpectation) Reachability {
 	}
 }
 
-// check whether two endpoints belong to the same server / external, regardless
-// of the specific IP being tested (in case of multi-homed servers)
 func IsSameEndpointNode(a, b *Endpoint) bool {
 	if a == nil || b == nil {
 		return false
@@ -492,31 +363,6 @@ func IsSameEndpointNode(a, b *Endpoint) bool {
 		(a.Server != nil && b.Server != nil && a.Server.Name == b.Server.Name)
 }
 
-// TestConnectivityWithMatrix runs ping/iperf/curl against the topology, using
-// the supplied ConnectivityMatrix as the authoritative source for both the
-// addresses to target and the expected verdicts. No live reachability
-// queries are made; matrix.Lookup is the only oracle.
-//
-// Server-server pairs run ping always (allow → expect success, deny →
-// expect failure) and iperf only when the matrix allows them. Bidirectional
-// iperf is detected by looking up the reverse pair in the matrix.
-//
-// Externals are treated as in the legacy test: one curl per source server
-// to a hardcoded environment IP ("1.0.0.1"), with the expectation derived
-// from the OR of all (src → *_external) matrix verdicts. External-as-source
-// paths are not exercised — the matrix doesn't track them today.
-//
-// opts.Sources and opts.Destinations filter the matrix iteration by server
-// name (matching the legacy TestConnectivity semantics): a non-empty
-// Sources restricts the source side, a non-empty Destinations restricts the
-// destination side, and bidir only triggers when the reverse pair also
-// falls inside the filters.
-
-// matrixTestDeps bundles the shared scaffolding TestConnectivityWithMatrix
-// hands to its per-phase helpers: SSH map, concurrency
-// semaphores, source/destination filter predicates, the WaitGroup that
-// drives goroutine completion, and the error channel that collects probe
-// failures.
 type matrixTestDeps struct {
 	sshByServer    map[string]*sshutil.Config
 	pings          *semaphore.Weighted
@@ -528,11 +374,6 @@ type matrixTestDeps struct {
 	errChan        chan<- error
 }
 
-// runMatrixServerServerPhase fans out ping (and iperf3 when allowed)
-// goroutines for every (src, dst) server pair the matrix knows about,
-// honoring NAT.DestinationIP when present. Pairs that carry a
-// DestinationPort are skipped here and instead exercised by
-// runMatrixPortForwardPhase, which uses the L4-aware iperf3 helper.
 func runMatrixServerServerPhase(ctx context.Context, opts TestConnectivityOpts, matrix *ConnectivityMatrix, deps *matrixTestDeps) error {
 	for _, src := range matrix.AllEndpoints {
 		if src.Server == nil {
@@ -545,8 +386,6 @@ func runMatrixServerServerPhase(ctx context.Context, opts TestConnectivityOpts, 
 			if dst.Server == nil || src == dst {
 				continue
 			}
-			// Skip pairs that ultimately point at the same host: same-host
-			// traffic short-circuits via lo and does not exercise the fabric.
 			if IsSameEndpointNode(src, dst) {
 				continue
 			}
@@ -609,12 +448,6 @@ func runMatrixServerServerPhase(ctx context.Context, opts TestConnectivityOpts, 
 	return nil
 }
 
-// runMatrixCurlPhase launches one curl per source server in
-// deps.inSources to the hardcoded outbound target ("1.0.0.1").
-// Each server's expected.Reachable is the OR of all (src → *_external)
-// matrix Allow entries that have SNAT info or no NAT at all; DNAT-only
-// (port-forward) entries don't generically route outbound and so don't
-// raise the expectation.
 func runMatrixCurlPhase(ctx context.Context, opts TestConnectivityOpts, matrix *ConnectivityMatrix, deps *matrixTestDeps) {
 	expectedByServer := map[string]Reachability{}
 	for _, src := range matrix.AllEndpoints {
@@ -670,17 +503,6 @@ func runMatrixCurlPhase(ctx context.Context, opts TestConnectivityOpts, matrix *
 	}
 }
 
-// runMatrixPortForwardPhase launches iperf3 against every port-forward
-// NAT virtual endpoint encoded in the matrix. External destinations are
-// deduped by (srcServer, IP, port) so the single external iperf3 server is hit once;
-// server destinations exercise every (src, dst) pair for full cross-product
-// coverage.
-//
-// Deny entries that carry port-forward NAT details are probed too: the
-// (IP, port) they name must NOT accept a connection. Without this,
-// negative expectations stop at the port-forward boundary — the
-// server-server phase skips DestinationPort pairs as L4-only, so a Deny
-// port-forward would otherwise be asserted nowhere.
 func runMatrixPortForwardPhase(ctx context.Context, opts TestConnectivityOpts, matrix *ConnectivityMatrix, deps *matrixTestDeps) {
 	type pfTargetKey struct {
 		from string
@@ -751,8 +573,6 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	if opts.PingsCount == 0 && opts.IPerfsSeconds == 0 && opts.CurlsCount == 0 {
 		return fmt.Errorf("at least one of pings, iperfs or curls should be enabled") //nolint:goerr113
 	}
-	// Deny verdicts drive assertions from here on; refuse to run if the
-	// matrix can't back them (see Validate).
 	if err := matrix.Validate(); err != nil {
 		return fmt.Errorf("connectivity matrix is not a sound oracle: %w", err)
 	}
@@ -776,8 +596,6 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	}
 	defer cacheCancel()
 
-	// Resolve the SSH config for every unique server name referenced by
-	// the matrix.
 	sshByServer := map[string]*sshutil.Config{}
 	for _, ep := range matrix.AllEndpoints {
 		if ep.Server == nil {
@@ -854,11 +672,6 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	return joined
 }
 
-// runMatrixIperfPortForward exercises one port-forward NAT path encoded by
-// the matrix: TCP-probe NAT.DestinationIP:Port until the gateway's DNAT
-// rule is programmed, then run iperf3 once. Targets may be external NAT
-// virtual IPs or other VPCs' NAT pool addresses — the function is agnostic
-// to where the (ip, port) lives.
 func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, iperfs *semaphore.Weighted, from string, ssh *sshutil.Config, toIP netip.Addr, toPort uint16, expected Reachability) *IperfError {
 	target := fmt.Sprintf("%s:%d", toIP.String(), toPort)
 	why := expectationWhy(expected)
@@ -871,10 +684,6 @@ func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, i
 	}
 	slog.Debug("Checking iperf3 through port-forward NAT (matrix)", logArgs...)
 
-	// Negative expectation: the virtual (IP, port) must refuse the
-	// connection. There is nothing to wait for — no DNAT rule is ever
-	// meant to appear — so a single probe decides it, and a successful
-	// connect is the failure.
 	if !expected.Reachable {
 		if _, _, err := retrySSHCmd(ctx, ssh, fmt.Sprintf("nc -zw2 %s %d", toIP.String(), toPort), from); err == nil {
 			return &IperfError{
@@ -888,11 +697,8 @@ func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, i
 		return nil
 	}
 
-	// Gate on TCP reachability: the gateway's port-forward DNAT rule has
-	// its own programming lag separate from fabric route propagation, and
-	// a successful TCP connect is the precise signal that both halves of
-	// the path (fabric route + gateway DNAT) are active. After the probe
-	// succeeds, iperf3 runs once and any failure is a real test failure.
+	// Gate on TCP reachability: a successful TCP connect is the precise signal
+	// that both halves of the path (fabric route + gateway DNAT) are active.
 	probe := fmt.Sprintf("nc -zw2 %s %d", toIP.String(), toPort)
 	deadline := time.Now().Add(gwNATPortForwardProbeTimeout)
 	var lastErr error

--- a/pkg/hhfab/matrix.go
+++ b/pkg/hhfab/matrix.go
@@ -312,6 +312,9 @@ func (m *ConnectivityMatrix) Validate() error {
 			if pair.Destination != nil && pair.Destination.External != nil && extAllowBySource[pair.Source] {
 				continue
 			}
+			if m.defaultEntryShadowed(pair, pp, e) {
+				continue
+			}
 			unknowns = append(unknowns, describeUnknownEntry(pair, pp, e))
 		}
 	}
@@ -322,6 +325,24 @@ func (m *ConnectivityMatrix) Validate() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// defaultEntryShadowed reports whether a default-ProtoPort entry is read by no
+// phase at all: runMatrixServerServerPhase hands a pair carrying proto-port
+// entries to runMatrixProtoPortPhase, which reads only those. Port-forward
+// entries are exempt, runMatrixPortForwardPhase still reads them.
+func (m *ConnectivityMatrix) defaultEntryShadowed(pair EndpointPair, pp ProtoPort, e ConnectivityExpectation) bool {
+	if pp != (ProtoPort{}) {
+		return false
+	}
+	if pair.Source == nil || pair.Destination == nil || pair.Source.Server == nil || pair.Destination.Server == nil {
+		return false
+	}
+	if e.NAT != nil && e.NAT.DestinationPort != 0 {
+		return false
+	}
+
+	return m.HasProtoPortEntries(pair.Source, pair.Destination)
 }
 
 func (m *ConnectivityMatrix) externalCurlAllowed(src *Endpoint) (ConnectivityExpectation, bool) {
@@ -897,16 +918,12 @@ func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, i
 	slog.Debug("Checking iperf3 through port-forward NAT (matrix)", logArgs...)
 
 	if !expected.Reachable {
-		if _, _, err := retrySSHCmd(ctx, ssh, fmt.Sprintf("nc -zw2 %s %d", toIP.String(), toPort), from); err == nil {
-			return &IperfError{
-				Source:      from,
-				Destination: target,
-				Why:         why,
-				ClientMsg:   "port-forward target is reachable but the matrix expects it to be denied",
-			}
+		ie := checkTCPPort(ctx, nil, from, ssh, toIP, toPort, false)
+		if ie != nil {
+			ie.Why = why
 		}
 
-		return nil
+		return ie
 	}
 
 	// Gate on TCP reachability: a successful TCP connect is the precise signal

--- a/pkg/hhfab/matrix.go
+++ b/pkg/hhfab/matrix.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/netip"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,6 +56,15 @@ type ConnectivityVerdict string
 const (
 	VerdictAllow ConnectivityVerdict = "allow"
 	VerdictDeny  ConnectivityVerdict = "deny"
+
+	// VerdictUnknown marks a pair the generator could not evaluate — today
+	// only peering shapes the reachability helpers don't model (see
+	// reachCheckUnsupported). It exists so that "we can't tell" is
+	// distinguishable from "must not work": a missing entry reads as Deny
+	// and would quietly pass by proving unreachability, while Validate
+	// refuses to run a test against a matrix that still holds one. Tests
+	// that know the real answer overlay it explicitly.
+	VerdictUnknown ConnectivityVerdict = "unknown"
 )
 
 // TranslatedAddress describes NAT translation expected on a path. Each field
@@ -102,6 +112,11 @@ type ConnectivityExpectation struct {
 
 	// Peering: name of the CRD that produced this expectation (diagnostic).
 	Peering string
+
+	// Detail: free-form context for Reason, currently only set on
+	// VerdictUnknown entries to carry why the pair could not be evaluated
+	// (diagnostic; surfaced by Validate).
+	Detail string
 
 	// ProtoPort scopes this expectation to a specific protocol/port. The
 	// zero value applies to the runner's default check.
@@ -154,6 +169,11 @@ type ConnectivityMatrix struct {
 	// entries[pair][protoPort] = expectation. The zero ProtoPort{} key holds
 	// the default-check expectation for the pair.
 	entries map[EndpointPair]map[ProtoPort]ConnectivityExpectation
+
+	// dropped: attachments/addresses endpoint discovery could not turn into
+	// endpoints. Not testable, so not in AllEndpoints — kept here so
+	// Validate can refuse to test a topology it only partially sees.
+	dropped []DroppedEndpoint
 }
 
 // NewConnectivityMatrix returns an empty matrix. AllEndpoints should be set
@@ -180,6 +200,19 @@ func ExternalNamed(name string) EndpointPredicate {
 	return func(ep *Endpoint) bool {
 		return ep.External != nil && ep.External.ExternalName == name
 	}
+}
+
+// overlayReason keeps the reason populate already established for a pair
+// when an overlay rewrites its verdict. Only pairs populate could not see
+// (it has no entry, or could not evaluate one) fall back to gateway
+// peering — which is what every overlay models today: NAT is a gateway
+// feature, and a pair the switch fabric already allows is not overlaid.
+func overlayReason(existing ReachabilityReason) ReachabilityReason {
+	if existing != "" {
+		return existing
+	}
+
+	return ReachabilityReasonGatewayPeering
 }
 
 // NATMutator updates a TranslatedAddress for a specific (src, dst) pair.
@@ -219,7 +252,7 @@ func OverlayMatrixNAT(
 			matrix.Add(ConnectivityExpectation{
 				Pair:    EndpointPair{Source: src, Destination: dst},
 				Verdict: VerdictAllow,
-				Reason:  ReachabilityReasonGatewayPeering,
+				Reason:  overlayReason(existing.Reason),
 				Peering: existing.Peering,
 				NAT:     &nat,
 			})
@@ -245,9 +278,10 @@ func OverlayMatrixNAT(
 // strictly a test-side opt-in. setupTest calls it once at suite startup;
 // matrix-driven tests call Repopulate on the existing matrix after
 // DoSetupPeerings to refresh verdicts to the post-peering state.
-func BuildConnectivityMatrix(ctx context.Context, kube kclient.Client, serverEndpoints []*Endpoint) (*ConnectivityMatrix, error) {
+func BuildConnectivityMatrix(ctx context.Context, kube kclient.Client, serverEndpoints []*Endpoint, dropped []DroppedEndpoint) (*ConnectivityMatrix, error) {
 	matrix := NewConnectivityMatrix()
 	matrix.AllEndpoints = append(matrix.AllEndpoints, serverEndpoints...)
+	matrix.dropped = append(matrix.dropped, dropped...)
 
 	externalList := vpcapi.ExternalList{}
 	if err := kube.List(ctx, &externalList); err != nil {
@@ -268,12 +302,12 @@ func BuildConnectivityMatrix(ctx context.Context, kube kclient.Client, serverEnd
 // BuildConnectivityMatrix. Used when a caller needs to build a matrix
 // against a pre-existing topology without re-running SetupVPCs.
 func BuildConnectivityMatrixFromCluster(ctx context.Context, kube kclient.Client, ssh SSHResolver) (*ConnectivityMatrix, error) {
-	endpoints, err := CollectServerEndpoints(ctx, kube, ssh, nil)
+	endpoints, dropped, err := CollectServerEndpoints(ctx, kube, ssh, nil)
 	if err != nil {
 		return nil, fmt.Errorf("collecting server endpoints for matrix: %w", err)
 	}
 
-	return BuildConnectivityMatrix(ctx, kube, endpoints)
+	return BuildConnectivityMatrix(ctx, kube, endpoints, dropped)
 }
 
 // Repopulate clears the matrix's expectation entries and refills Allow
@@ -329,6 +363,110 @@ func (m *ConnectivityMatrix) Lookup(src, dst *Endpoint, pp ProtoPort) Connectivi
 		Pair:      pair,
 		Verdict:   VerdictDeny,
 		ProtoPort: pp,
+	}
+}
+
+// Validate reports whether the matrix is a sound oracle for a connectivity
+// run. Lookup answers Deny for every pair it has no entry for, so a matrix
+// that silently lost endpoints or could not evaluate a peering would assert
+// unreachability it never established — and pass. Validate is the single
+// gate in front of that: it runs at the top of TestConnectivityWithMatrix,
+// after generators have populated and tests have applied their overlays.
+//
+// It rejects:
+//   - an empty endpoint set (nothing to test, e.g. a matrix built with
+//     noSetup against a topology that was never discovered);
+//   - discovery drops (an attachment or address that never became an
+//     endpoint, so a slice of the topology goes untested);
+//   - leftover VerdictUnknown entries, which mean populate could not
+//     evaluate the pair and no test overlaid the real expectation.
+//
+// It deliberately does not require any Allow entry: a topology of mutually
+// isolated VPCs with no peerings is a legitimate thing to assert.
+//
+// Unknown on a server→external pair is only fatal when that source has no
+// Allow to any external. The reachability helper behind external
+// destinations ORs over every External in the cluster rather than
+// answering per-destination, and runMatrixCurlPhase consumes it the same
+// way, so one Allow settles the source's expectation regardless of the
+// other externals' entries.
+func (m *ConnectivityMatrix) Validate() error {
+	if m == nil {
+		return fmt.Errorf("connectivity matrix is nil") //nolint:goerr113
+	}
+
+	var errs []error
+
+	if len(m.AllEndpoints) == 0 {
+		errs = append(errs, fmt.Errorf("matrix has no endpoints")) //nolint:goerr113
+	}
+
+	if len(m.dropped) > 0 {
+		reasons := make([]string, 0, len(m.dropped))
+		for _, d := range m.dropped {
+			reasons = append(reasons, d.String())
+		}
+		slices.Sort(reasons)
+		errs = append(errs, fmt.Errorf("endpoint discovery dropped %d attachment(s)/address(es), topology only partially visible: %s", //nolint:goerr113
+			len(m.dropped), strings.Join(reasons, "; ")))
+	}
+
+	extAllowBySource := map[*Endpoint]bool{}
+	for pair, byPP := range m.entries {
+		for _, e := range byPP {
+			if e.Verdict == VerdictAllow && pair.Destination != nil && pair.Destination.External != nil {
+				extAllowBySource[pair.Source] = true
+			}
+		}
+	}
+
+	unknowns := []string{}
+	for pair, byPP := range m.entries {
+		for pp, e := range byPP {
+			if e.Verdict != VerdictUnknown {
+				continue
+			}
+			if pair.Destination != nil && pair.Destination.External != nil && extAllowBySource[pair.Source] {
+				continue
+			}
+			unknowns = append(unknowns, describeUnknownEntry(pair, pp, e))
+		}
+	}
+	if len(unknowns) > 0 {
+		slices.Sort(unknowns)
+		errs = append(errs, fmt.Errorf("%d matrix entr(ies) could not be evaluated and were not overlaid by the test: %s", //nolint:goerr113
+			len(unknowns), strings.Join(unknowns, "; ")))
+	}
+
+	return errors.Join(errs...)
+}
+
+// describeUnknownEntry renders a pair for Validate's diagnostics.
+func describeUnknownEntry(pair EndpointPair, pp ProtoPort, e ConnectivityExpectation) string {
+	out := fmt.Sprintf("%s → %s", endpointLabel(pair.Source), endpointLabel(pair.Destination))
+	if pp != (ProtoPort{}) {
+		out += fmt.Sprintf(" [%s/%d]", pp.Protocol, pp.Port)
+	}
+	if e.Detail != "" {
+		out += ": " + e.Detail
+	} else if e.Reason != "" {
+		out += ": " + string(e.Reason)
+	}
+
+	return out
+}
+
+// endpointLabel renders an endpoint for diagnostics.
+func endpointLabel(ep *Endpoint) string {
+	switch {
+	case ep == nil:
+		return "<nil>"
+	case ep.Server != nil:
+		return fmt.Sprintf("%s(%s/%s)", ep.Server.Name, ep.Server.VPC, ep.Server.Subnet)
+	case ep.External != nil:
+		return "external:" + ep.External.ExternalName
+	default:
+		return "<empty>"
 	}
 }
 
@@ -525,7 +663,7 @@ func runMatrixCurlPhase(ctx context.Context, opts TestConnectivityOpts, matrix *
 			}
 			slog.Debug("Checking external connectivity", logArgs...)
 
-			if ce := checkCurl(ctx, opts, deps.curls, name, ssh, "1.0.0.1", expected.Reachable); ce != nil {
+			if ce := checkCurl(ctx, opts, deps.curls, name, ssh, "1.0.0.1", expected); ce != nil {
 				deps.errChan <- ce
 			}
 		})
@@ -537,6 +675,12 @@ func runMatrixCurlPhase(ctx context.Context, opts TestConnectivityOpts, matrix *
 // deduped by (srcServer, IP, port) so the single external iperf3 server is hit once;
 // server destinations exercise every (src, dst) pair for full cross-product
 // coverage.
+//
+// Deny entries that carry port-forward NAT details are probed too: the
+// (IP, port) they name must NOT accept a connection. Without this,
+// negative expectations stop at the port-forward boundary — the
+// server-server phase skips DestinationPort pairs as L4-only, so a Deny
+// port-forward would otherwise be asserted nowhere.
 func runMatrixPortForwardPhase(ctx context.Context, opts TestConnectivityOpts, matrix *ConnectivityMatrix, deps *matrixTestDeps) {
 	type pfTargetKey struct {
 		from string
@@ -556,7 +700,7 @@ func runMatrixPortForwardPhase(ctx context.Context, opts TestConnectivityOpts, m
 				continue
 			}
 			e := matrix.Lookup(src, dst, ProtoPort{})
-			if e.Verdict != VerdictAllow || e.NAT == nil {
+			if e.NAT == nil || (e.Verdict != VerdictAllow && e.Verdict != VerdictDeny) {
 				continue
 			}
 			if !e.NAT.DestinationIP.IsValid() || e.NAT.DestinationPort == 0 {
@@ -565,7 +709,10 @@ func runMatrixPortForwardPhase(ctx context.Context, opts TestConnectivityOpts, m
 			switch {
 			case dst.External != nil:
 				key := pfTargetKey{from: src.Server.Name, ip: e.NAT.DestinationIP, port: e.NAT.DestinationPort}
-				if _, seen := extTargets[key]; seen {
+				// Several externals can share one port-forward virtual
+				// (IP, port); an Allow anywhere in that set wins over a
+				// Deny, since a single probe can't distinguish them.
+				if prev, seen := extTargets[key]; seen && (prev.Reachable || e.Verdict != VerdictAllow) {
 					continue
 				}
 				extTargets[key] = reachabilityFromExpectation(e)
@@ -604,6 +751,11 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	if opts.PingsCount == 0 && opts.IPerfsSeconds == 0 && opts.CurlsCount == 0 {
 		return fmt.Errorf("at least one of pings, iperfs or curls should be enabled") //nolint:goerr113
 	}
+	// Deny verdicts drive assertions from here on; refuse to run if the
+	// matrix can't back them (see Validate).
+	if err := matrix.Validate(); err != nil {
+		return fmt.Errorf("connectivity matrix is not a sound oracle: %w", err)
+	}
 	start := time.Now()
 
 	if opts.PingsParallel <= 0 {
@@ -624,16 +776,15 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	}
 	defer cacheCancel()
 
-	// Resolve the SSH config and a toolbox mutex for every unique server
-	// name referenced by the matrix.
+	// Resolve the SSH config for every unique server name referenced by
+	// the matrix.
 	sshByServer := map[string]*sshutil.Config{}
-	toolboxMutexes := map[string]*sync.Mutex{}
 	for _, ep := range matrix.AllEndpoints {
 		if ep.Server == nil {
 			continue
 		}
 		name := ep.Server.Name
-		if _, ok := toolboxMutexes[name]; ok {
+		if _, ok := sshByServer[name]; ok {
 			continue
 		}
 		ssh, ok := sshConfigs[name]
@@ -641,7 +792,6 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 			return fmt.Errorf("no ssh config for server %q referenced by matrix", name) //nolint:goerr113
 		}
 		sshByServer[name] = ssh
-		toolboxMutexes[name] = &sync.Mutex{}
 	}
 
 	n := len(matrix.AllEndpoints)
@@ -711,6 +861,7 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 // to where the (ip, port) lives.
 func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, iperfs *semaphore.Weighted, from string, ssh *sshutil.Config, toIP netip.Addr, toPort uint16, expected Reachability) *IperfError {
 	target := fmt.Sprintf("%s:%d", toIP.String(), toPort)
+	why := expectationWhy(expected)
 	logArgs := []any{"from", from, "target", target, "expected", expected.Reachable}
 	if expected.Reason != "" {
 		logArgs = append(logArgs, "reason", expected.Reason)
@@ -719,6 +870,23 @@ func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, i
 		logArgs = append(logArgs, "peering", expected.Peering)
 	}
 	slog.Debug("Checking iperf3 through port-forward NAT (matrix)", logArgs...)
+
+	// Negative expectation: the virtual (IP, port) must refuse the
+	// connection. There is nothing to wait for — no DNAT rule is ever
+	// meant to appear — so a single probe decides it, and a successful
+	// connect is the failure.
+	if !expected.Reachable {
+		if _, _, err := retrySSHCmd(ctx, ssh, fmt.Sprintf("nc -zw2 %s %d", toIP.String(), toPort), from); err == nil {
+			return &IperfError{
+				Source:      from,
+				Destination: target,
+				Why:         why,
+				ClientMsg:   "port-forward target is reachable but the matrix expects it to be denied",
+			}
+		}
+
+		return nil
+	}
 
 	// Gate on TCP reachability: the gateway's port-forward DNAT rule has
 	// its own programming lag separate from fabric route propagation, and
@@ -738,18 +906,19 @@ func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, i
 			return &IperfError{
 				Source:      from,
 				Destination: target,
+				Why:         why,
 				ClientMsg:   fmt.Sprintf("port-forward target not reachable after %s: %s", gwNATPortForwardProbeTimeout, lastErr),
 			}
 		}
 		select {
 		case <-ctx.Done():
-			return &IperfError{Source: from, Destination: target, ClientMsg: ctx.Err().Error()}
+			return &IperfError{Source: from, Destination: target, Why: why, ClientMsg: ctx.Err().Error()}
 		case <-time.After(gwNATPortForwardProbeInterval):
 		}
 	}
 
 	if err := iperfs.Acquire(ctx, 1); err != nil {
-		return &IperfError{Source: from, Destination: target, ClientMsg: fmt.Sprintf("acquiring iperf3 semaphore: %s", err)}
+		return &IperfError{Source: from, Destination: target, Why: why, ClientMsg: fmt.Sprintf("acquiring iperf3 semaphore: %s", err)}
 	}
 	defer iperfs.Release(1)
 
@@ -757,7 +926,7 @@ func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, i
 	cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 -J -c %s -p %d -t %d",
 		secs+25, toIP.String(), toPort, secs)
 	if _, _, iperfErr := retrySSHCmd(ctx, ssh, cmd, from); iperfErr != nil {
-		return &IperfError{Source: from, Destination: target, ClientMsg: iperfErr.Error()}
+		return &IperfError{Source: from, Destination: target, Why: why, ClientMsg: iperfErr.Error()}
 	}
 
 	return nil

--- a/pkg/hhfab/matrix.go
+++ b/pkg/hhfab/matrix.go
@@ -37,6 +37,13 @@ const gwNATPortForwardProbeTimeout = 2 * time.Minute
 // gwNATPortForwardProbeInterval is the polling interval between TCP-reachability probes.
 const gwNATPortForwardProbeInterval = 5 * time.Second
 
+// Bound the wait for an on-demand iperf3 listener to bind its port (~5s total).
+// The interval is a remote shell sleep argument, in seconds.
+const (
+	protoPortListenerBindAttempts = 20
+	protoPortListenerBindSleepArg = "0.25"
+)
+
 type ConnectivityVerdict string
 
 const (
@@ -290,11 +297,9 @@ func (m *ConnectivityMatrix) Validate() error {
 	}
 
 	extAllowBySource := map[*Endpoint]bool{}
-	for pair, byPP := range m.entries {
-		for _, e := range byPP {
-			if e.Verdict == VerdictAllow && pair.Destination != nil && pair.Destination.External != nil {
-				extAllowBySource[pair.Source] = true
-			}
+	for _, src := range m.AllEndpoints {
+		if _, ok := m.externalCurlAllowed(src); ok {
+			extAllowBySource[src] = true
 		}
 	}
 
@@ -312,11 +317,33 @@ func (m *ConnectivityMatrix) Validate() error {
 	}
 	if len(unknowns) > 0 {
 		slices.Sort(unknowns)
-		errs = append(errs, fmt.Errorf("%d matrix entr(ies) could not be evaluated and were not overlaid by the test: %s", //nolint:goerr113
+		errs = append(errs, fmt.Errorf("%d matrix entries could not be evaluated and were not overlaid by the test: %s", //nolint:goerr113
 			len(unknowns), strings.Join(unknowns, "; ")))
 	}
 
 	return errors.Join(errs...)
+}
+
+func (m *ConnectivityMatrix) externalCurlAllowed(src *Endpoint) (ConnectivityExpectation, bool) {
+	if src == nil || src.Server == nil {
+		return ConnectivityExpectation{}, false
+	}
+	for _, dst := range m.AllEndpoints {
+		if dst.External == nil {
+			continue
+		}
+		e := m.Lookup(src, dst, ProtoPort{})
+		if e.Verdict != VerdictAllow {
+			continue
+		}
+		if e.NAT != nil && !e.NAT.SourcePool.IsValid() {
+			continue
+		}
+
+		return e, true
+	}
+
+	return ConnectivityExpectation{}, false
 }
 
 func describeUnknownEntry(pair EndpointPair, pp ProtoPort, e ConnectivityExpectation) string {
@@ -506,20 +533,8 @@ func runMatrixCurlPhase(ctx context.Context, opts TestConnectivityOpts, matrix *
 		if expectedByServer[name].Reachable {
 			continue
 		}
-		for _, dst := range matrix.AllEndpoints {
-			if dst.External == nil {
-				continue
-			}
-			e := matrix.Lookup(src, dst, ProtoPort{})
-			if e.Verdict != VerdictAllow {
-				continue
-			}
-			if e.NAT != nil && !e.NAT.SourcePool.IsValid() {
-				continue
-			}
+		if e, ok := matrix.externalCurlAllowed(src); ok {
 			expectedByServer[name] = reachabilityFromExpectation(e)
-
-			break
 		}
 	}
 
@@ -662,13 +677,16 @@ func startMatrixProtoPortListeners(ctx context.Context, matrix *ConnectivityMatr
 
 			return nil, fmt.Errorf("no ssh config for server %q needed as proto-port listener", hp.host) //nolint:goerr113
 		}
-		cmd := fmt.Sprintf("sudo docker exec -d iperf3 iperf3 -s -p %d", hp.port)
+		// docker exec -d returns as soon as the process is spawned, so wait for
+		// the listener to actually bind.
+		cmd := fmt.Sprintf("sudo docker exec -d iperf3 iperf3 -s -p %d && for i in $(seq 1 %d); do nc -z 127.0.0.1 %d && exit 0; sleep %s; done; exit 1",
+			hp.port, protoPortListenerBindAttempts, hp.port, protoPortListenerBindSleepArg)
+		started = append(started, hp)
 		if _, stderr, err := retrySSHCmd(ctx, ssh, cmd, hp.host); err != nil {
 			teardown()
 
 			return nil, fmt.Errorf("starting proto-port iperf3 listener on %s:%d: %w: %s", hp.host, hp.port, err, stderr)
 		}
-		started = append(started, hp)
 		slog.Debug("Started proto-port iperf3 listener", "host", hp.host, "port", hp.port)
 	}
 

--- a/pkg/hhfab/matrix_test.go
+++ b/pkg/hhfab/matrix_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtoPortEntries_ExcludesDefaultAndSorts(t *testing.T) {
+	m := NewConnectivityMatrix()
+	src := serverEP("server-1", "vpc-1", "default", "10.0.1.1")
+	dst := serverEP("server-2", "vpc-2", "default", "10.0.2.2")
+	m.AllEndpoints = []*Endpoint{src, dst}
+
+	// A default (ProtoPort{}) entry must be excluded from the proto list.
+	m.Add(ConnectivityExpectation{
+		Pair:    EndpointPair{Source: src, Destination: dst},
+		Verdict: VerdictAllow,
+	})
+	// Add out of order to prove sorting by (Protocol, Port).
+	m.Add(ConnectivityExpectation{
+		Pair:      EndpointPair{Source: src, Destination: dst},
+		Verdict:   VerdictDeny,
+		ProtoPort: ProtoPort{Protocol: "udp", Port: 5201},
+	})
+	m.Add(ConnectivityExpectation{
+		Pair:      EndpointPair{Source: src, Destination: dst},
+		Verdict:   VerdictAllow,
+		ProtoPort: ProtoPort{Protocol: "tcp", Port: 6201},
+	})
+	m.Add(ConnectivityExpectation{
+		Pair:      EndpointPair{Source: src, Destination: dst},
+		Verdict:   VerdictAllow,
+		ProtoPort: ProtoPort{Protocol: "tcp", Port: 5201},
+	})
+
+	got := m.ProtoPortEntries(src, dst)
+	require.Len(t, got, 3, "default entry excluded")
+	require.Equal(t, ProtoPort{Protocol: "tcp", Port: 5201}, got[0].ProtoPort)
+	require.Equal(t, ProtoPort{Protocol: "tcp", Port: 6201}, got[1].ProtoPort)
+	require.Equal(t, ProtoPort{Protocol: "udp", Port: 5201}, got[2].ProtoPort)
+	require.Equal(t, VerdictDeny, got[2].Verdict)
+}
+
+func TestProtoPortEntries_NoneForUnknownPair(t *testing.T) {
+	m := NewConnectivityMatrix()
+	src := serverEP("server-1", "vpc-1", "default", "10.0.1.1")
+	dst := serverEP("server-2", "vpc-2", "default", "10.0.2.2")
+	m.AllEndpoints = []*Endpoint{src, dst}
+
+	require.Nil(t, m.ProtoPortEntries(src, dst))
+	require.False(t, m.HasProtoPortEntries(src, dst))
+}
+
+func TestHasProtoPortEntries_IgnoresDefaultOnly(t *testing.T) {
+	m := NewConnectivityMatrix()
+	src := serverEP("server-1", "vpc-1", "default", "10.0.1.1")
+	dst := serverEP("server-2", "vpc-2", "default", "10.0.2.2")
+	m.AllEndpoints = []*Endpoint{src, dst}
+
+	// A pair with only a default entry must NOT be treated as proto-scoped,
+	// so the legacy server-server phase keeps owning it.
+	m.Add(ConnectivityExpectation{
+		Pair:    EndpointPair{Source: src, Destination: dst},
+		Verdict: VerdictAllow,
+	})
+	require.False(t, m.HasProtoPortEntries(src, dst))
+
+	// Once a non-zero ProtoPort entry lands, the pair is proto-scoped and the
+	// legacy phase gate (which keys on this) routes it to the proto-port phase.
+	m.Add(ConnectivityExpectation{
+		Pair:      EndpointPair{Source: src, Destination: dst},
+		Verdict:   VerdictAllow,
+		ProtoPort: ProtoPort{Protocol: "tcp", Port: 5201},
+	})
+	require.True(t, m.HasProtoPortEntries(src, dst))
+}
+
+func TestParseNCReturnCode(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+		wantRC int
+		wantOk bool
+	}{
+		{"connect ok", "NCRC=0\n", 0, true},
+		{"refused/timeout", "nc: connect failed\nNCRC=1\n", 1, true},
+		{"not found", "bash: nc: command not found\nNCRC=127\n", 127, true},
+		{"marker with spaces", "  NCRC=1  \n", 1, true},
+		{"no marker (probe did not complete)", "some ssh noise\n", 0, false},
+		{"empty", "", 0, false},
+		{"non-numeric marker", "NCRC=oops\n", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rc, ok := parseNCReturnCode(tc.stdout)
+			require.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				require.Equal(t, tc.wantRC, rc)
+			}
+		})
+	}
+}
+
+func TestSetVPCToVPCProtoVerdict_AccumulatesScopesAndPreservesPeering(t *testing.T) {
+	m := NewConnectivityMatrix()
+	a1 := serverEP("server-1", "vpc-1", "default", "10.0.1.1")
+	a2 := serverEP("server-2", "vpc-1", "default", "10.0.1.2")
+	b1 := serverEP("server-3", "vpc-2", "default", "10.0.2.1")
+	c1 := serverEP("server-4", "vpc-3", "default", "10.0.3.1")
+	m.AllEndpoints = []*Endpoint{a1, a2, b1, c1}
+
+	// Seed a default entry so we can prove Peering is preserved onto the
+	// proto entries.
+	m.Add(ConnectivityExpectation{
+		Pair:    EndpointPair{Source: a1, Destination: b1},
+		Verdict: VerdictAllow,
+		Peering: "vpc-1--vpc-2",
+	})
+
+	setVPCToVPCProtoVerdict(m, "vpc-1", "vpc-2", ProtoPort{Protocol: "tcp", Port: 5201}, VerdictAllow)
+	setVPCToVPCProtoVerdict(m, "vpc-1", "vpc-2", ProtoPort{Protocol: "udp", Port: 5201}, VerdictDeny)
+
+	// Both protocols coexist on the same pair.
+	tcp := m.Lookup(a1, b1, ProtoPort{Protocol: "tcp", Port: 5201})
+	udp := m.Lookup(a1, b1, ProtoPort{Protocol: "udp", Port: 5201})
+	require.Equal(t, VerdictAllow, tcp.Verdict)
+	require.Equal(t, VerdictDeny, udp.Verdict)
+	require.Equal(t, "vpc-1--vpc-2", tcp.Peering, "existing peering preserved")
+	require.Equal(t, ReachabilityReasonGatewayPeering, tcp.Reason)
+
+	// Applied to every source in vpc-1 (a2 too), not just a1.
+	require.Equal(t, VerdictAllow, m.Lookup(a2, b1, ProtoPort{Protocol: "tcp", Port: 5201}).Verdict)
+
+	// Not applied to a server outside the destination VPC.
+	require.False(t, m.HasProtoPortEntries(a1, c1), "vpc-3 destination untouched")
+}

--- a/pkg/hhfab/rt_acl_tests.go
+++ b/pkg/hhfab/rt_acl_tests.go
@@ -1,0 +1,423 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package hhfab
+
+import (
+	"context"
+	"fmt"
+
+	gwapi "go.githedgehog.com/fabric/api/gateway/v1alpha1"
+	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
+)
+
+const (
+	// aclProbePort is served by the always-on iperf3 daemon (TCP+UDP), so
+	// tests probing it need no on-demand listener.
+	aclProbePort    uint16 = 5201
+	aclAltPort      uint16 = 6201
+	aclAltPortRange        = "6000-6500"
+	aclUnprobedPort uint16 = 9999
+)
+
+func setACLDirVerdicts(m *ConnectivityMatrix, srcVPC, dstVPC string, icmp, tcp, udp ConnectivityVerdict) {
+	setVPCToVPCProtoVerdict(m, srcVPC, dstVPC, ProtoPort{Protocol: "icmp"}, icmp)
+	setVPCToVPCProtoVerdict(m, srcVPC, dstVPC, ProtoPort{Protocol: "tcp", Port: aclProbePort}, tcp)
+	setVPCToVPCProtoVerdict(m, srcVPC, dstVPC, ProtoPort{Protocol: "udp", Port: aclProbePort}, udp)
+}
+
+// gatewayACLDefaultDenyTest: default=deny blocks all traffic despite the subnets
+// being exposed. The ACL carries one narrow allow rule on an unprobed port
+// (rule-less ACLs are rejected by the dataplane); every probed path still falls
+// to the default deny.
+func gatewayACLDefaultDenyTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL default deny",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{{
+					Name: "allow-unprobed", From: vpc1.Name, To: vpc2.Name,
+					Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+					Match: gwapi.PeeringACLMatch{
+						Protocol:    gwapi.ACLMatchProtocolTCP,
+						Destination: []gwapi.PeeringACLMatchEndpoint{{Ports: []string{fmt.Sprintf("%d", aclUnprobedPort)}}},
+					},
+				}},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLDenyUnlessExposedTest: default=deny-unless-exposed keeps exposed
+// subnets reachable, while an explicit deny rule carves out a slice.
+// This is both the permissive-default positive control AND coverage of a
+// Protocol:udp deny rule.
+func gatewayACLDenyUnlessExposedTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL deny-unless-exposed with udp carve-out",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDenyUnlessExposed,
+				Rules: []gwapi.PeeringACLRule{
+					{Name: "deny-udp-fwd", From: vpc1.Name, To: vpc2.Name, Action: gwapi.ACLActionDeny, Scope: gwapi.ACLScopePacket, Match: gwapi.PeeringACLMatch{Protocol: gwapi.ACLMatchProtocolUDP}},
+					{Name: "deny-udp-rev", From: vpc2.Name, To: vpc1.Name, Action: gwapi.ACLActionDeny, Scope: gwapi.ACLScopePacket, Match: gwapi.PeeringACLMatch{Protocol: gwapi.ACLMatchProtocolUDP}},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			// TCP/ICMP: exposed ⇒ allowed both ways. UDP: denied both ways.
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictAllow, VerdictAllow, VerdictDeny)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictAllow, VerdictAllow, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLExplicitAllowTest: default=deny plus explicit allow rules for both
+// directions restore full connectivity
+func gatewayACLExplicitAllowTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL explicit allow rule",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{Name: "allow-fwd", From: vpc1.Name, To: vpc2.Name, Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket},
+					{Name: "allow-rev", From: vpc2.Name, To: vpc1.Name, Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictAllow, VerdictAllow, VerdictAllow)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictAllow, VerdictAllow, VerdictAllow)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLProtocolScopingTest: allow TCP in both directions; UDP and ICMP fall
+// to the default deny.
+func gatewayACLProtocolScopingTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL protocol scoping",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{Name: "allow-tcp-fwd", From: vpc1.Name, To: vpc2.Name, Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket, Match: gwapi.PeeringACLMatch{Protocol: gwapi.ACLMatchProtocolTCP}},
+					{Name: "allow-tcp-rev", From: vpc2.Name, To: vpc1.Name, Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket, Match: gwapi.PeeringACLMatch{Protocol: gwapi.ACLMatchProtocolTCP}},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictDeny, VerdictAllow, VerdictDeny)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictDeny, VerdictAllow, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLPacketOneWayTest: a single packet-scoped From:vpc1,To:vpc2 allow rule
+// permits only the forward packets; the reply (vpc2→vpc1) has no matching rule
+// and hits the default deny, so no probe can complete a handshake or get an ICMP reply.
+func gatewayACLPacketOneWayTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL packet one-way (no return)",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{Name: "allow-fwd", From: vpc1.Name, To: vpc2.Name, Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			// Forward flow can't complete without its return, so both
+			// directions are unreachable.
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLFlowScopeMasqueradeTest: a flow-scoped rule is only valid on a
+// peering that has stateful NAT (where the dataplane keeps flow/conntrack
+// state), so this case pairs a masquerade NAT on VPC1 with a flow-scoped
+// From:vpc1,To:vpc2 allow rule. Masquerade SNAT lets VPC1 reach VPC2's real
+// IPs and the flow rule permits that stateful flow (and its return traffic);
+// VPC2 cannot initiate (masquerade blocks unsolicited inbound and no reverse
+// rule exists). Verifies flow scope is accepted and enforced with masquerade.
+func gatewayACLFlowScopeMasqueradeTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	const vpc1NATCIDR = "192.168.81.0/24"
+
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL flow scope with masquerade",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{Name: "allow-flow", From: vpc1.Name, To: vpc2.Name, Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopeFlow},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{
+				VPC1NATCIDR: []string{vpc1NATCIDR},
+				VPC1NATMode: NATModeMasquerade,
+				ACL:         acl,
+			})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			// vpc1→vpc2 rides masquerade SNAT against vpc2's real IPs and is
+			// permitted by the flow rule. vpc2→vpc1 is blocked both by
+			// masquerade (stateful, no unsolicited inbound) and by the ACL
+			// default deny.
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictAllow, VerdictAllow, VerdictAllow)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLSubnetScopingTest: packet-scoped rules matching source and
+// destination in BOTH directions so the reply is permitted too. The forward rule
+// selects by VPCSubnet name and the reverse rule by CIDR, so a single test
+// exercises both endpoint selectors.
+func gatewayACLSubnetScopingTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL subnet/CIDR scoping",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			vpc1CIDR, err := vpcFirstSubnetCIDR(vpc1)
+			if err != nil {
+				return specs, err
+			}
+			vpc2CIDR, err := vpcFirstSubnetCIDR(vpc2)
+			if err != nil {
+				return specs, err
+			}
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{
+						Name: "allow-subnet-fwd", From: vpc1.Name, To: vpc2.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Source:      []gwapi.PeeringACLMatchEndpoint{{VPCSubnet: "subnet-01"}},
+							Destination: []gwapi.PeeringACLMatchEndpoint{{VPCSubnet: "subnet-01"}},
+						},
+					},
+					{
+						Name: "allow-cidr-rev", From: vpc2.Name, To: vpc1.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Source:      []gwapi.PeeringACLMatchEndpoint{{CIDR: vpc2CIDR}},
+							Destination: []gwapi.PeeringACLMatchEndpoint{{CIDR: vpc1CIDR}},
+						},
+					},
+				},
+			}
+			err = appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictAllow, VerdictAllow, VerdictAllow)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictAllow, VerdictAllow, VerdictAllow)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLPortScopingTest: allow a vpc1→vpc2 TCP flow whose port falls in
+// aclAltPortRange. The forward rule matches a destination-port RANGE; the reverse
+// rule matches the same SOURCE-port range so the server's replies (whose source
+// port is the listener port) are permitted and the handshake completes.
+// Covers both port-range matching and src/dst-port selectors in one case.
+func gatewayACLPortScopingTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL port range scoping",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{
+						Name: "allow-alt-fwd", From: vpc1.Name, To: vpc2.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Protocol:    gwapi.ACLMatchProtocolTCP,
+							Destination: []gwapi.PeeringACLMatchEndpoint{{Ports: []string{aclAltPortRange}}},
+						},
+					},
+					{
+						Name: "allow-alt-ret", From: vpc2.Name, To: vpc1.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Protocol: gwapi.ACLMatchProtocolTCP,
+							Source:   []gwapi.PeeringACLMatchEndpoint{{Ports: []string{aclAltPortRange}}},
+						},
+					},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			// Forward: only TCP/aclAltPort completes (reply rides the src-port
+			// return rule). Reverse: a vpc2-initiated connect to aclAltPort has
+			// dst=aclAltPort/src=ephemeral, matching neither rule → default deny.
+			setVPCToVPCProtoVerdict(matrix, vpc1.Name, vpc2.Name, ProtoPort{Protocol: "tcp", Port: aclAltPort}, VerdictAllow)
+			setVPCToVPCProtoVerdict(matrix, vpc1.Name, vpc2.Name, ProtoPort{Protocol: "tcp", Port: aclProbePort}, VerdictDeny)
+			setVPCToVPCProtoVerdict(matrix, vpc1.Name, vpc2.Name, ProtoPort{Protocol: "udp", Port: aclProbePort}, VerdictDeny)
+			setVPCToVPCProtoVerdict(matrix, vpc1.Name, vpc2.Name, ProtoPort{Protocol: "icmp"}, VerdictDeny)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+			setVPCToVPCProtoVerdict(matrix, vpc2.Name, vpc1.Name, ProtoPort{Protocol: "tcp", Port: aclAltPort}, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLPrecedenceAllowThenDenyTest: an allow for TCP/aclProbePort ahead of a
+// broad deny (packet-scoped, vpc1→vpc2). Under first-match-wins TCP/aclProbePort
+// is allowed forward while everything else is denied. A reverse source-port rule
+// lets the server's replies through so the allowed flow completes; the reverse
+// direction otherwise follows the default deny.
+func gatewayACLPrecedenceAllowThenDenyTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	probePortStr := fmt.Sprintf("%d", aclProbePort)
+
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL precedence allow-then-deny",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{
+						Name: "allow-tcp", From: vpc1.Name, To: vpc2.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Protocol:    gwapi.ACLMatchProtocolTCP,
+							Destination: []gwapi.PeeringACLMatchEndpoint{{Ports: []string{probePortStr}}},
+						},
+					},
+					{Name: "deny-all", From: vpc1.Name, To: vpc2.Name, Action: gwapi.ACLActionDeny, Scope: gwapi.ACLScopePacket},
+					{
+						Name: "allow-tcp-ret", From: vpc2.Name, To: vpc1.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Protocol: gwapi.ACLMatchProtocolTCP,
+							Source:   []gwapi.PeeringACLMatchEndpoint{{Ports: []string{probePortStr}}},
+						},
+					},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictDeny, VerdictAllow, VerdictDeny)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+// gatewayACLPrecedenceDenyThenAllowTest: the reverse rule order of the previous
+// test. Under first-match-wins the broad deny
+// matches first, so even TCP/aclProbePort is denied and nothing gets through.
+func gatewayACLPrecedenceDenyThenAllowTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *ConnectivityMatrix) (bool, []RevertFunc, error) {
+	probePortStr := fmt.Sprintf("%d", aclProbePort)
+
+	return testCtx.runNATTest(ctx, matrix, natTestSpec{
+		Name: "gateway ACL precedence deny-then-allow",
+		BuildSpec: func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error) {
+			specs := emptyPeeringSpecs()
+			acl := &gwapi.PeeringACL{
+				Default: gwapi.ACLDefaultDeny,
+				Rules: []gwapi.PeeringACLRule{
+					{Name: "deny-all", From: vpc1.Name, To: vpc2.Name, Action: gwapi.ACLActionDeny, Scope: gwapi.ACLScopePacket},
+					{
+						Name: "allow-tcp", From: vpc1.Name, To: vpc2.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Protocol:    gwapi.ACLMatchProtocolTCP,
+							Destination: []gwapi.PeeringACLMatchEndpoint{{Ports: []string{probePortStr}}},
+						},
+					},
+					{
+						Name: "allow-tcp-ret", From: vpc2.Name, To: vpc1.Name,
+						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
+						Match: gwapi.PeeringACLMatch{
+							Protocol: gwapi.ACLMatchProtocolTCP,
+							Source:   []gwapi.PeeringACLMatchEndpoint{{Ports: []string{probePortStr}}},
+						},
+					},
+				},
+			}
+			err := appendGwPeeringSpec(specs.Gateway, vpc1, vpc2, &GwPeeringOptions{ACL: acl})
+
+			return specs, err
+		},
+		Overlay: func(vpc1, vpc2 *vpcapi.VPC, matrix *ConnectivityMatrix) error {
+			setACLDirVerdicts(matrix, vpc1.Name, vpc2.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+			setACLDirVerdicts(matrix, vpc2.Name, vpc1.Name, VerdictDeny, VerdictDeny, VerdictDeny)
+
+			return nil
+		},
+	})
+}
+
+func getACLTestCases() []JUnitTestCase {
+	return []JUnitTestCase{
+		{Name: "Gateway Peering ACL Default Deny", F: gatewayACLDefaultDenyTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Deny-Unless-Exposed UDP Carve-Out", F: gatewayACLDenyUnlessExposedTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Explicit Allow", F: gatewayACLExplicitAllowTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Protocol Scoping", F: gatewayACLProtocolScopingTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Packet One-Way", F: gatewayACLPacketOneWayTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Flow Scope Masquerade", F: gatewayACLFlowScopeMasqueradeTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Subnet/CIDR Scoping", F: gatewayACLSubnetScopingTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Port Range Scoping", F: gatewayACLPortScopingTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Precedence Allow-Then-Deny", F: gatewayACLPrecedenceAllowThenDenyTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+		{Name: "Gateway Peering ACL Precedence Deny-Then-Allow", F: gatewayACLPrecedenceDenyThenAllowTest, SkipFlags: SkipFlags{NoGateway: true, NoServers: true}},
+	}
+}

--- a/pkg/hhfab/rt_acl_tests.go
+++ b/pkg/hhfab/rt_acl_tests.go
@@ -230,6 +230,14 @@ func gatewayACLSubnetScopingTest(ctx context.Context, testCtx *VPCPeeringTestCtx
 			if err != nil {
 				return specs, err
 			}
+			vpc1Subnet, err := vpcFirstSubnetName(vpc1)
+			if err != nil {
+				return specs, err
+			}
+			vpc2Subnet, err := vpcFirstSubnetName(vpc2)
+			if err != nil {
+				return specs, err
+			}
 			acl := &gwapi.PeeringACL{
 				Default: gwapi.ACLDefaultDeny,
 				Rules: []gwapi.PeeringACLRule{
@@ -237,8 +245,8 @@ func gatewayACLSubnetScopingTest(ctx context.Context, testCtx *VPCPeeringTestCtx
 						Name: "allow-subnet-fwd", From: vpc1.Name, To: vpc2.Name,
 						Action: gwapi.ACLActionAllow, Scope: gwapi.ACLScopePacket,
 						Match: gwapi.PeeringACLMatch{
-							Source:      []gwapi.PeeringACLMatchEndpoint{{VPCSubnet: "subnet-01"}},
-							Destination: []gwapi.PeeringACLMatchEndpoint{{VPCSubnet: "subnet-01"}},
+							Source:      []gwapi.PeeringACLMatchEndpoint{{VPCSubnet: vpc1Subnet}},
+							Destination: []gwapi.PeeringACLMatchEndpoint{{VPCSubnet: vpc2Subnet}},
 						},
 					},
 					{

--- a/pkg/hhfab/rt_acl_tests.md
+++ b/pkg/hhfab/rt_acl_tests.md
@@ -1,0 +1,86 @@
+# Gateway Peering ACL release tests
+
+Documents the ACL cases in `rt_acl_tests.go`: the probe infrastructure they run
+on, what each case asserts, and the coverage they add. Intended for reviewers
+assessing whether the coverage is correct and sufficient.
+
+## Probe infrastructure
+
+ACL enforcement is protocol/port-specific, so the tests drive the
+`ConnectivityMatrix` (`matrix.go`) keyed by `ProtoPort{Protocol, Port}` rather
+than the legacy default check.
+
+- **Expectations** are stamped on the matrix via `setVPCToVPCProtoVerdict(m,
+  srcVPC, dstVPC, ProtoPort, verdict)` (and the `setACLDirVerdicts` helper, which
+  sets the common icmp + tcp/5201 + udp/5201 triple for one direction).
+- A pair carrying any non-zero `ProtoPort` entry is owned entirely by
+  `runMatrixProtoPortPhase` and skipped by the legacy server-server phase
+  (`HasProtoPortEntries` gate), so every expected verdict — including ICMP — is an
+  explicit entry.
+- Each case is a `natTestSpec` run through `runNATTest`: `BuildSpec` attaches the
+  `PeeringACL` to the gateway peering (via `GwPeeringOptions.ACL`), then
+  `DoSetupPeerings → WaitReady → matrix.Repopulate → Overlay →
+  DoVLABTestConnectivityWithMatrix`.
+
+### Per-protocol probes
+
+| Protocol | Helper | Wire probe | Verdict signal |
+|---|---|---|---|
+| `icmp` | `checkPing` | `ping -c N` | all replies received = allow; zero = deny |
+| `tcp`  | `checkTCPPort` | `nc -zw2 <ip> <port>; echo NCRC=$?` | rc 0 = allow, rc 1 = deny; anything else / no marker / SSH error = surfaced as infra failure |
+| `udp`  | `checkUDPPort` | `iperf3 -u -J -c <ip> -p <port>` | datagrams delivered (loss < 90%) = allow; control-channel error / 0 packets / loss ≥ 99% = deny; unparseable output = surfaced |
+
+Port 5201 is served by the always-on `iperf3 -s` daemon (TCP+UDP). Any other port
+(e.g. the 6xxx range) gets an on-demand `iperf3 -s -p <port>` listener started by
+`startMatrixProtoPortListeners` and torn down at the end of the run.
+
+### Two facts that shape every case
+
+1. **Return path** — a working probe (ping reply, TCP handshake, iperf3 control
+   channel) needs *both* directions permitted. With `packet` (stateless) scope
+   the reply must be matched by its own rule, and because the reply has ports
+   swapped, a destination-port allow needs a matching **source-port** allow for
+   the reverse direction. A single one-way packet rule yields **no** connectivity.
+2. **`flow` scope requires stateful NAT** — the dataplane only keeps
+   flow/conntrack state where masquerade (or port-forward) NAT is present, so a
+   `flow`-scoped rule is only valid on such a peering; there conntrack permits the
+   return automatically. NAT-free cases therefore use explicit `packet` scope.
+
+## Test cases
+
+All cases peer the first two VPCs (`vpc1`, `vpc2`), default action `deny` unless
+noted, and run with `SkipFlags{NoGateway, NoServers}`.
+
+| Test | ACL under test | Expected (fwd = vpc1→vpc2, rev = vpc2→vpc1) |
+|---|---|---|
+| **Default Deny** | `deny` default + one allow rule on an unprobed port | all deny both ways (probed traffic hits the default) |
+| **Deny-Unless-Exposed UDP Carve-Out** | `deny-unless-exposed` default + `deny udp` both dirs | tcp+icmp allow both ways (exposed); udp deny both ways |
+| **Explicit Allow** | `allow` rules both dirs (any proto) | all allow both ways |
+| **Protocol Scoping** | `allow tcp` both dirs | tcp allow; udp+icmp deny (fall to default) |
+| **Packet One-Way** | single `allow` rule, one direction only, `packet` | all deny both ways — reply is dropped, so nothing completes |
+| **Flow Scope Masquerade** | masquerade NAT on vpc1 + `flow allow` vpc1→vpc2 | fwd allow; rev deny (masquerade blocks inbound + default deny) |
+| **Subnet/CIDR Scoping** | allow both dirs; fwd matched by `VPCSubnet`, rev by `CIDR` | all allow both ways |
+| **Port Range Scoping** | allow tcp; fwd dst-port range `6000-6500`, rev src-port range | fwd tcp/6201 allow; tcp/5201 + udp + icmp + all rev = deny |
+| **Precedence Allow-Then-Deny** | `[allow tcp/5201, deny-all]` fwd + src-port return rule | fwd tcp/5201 allow; everything else deny |
+| **Precedence Deny-Then-Allow** | same rules, `deny-all` first | all deny (first match wins) |
+
+## Coverage
+
+| Dimension | Covered by |
+|---|---|
+| Default action `deny` / `deny-unless-exposed` | Default Deny / Deny-Unless-Exposed |
+| Rule action `allow` / `deny` | all allow cases / carve-out + precedence |
+| Protocol `tcp` / `udp` / any | Protocol Scoping, Port Range / UDP Carve-Out / Explicit Allow, Subnet |
+| Selector `VPCSubnet` / `CIDR` | Subnet/CIDR Scoping (both, one per direction) |
+| Ports single / range, dst / src side | Precedence (single dst+src) / Port Range (range dst+src) |
+| Scope `packet` / `flow` | all packet cases / Flow Scope Masquerade |
+| Rule precedence (first-match) | Precedence Allow-Then-Deny + Deny-Then-Allow |
+| Stateless return-path requirement | Packet One-Way (negative) |
+
+### Known limitations / assumptions
+
+- **UDP is verifiable only as "denied while TCP allowed."** The `iperf3 -u` probe
+  opens a TCP control channel on the same port, so "deny TCP + allow UDP on one
+  port" cannot be distinguished from a UDP block — no case relies on it.
+- **ICMP falls to the default action** (it matches neither `tcp` nor `udp`
+  rules). Numeric-protocol matching (e.g. proto `1` for ICMP) is **not** covered.

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -427,7 +427,7 @@ func (testCtx *VPCPeeringTestCtx) setupTest(ctx context.Context, initialSuiteSet
 	opts := testCtx.setupOpts
 	opts.ForceCleanup = initialSuiteSetup
 	// this will also remove all peerings
-	endpoints, err := DoVLABSetupVPCs(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, opts)
+	endpoints, dropped, err := DoVLABSetupVPCs(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, opts)
 	if err != nil {
 		return nil, fmt.Errorf("setting up VPCs: %w", err)
 	}
@@ -440,7 +440,7 @@ func (testCtx *VPCPeeringTestCtx) setupTest(ctx context.Context, initialSuiteSet
 	// sweep. Tests that don't use the matrix simply ignore it;
 	// matrix-driven tests call matrix.Repopulate after applying their
 	// peerings to refresh verdicts.
-	matrix, err := BuildConnectivityMatrix(ctx, testCtx.kube, endpoints)
+	matrix, err := BuildConnectivityMatrix(ctx, testCtx.kube, endpoints, dropped)
 	if err != nil {
 		return nil, fmt.Errorf("building initial connectivity matrix: %w", err)
 	}

--- a/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_multi_subnet_suite.go
@@ -285,11 +285,11 @@ func (testCtx *VPCPeeringTestCtx) pingStaticExternal(ctx context.Context, source
 		sIP = pointer.To(netip.MustParseAddr(sourceIP))
 	}
 
-	if err := checkPing(ctx, 3, nil, sourceNode, StaticExternalNH, ssh, seNhIP, sIP, expected); err != nil {
+	if err := checkPing(ctx, 3, nil, sourceNode, StaticExternalNH, ssh, seNhIP, sIP, Reachability{Reachable: expected}); err != nil {
 		return fmt.Errorf("ping to static external next hop: %w", err)
 	}
 	slog.Debug("Pinging static external dummy interface", "sourceNode", sourceNode, "dummy-interface", StaticExternalDummyIface, "expected", expected)
-	if err := checkPing(ctx, 3, nil, sourceNode, StaticExternalDummyIface, ssh, seDummyIP, sIP, expected); err != nil {
+	if err := checkPing(ctx, 3, nil, sourceNode, StaticExternalDummyIface, ssh, seDummyIP, sIP, Reachability{Reachable: expected}); err != nil {
 		return fmt.Errorf("ping to static external dummy interface: %w", err)
 	}
 

--- a/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
+++ b/pkg/hhfab/rt_multi_vpc_single_subnet_suite.go
@@ -121,6 +121,8 @@ func makeMultiVPCSingleSubnetSuite() *JUnitTestSuite {
 	suite.TestCases = append(suite.TestCases, getNATTestCases()...)
 	// Add external NAT test cases
 	suite.TestCases = append(suite.TestCases, getExternalNATTestCases()...)
+	// Add gateway peering ACL test cases
+	suite.TestCases = append(suite.TestCases, getACLTestCases()...)
 	suite.Tests = len(suite.TestCases)
 
 	return suite

--- a/pkg/hhfab/rt_nat_external_tests.go
+++ b/pkg/hhfab/rt_nat_external_tests.go
@@ -60,7 +60,7 @@ func (testCtx *VPCPeeringTestCtx) pingExternalStability(ctx context.Context, mat
 			return fmt.Errorf("getting ssh config for %s: %w", ep.Server.Name, err)
 		}
 		slog.Debug("Testing NAT external connectivity stability via ping", "server", ep.Server.Name, "target", remoteIP)
-		if pingErr := checkPing(ctx, 10, nil, ep.Server.Name, remoteIP, sshCfg, remoteAddr, nil, true); pingErr != nil {
+		if pingErr := checkPing(ctx, 10, nil, ep.Server.Name, remoteIP, sshCfg, remoteAddr, nil, Reachability{Reachable: true}); pingErr != nil {
 			return fmt.Errorf("NAT external connectivity ping stability check: %w", pingErr)
 		}
 		tested++

--- a/pkg/hhfab/rt_nat_external_tests.go
+++ b/pkg/hhfab/rt_nat_external_tests.go
@@ -86,12 +86,37 @@ func overlayExternalPortForward(matrix *ConnectivityMatrix, vpcName, extName str
 		return fmt.Errorf("destIP must be valid for port-forward overlay") //nolint:goerr113
 	}
 
+	overlayExternalNoEgress(matrix, vpcName, extName)
+
 	return OverlayMatrixNAT(matrix, ServerInVPC(vpcName), ExternalNamed(extName), func(_, _ *Endpoint, nat *TranslatedAddress) error {
 		nat.DestinationIP = destIP
 		nat.DestinationPort = destPort
 
 		return nil
 	})
+}
+
+// overlayExternalNoEgress states the "correctly expects failure" half of the
+// contract above for the externals the peering never mentions. The curl oracle
+// ORs over every external, so leaving them undecided leaves the whole check
+// undecided — and populate cannot decide them itself, since one unevaluable
+// NAT peering aborts its scan over all externals.
+func overlayExternalNoEgress(matrix *ConnectivityMatrix, vpcName, keepExt string) {
+	inVPC := ServerInVPC(vpcName)
+	for _, src := range matrix.AllEndpoints {
+		if !inVPC(src) {
+			continue
+		}
+		for _, dst := range matrix.AllEndpoints {
+			if dst.External == nil || dst.External.ExternalName == keepExt {
+				continue
+			}
+			matrix.Add(ConnectivityExpectation{
+				Pair:    EndpointPair{Source: src, Destination: dst},
+				Verdict: VerdictDeny,
+			})
+		}
+	}
 }
 
 // Test gateway external peering with no NAT (baseline)

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -257,15 +257,30 @@ func (testCtx *VPCPeeringTestCtx) rebindMatrixServerEndpoint(ctx context.Context
 	return nil
 }
 
-func vpcFirstSubnetCIDR(vpc *vpcapi.VPC) (string, error) {
+func vpcFirstSubnet(vpc *vpcapi.VPC) (string, *vpcapi.VPCSubnet, error) {
 	if len(vpc.Spec.Subnets) != 1 {
-		return "", fmt.Errorf("VPC %s has %d subnets, NAT test requires exactly one", vpc.Name, len(vpc.Spec.Subnets)) //nolint:goerr113
+		return "", nil, fmt.Errorf("VPC %s has %d subnets, NAT test requires exactly one", vpc.Name, len(vpc.Spec.Subnets)) //nolint:goerr113
 	}
-	for _, subnet := range vpc.Spec.Subnets {
-		return subnet.Subnet, nil
+	for name, subnet := range vpc.Spec.Subnets {
+		return name, subnet, nil
 	}
 
-	return "", fmt.Errorf("VPC %s has empty subnet map", vpc.Name) //nolint:goerr113
+	return "", nil, fmt.Errorf("VPC %s has empty subnet map", vpc.Name) //nolint:goerr113
+}
+
+func vpcFirstSubnetName(vpc *vpcapi.VPC) (string, error) {
+	name, _, err := vpcFirstSubnet(vpc)
+
+	return name, err
+}
+
+func vpcFirstSubnetCIDR(vpc *vpcapi.VPC) (string, error) {
+	_, subnet, err := vpcFirstSubnet(vpc)
+	if err != nil {
+		return "", err
+	}
+
+	return subnet.Subnet, nil
 }
 
 // Test gateway peering with masquerade source NAT (only VPC1 has masquerade NAT configured)

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -20,16 +20,12 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// peeringSpecs bundles the three peering kinds a NAT test may need to
-// install. Returned by natTestSpec.BuildSpec.
 type peeringSpecs struct {
 	VPC      map[string]*vpcapi.VPCPeeringSpec
 	External map[string]*vpcapi.ExternalPeeringSpec
 	Gateway  map[string]*gwapi.PeeringSpec
 }
 
-// emptyPeeringSpecs returns an initialized peeringSpecs that BuildSpec
-// callbacks can populate without manually constructing each map.
 func emptyPeeringSpecs() peeringSpecs {
 	return peeringSpecs{
 		VPC:      make(map[string]*vpcapi.VPCPeeringSpec),
@@ -41,8 +37,7 @@ func emptyPeeringSpecs() peeringSpecs {
 // natTestSpec describes a VPC-to-VPC NAT test that follows the standard
 // driver shape: pick the first two VPCs (sorted alphabetically), build
 // peerings, refresh the matrix, optionally overlay NAT info, then run the
-// matrix-driven connectivity test. Tests that need a server move (overlap)
-// or external CRD annotation lookup hand-roll instead.
+// matrix-driven connectivity test.
 type natTestSpec struct {
 	Name      string
 	BuildSpec func(vpc1, vpc2 *vpcapi.VPC) (peeringSpecs, error)
@@ -50,8 +45,6 @@ type natTestSpec struct {
 }
 
 // runNATTest executes the standard NAT-test sequence defined by spec.
-// Returns (skip=true) when fewer than two VPCs are available so the suite
-// can mark the case as skipped.
 func (testCtx *VPCPeeringTestCtx) runNATTest(ctx context.Context, matrix *ConnectivityMatrix, spec natTestSpec) (bool, []RevertFunc, error) {
 	vpcs := &vpcapi.VPCList{}
 	if err := testCtx.kube.List(ctx, vpcs); err != nil {
@@ -159,8 +152,7 @@ func overlayVPCToVPCStaticDNAT(matrix *ConnectivityMatrix, srcVPCName, dstVPCNam
 
 // overlayVPCToVPCPortForwardDNAT marks every (server-in-srcVPCName →
 // server-in-dstVPCName) entry with a port-forward DNAT to the destination's
-// NAT IP on destPort. The matrix tester then runs iperf3 against
-// (NAT IP, destPort) without ping for those pairs.
+// NAT IP on destPort.
 func overlayVPCToVPCPortForwardDNAT(matrix *ConnectivityMatrix, srcVPCName, dstVPCName, dstSubnetCIDR, dstNATPoolCIDR string, destPort uint16) error {
 	if destPort == 0 {
 		return fmt.Errorf("destPort must be non-zero for port-forward overlay") //nolint:goerr113
@@ -191,9 +183,6 @@ func overlayVPCToVPCPortForwardDNAT(matrix *ConnectivityMatrix, srcVPCName, dstV
 	})
 }
 
-// overrideVPCToVPCVerdict forces every (server-in-srcVPCName →
-// server-in-dstVPCName) entry to the given verdict.
-// Used to mark direction-asymmetric paths.
 func overrideVPCToVPCVerdict(matrix *ConnectivityMatrix, srcVPCName, dstVPCName string, verdict ConnectivityVerdict) {
 	srcPred := ServerInVPC(srcVPCName)
 	dstPred := ServerInVPC(dstVPCName)
@@ -218,12 +207,7 @@ func overrideVPCToVPCVerdict(matrix *ConnectivityMatrix, srcVPCName, dstVPCName 
 }
 
 // rebindMatrixServerEndpoint refreshes the matrix's endpoint(s) for
-// serverName to reflect the current cluster state. Used after a runtime
-// attachment change (e.g., the overlap NAT test moves one server to a
-// freshly created overlap VPC) so VPC-keyed overlays match the moved
-// server. The (vpc, subnet) the server now belongs to is read from the
-// VPCAttachment CRDs by CollectServerEndpoints — no need for the caller
-// to restate it. Multi-IP servers produce multiple endpoints.
+// serverName to reflect the current cluster state.
 func (testCtx *VPCPeeringTestCtx) rebindMatrixServerEndpoint(ctx context.Context, matrix *ConnectivityMatrix, serverName string) error {
 	ssh := func(name string) (*sshutil.Config, error) {
 		return testCtx.getSSH(ctx, name)
@@ -241,9 +225,7 @@ func (testCtx *VPCPeeringTestCtx) rebindMatrixServerEndpoint(ctx context.Context
 	return nil
 }
 
-// vpcFirstSubnetCIDR returns the (only) subnet CIDR for a VPC used in the
-// NAT tests. The NAT overlays require exactly one subnet per VPC because
-// the static-NAT offset algorithm is unambiguous only then.
+// vpcFirstSubnetCIDR returns the (only) subnet CIDR for a VPC used in the NAT tests.
 func vpcFirstSubnetCIDR(vpc *vpcapi.VPC) (string, error) {
 	if len(vpc.Spec.Subnets) != 1 {
 		return "", fmt.Errorf("VPC %s has %d subnets, NAT test requires exactly one", vpc.Name, len(vpc.Spec.Subnets)) //nolint:goerr113

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -257,7 +257,6 @@ func (testCtx *VPCPeeringTestCtx) rebindMatrixServerEndpoint(ctx context.Context
 	return nil
 }
 
-// vpcFirstSubnetCIDR returns the (only) subnet CIDR for a VPC used in the NAT tests.
 func vpcFirstSubnetCIDR(vpc *vpcapi.VPC) (string, error) {
 	if len(vpc.Spec.Subnets) != 1 {
 		return "", fmt.Errorf("VPC %s has %d subnets, NAT test requires exactly one", vpc.Name, len(vpc.Spec.Subnets)) //nolint:goerr113

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -209,7 +209,7 @@ func overrideVPCToVPCVerdict(matrix *ConnectivityMatrix, srcVPCName, dstVPCName 
 			matrix.Add(ConnectivityExpectation{
 				Pair:    EndpointPair{Source: src, Destination: dst},
 				Verdict: verdict,
-				Reason:  ReachabilityReasonGatewayPeering,
+				Reason:  overlayReason(existing.Reason),
 				Peering: existing.Peering,
 				NAT:     existing.NAT,
 			})
@@ -228,7 +228,7 @@ func (testCtx *VPCPeeringTestCtx) rebindMatrixServerEndpoint(ctx context.Context
 	ssh := func(name string) (*sshutil.Config, error) {
 		return testCtx.getSSH(ctx, name)
 	}
-	newEPs, err := CollectServerEndpoints(ctx, testCtx.kube, ssh, []string{serverName})
+	newEPs, dropped, err := CollectServerEndpoints(ctx, testCtx.kube, ssh, []string{serverName})
 	if err != nil {
 		return fmt.Errorf("collecting endpoints for %s: %w", serverName, err)
 	}
@@ -236,6 +236,7 @@ func (testCtx *VPCPeeringTestCtx) rebindMatrixServerEndpoint(ctx context.Context
 		return fmt.Errorf("no endpoints discovered for server %s after rebind", serverName) //nolint:goerr113
 	}
 	matrix.ReplaceServerEndpoints(serverName, newEPs)
+	matrix.ReplaceServerDrops(serverName, dropped)
 
 	return nil
 }

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -206,6 +206,38 @@ func overrideVPCToVPCVerdict(matrix *ConnectivityMatrix, srcVPCName, dstVPCName 
 	}
 }
 
+// setVPCToVPCProtoVerdict adds a protocol/port-scoped expectation on every
+// (server-in-srcVPCName → server-in-dstVPCName) pair. Unlike
+// overrideVPCToVPCVerdict (which writes the default ProtoPort{} entry), this
+// keys the entry by pp, so the matrix-driven runner exercises it with a
+// protocol-specific probe (icmp/tcp/udp) in runMatrixProtoPortPhase. Multiple
+// calls with different pp accumulate on the same pair, letting a single peering
+// express e.g. TCP allow + UDP deny. pp must be non-zero. The pair's existing
+// default-entry Peering is preserved for diagnostics.
+func setVPCToVPCProtoVerdict(matrix *ConnectivityMatrix, srcVPCName, dstVPCName string, pp ProtoPort, verdict ConnectivityVerdict) {
+	srcPred := ServerInVPC(srcVPCName)
+	dstPred := ServerInVPC(dstVPCName)
+	for _, src := range matrix.AllEndpoints {
+		if !srcPred(src) {
+			continue
+		}
+		for _, dst := range matrix.AllEndpoints {
+			if !dstPred(dst) {
+				continue
+			}
+			existing := matrix.Lookup(src, dst, ProtoPort{})
+			matrix.Add(ConnectivityExpectation{
+				Pair:      EndpointPair{Source: src, Destination: dst},
+				Verdict:   verdict,
+				Reason:    ReachabilityReasonGatewayPeering,
+				Peering:   existing.Peering,
+				NAT:       existing.NAT,
+				ProtoPort: pp,
+			})
+		}
+	}
+}
+
 // rebindMatrixServerEndpoint refreshes the matrix's endpoint(s) for
 // serverName to reflect the current cluster state.
 func (testCtx *VPCPeeringTestCtx) rebindMatrixServerEndpoint(ctx context.Context, matrix *ConnectivityMatrix, serverName string) error {

--- a/pkg/hhfab/rt_on_ready_suite.go
+++ b/pkg/hhfab/rt_on_ready_suite.go
@@ -446,7 +446,15 @@ func newOnReadyTest(ctx context.Context, testCtx *VPCPeeringTestCtx, _ *Connecti
 		if err != nil {
 			return false, nil, fmt.Errorf("parsing VPC B subnet: %w", err)
 		}
-		hostBGPCmd, err := getServerHostBGPCmd(&hostBGPServer.conn, vlan, subPrefix, 1)
+		hostBGPCmd, err := getServerHostBGPCmd([]HostBGPParams{
+			{
+				VPCLabel:     vpcBName,
+				Connections:  []*wiringapi.Connection{&hostBGPServer.conn},
+				VLAN:         vlan,
+				Subnet:       subPrefix,
+				ServerOffset: 1,
+			},
+		})
 		if err != nil {
 			return false, nil, fmt.Errorf("hostBGP cmd for %s: %w", hostBGPServer.name, err)
 		}

--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -274,7 +274,7 @@ outer:
 		// wait a bit to make sure that the fabric has converged; can't rely on agents as we disabled them
 		slog.Debug("Waiting 30 seconds for fabric to converge")
 		time.Sleep(30 * time.Second)
-		if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		if err := DoVLABTestConnectivityWithMatrix(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts, matrix); err != nil {
 			returnErr = err
 		}
 	}
@@ -456,6 +456,16 @@ func gatewayFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix
 		return nil
 	})
 
+	// The suite-level matrix predates this peering; refresh it so the
+	// connectivity checks below (during failover, and in the reverts while
+	// the peering is still up) assert the peered state. Reverts run in
+	// reverse order, so the teardown registered above runs after them.
+	// Repopulating only once the teardown is registered keeps a failure
+	// here from leaking the peering into the next test.
+	if err := matrix.Repopulate(ctx, testCtx.kube); err != nil {
+		return false, reverts, fmt.Errorf("refreshing matrix after gateway peering: %w", err)
+	}
+
 	// HACK: test connectivity after restoring spines as part of the reverts
 	reverts = append(reverts, func(ctx context.Context) error {
 		slog.Debug("Waiting for agents to converge...")
@@ -496,7 +506,7 @@ func gatewayFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix
 		}
 
 		slog.Debug("Testing connectivity after re-enabling spines and agents")
-		if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		if err := DoVLABTestConnectivityWithMatrix(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts, matrix); err != nil {
 			return fmt.Errorf("connectivity test after re-enabling spines and agents: %w", err)
 		}
 
@@ -625,7 +635,7 @@ func gatewayFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix
 
 		// test connectivity during failover
 		slog.Debug("Testing connectivity during failover")
-		if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		if err := DoVLABTestConnectivityWithMatrix(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts, matrix); err != nil {
 			returnErr = fmt.Errorf("connectivity test during failover: %w", err)
 		}
 	}
@@ -754,7 +764,7 @@ func meshFailoverTest(ctx context.Context, testCtx *VPCPeeringTestCtx, matrix *C
 		// wait a bit to make sure that the fabric has converged; can't rely on agents as we disabled them
 		slog.Debug("Waiting 30 seconds for fabric to converge")
 		time.Sleep(30 * time.Second)
-		if err := DoVLABTestConnectivity(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts); err != nil {
+		if err := DoVLABTestConnectivityWithMatrix(ctx, testCtx.vlabCfg.WorkDir, testCtx.vlabCfg.CacheDir, testCtx.tcOpts, matrix); err != nil {
 			return false, reverts, err
 		}
 		someLeafTested = true

--- a/pkg/hhfab/rt_utils.go
+++ b/pkg/hhfab/rt_utils.go
@@ -769,6 +769,8 @@ type GwPeeringOptions struct {
 	VPC1PortForwardRules []gwapi.PeeringNATPortForwardEntry
 	// VPC2PortForwardRules specifies port-forwarding rules for VPC2
 	VPC2PortForwardRules []gwapi.PeeringNATPortForwardEntry
+	// ACL is an optional peering-scoped ACL applied to the gateway peering.
+	ACL *gwapi.PeeringACL
 }
 
 // GwExtPeeringOptions contains optional parameters for gateway external peering configuration
@@ -914,6 +916,7 @@ func appendGwPeeringSpec(gwPeerings map[string]*gwapi.PeeringSpec, vpc1, vpc2 *v
 				Expose: vpc2Exposes,
 			},
 		},
+		ACL: opts.ACL,
 	}
 
 	return nil

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -778,6 +778,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		}
 
 		conns := &wiringapi.ConnectionList{}
+		multihomed := false
 		if err := kube.List(ctx, conns, wiringapi.MatchingLabelsForListLabelServer(server.Name)); err != nil {
 			return nil, nil, fmt.Errorf("listing connections for server %q: %w", server.Name, err)
 		}
@@ -785,16 +786,25 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 			return nil, nil, fmt.Errorf("no connections for server %q", server.Name)
 		}
 		if len(conns.Items) > 1 {
-			return nil, nil, fmt.Errorf("multiple connections for server %q", server.Name)
+			for _, c := range conns.Items {
+				if c.Spec.Unbundled == nil {
+					return nil, nil, fmt.Errorf("multiple connections for server %q of which some are not unbundled", server.Name)
+				}
+			}
+			multihomed = true
 		}
 		conn := conns.Items[0]
 
 		vpcName := fmt.Sprintf("vpc-%02d", vpcID+1)
 		subnetName := fmt.Sprintf("subnet-%02d", subnetInVPC+1)
-		hostBGP := opts.HostBGPSubnet && !hostBGPDoneForVPC && conn.Spec.Unbundled != nil
+		hostBGP := multihomed || (opts.HostBGPSubnet && !hostBGPDoneForVPC && conn.Spec.Unbundled != nil)
 		if hostBGP {
 			hostBGPDoneForVPC = true
 		}
+		// hostBGP and P2P are mutually exclusive per server: a hostBGP host uses
+		// its real subnet and a /32 VIP, so the P2P /31 semantics must not apply
+		// (relevant when P2P is force-enabled on an all-Cumulus fabric).
+		useP2P := opts.P2P && !hostBGP
 
 		var vpc *vpcapi.VPC
 		if len(vpcs) > 0 && vpcs[len(vpcs)-1].Name == vpcName {
@@ -847,7 +857,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		}
 
 		p2p := netip.Prefix{}
-		if opts.P2P {
+		if useP2P {
 			subnet, err := netip.ParsePrefix(vpc.Spec.Subnets[subnetName].Subnet)
 			if err != nil {
 				return nil, nil, fmt.Errorf("parsing vpc subnet %s/%s %q: %w", vpcName, subnetName, vpc.Spec.Subnets[subnetName].Subnet, err)
@@ -867,37 +877,47 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 			return nil, nil, fmt.Errorf("parsing vpc subnet %s/%s %q: %w", vpcName, subnetName, vpc.Spec.Subnets[subnetName].Subnet, err)
 		}
 		expectedSubnets[server.Name] = expectedSubnet
-		if opts.P2P {
+		if useP2P {
 			expectedSubnets[server.Name] = p2p
 		}
 		if hostBGP {
 			hostBGPServers[server.Name] = true
 		}
 
-		attachName := fmt.Sprintf("%s--%s--%s", conn.Name, vpcName, subnetName)
-		attachNames[attachName] = true
-		attachAnns := map[string]string{}
-		if opts.P2P {
-			attachAnns[vpcapi.AnnotationVPCAttachmentP2PLink] = p2p.String()
+		// Connections to attach: the single connection normally, all of them for
+		// a multihomed server (which shares one hostBGP subnet across every link).
+		attachConns := []*wiringapi.Connection{&conn}
+		if multihomed {
+			attachConns = nil
+			for i := range conns.Items {
+				attachConns = append(attachConns, &conns.Items[i])
+			}
 		}
 
-		attach := &vpcapi.VPCAttachment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        attachName,
-				Namespace:   metav1.NamespaceDefault,
-				Annotations: attachAnns,
-			},
-			Spec: vpcapi.VPCAttachmentSpec{
-				Connection: conn.Name,
-				Subnet:     fmt.Sprintf("%s/%s", vpcName, subnetName),
-			},
-		}
-		attaches = append(attaches, attach)
+		for _, ac := range attachConns {
+			attachName := fmt.Sprintf("%s--%s--%s", ac.Name, vpcName, subnetName)
+			attachNames[attachName] = true
+			attachAnns := map[string]string{}
+			if useP2P {
+				attachAnns[vpcapi.AnnotationVPCAttachmentP2PLink] = p2p.String()
+			}
 
-		vlan := uint16(0)
-		if !attach.Spec.NativeVLAN {
-			vlan = vpc.Spec.Subnets[subnetName].VLAN
+			attaches = append(attaches, &vpcapi.VPCAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        attachName,
+					Namespace:   metav1.NamespaceDefault,
+					Annotations: attachAnns,
+				},
+				Spec: vpcapi.VPCAttachmentSpec{
+					Connection: ac.Name,
+					Subnet:     fmt.Sprintf("%s/%s", vpcName, subnetName),
+				},
+			})
 		}
+
+		// NativeVLAN is never set on the attachments we build above, so the VLAN
+		// is always the subnet's VLAN.
+		vlan := vpc.Spec.Subnets[subnetName].VLAN
 
 		var confCmd string
 		var confErr error
@@ -906,13 +926,13 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 			confCmd, confErr = getServerHostBGPCmd([]HostBGPParams{
 				{
 					VPCLabel:     vpcName,
-					Connections:  []*wiringapi.Connection{&conn},
+					Connections:  attachConns,
 					VLAN:         vlan,
 					Subnet:       expectedSubnet,
 					ServerOffset: serverInSubnet,
 				},
 			})
-		} else if opts.P2P {
+		} else if useP2P {
 			confCmd, confErr = GetServerNetconfCmd(&conn, ServerNetconfOpts{
 				P2P: p2p.String(),
 			})

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -572,42 +572,42 @@ func ResolveDefaultServerMTU(ctx context.Context, kube kclient.Client, opts *Set
 // modes are not included in the returned list. Callers that want to drive
 // matrix-based connectivity tests pass the result to BuildConnectivityMatrix;
 // CLI and vlabrunner callers discard it.
-func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) ([]*Endpoint, error) {
+func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) ([]*Endpoint, []DroppedEndpoint, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
 	start := time.Now()
 
 	if opts.ServersPerSubnet <= 0 {
-		return nil, fmt.Errorf("servers per subnet must be positive")
+		return nil, nil, fmt.Errorf("servers per subnet must be positive")
 	}
 	if opts.SubnetsPerVPC <= 0 {
-		return nil, fmt.Errorf("subnets per VPC must be positive")
+		return nil, nil, fmt.Errorf("subnets per VPC must be positive")
 	}
 	if !slices.Contains(HashPolicies, opts.HashPolicy) {
-		return nil, fmt.Errorf("invalid hash policy %q, must be one of %v", opts.HashPolicy, HashPolicies)
+		return nil, nil, fmt.Errorf("invalid hash policy %q, must be one of %v", opts.HashPolicy, HashPolicies)
 	} else if opts.HashPolicy != HashPolicyL2 && opts.HashPolicy != HashPolicyL2And3 {
 		slog.Warn("The selected hash policy is not fully 802.3ad compliant, use layer2 or layer2+3 for full compliance", "hashPolicy", opts.HashPolicy)
 	}
 	if !slices.Contains(vpcapi.VPCModes, opts.VPCMode) {
-		return nil, fmt.Errorf("invalid VPC mode %q, must be one of %v", opts.VPCMode, vpcapi.VPCModes)
+		return nil, nil, fmt.Errorf("invalid VPC mode %q, must be one of %v", opts.VPCMode, vpcapi.VPCModes)
 	}
 
 	cacheCancel, kube, err := getKubeClientWithCache(ctx, c.WorkDir)
 	if err != nil {
-		return nil, fmt.Errorf("creating kube client: %w", err)
+		return nil, nil, fmt.Errorf("creating kube client: %w", err)
 	}
 	defer cacheCancel()
 
 	switchList := wiringapi.SwitchList{}
 	if err := kube.List(ctx, &switchList); err != nil {
-		return nil, fmt.Errorf("listing switches: %w", err)
+		return nil, nil, fmt.Errorf("listing switches: %w", err)
 	}
 	allCumulus := true
 	for _, sw := range switchList.Items {
 		sp := &wiringapi.SwitchProfile{}
 		if err := kube.Get(ctx, kclient.ObjectKey{Name: sw.Spec.Profile, Namespace: kmetav1.NamespaceDefault}, sp); err != nil {
-			return nil, fmt.Errorf("getting switch profile %q: %w", sw.Spec.Profile, err)
+			return nil, nil, fmt.Errorf("getting switch profile %q: %w", sw.Spec.Profile, err)
 		}
 
 		if !slices.Contains(meta.NOSTypesCumulus, sp.Spec.NOSType) {
@@ -617,7 +617,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		}
 	}
 	if opts.P2P && !allCumulus {
-		return nil, fmt.Errorf("P2P mode requires all switches to be cumulus")
+		return nil, nil, fmt.Errorf("P2P mode requires all switches to be cumulus")
 	}
 	if !opts.P2P && allCumulus {
 		opts.P2P = true
@@ -625,7 +625,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	}
 
 	if err := ResolveDefaultServerMTU(ctx, kube, &opts); err != nil {
-		return nil, fmt.Errorf("resolving default server MTU: %w", err)
+		return nil, nil, fmt.Errorf("resolving default server MTU: %w", err)
 	}
 
 	{
@@ -648,7 +648,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	sshConfigs := map[string]*sshutil.Config{}
 	for _, vm := range vlab.VMs {
 		if sshCfg, err := c.SSHVM(ctx, vlab, vm); err != nil {
-			return nil, fmt.Errorf("getting ssh config for vm %q: %w", vm.Name, err)
+			return nil, nil, fmt.Errorf("getting ssh config for vm %q: %w", vm.Name, err)
 		} else {
 			sshConfigs[vm.Name] = sshCfg
 		}
@@ -663,32 +663,32 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		}
 
 		if err := client.IgnoreNotFound(kube.DeleteAllOf(ctx, &vpcapi.VPCPeering{}, &delAllOpts)); err != nil {
-			return nil, fmt.Errorf("cleaning up vpc peerings: %w", err)
+			return nil, nil, fmt.Errorf("cleaning up vpc peerings: %w", err)
 		}
 		if err := client.IgnoreNotFound(kube.DeleteAllOf(ctx, &vpcapi.ExternalPeering{}, &delAllOpts)); err != nil {
-			return nil, fmt.Errorf("cleaning up external peerings: %w", err)
+			return nil, nil, fmt.Errorf("cleaning up external peerings: %w", err)
 		}
 		if c.Fab.Spec.Config.Gateway.Enable {
 			if err := client.IgnoreNotFound(kube.DeleteAllOf(ctx, &gwapi.GatewayPeering{}, &delAllOpts)); err != nil {
-				return nil, fmt.Errorf("cleaning up gateway peerings: %w", err)
+				return nil, nil, fmt.Errorf("cleaning up gateway peerings: %w", err)
 			}
 		}
 	}
 
 	servers := &wiringapi.ServerList{}
 	if err := kube.List(ctx, servers); err != nil {
-		return nil, fmt.Errorf("listing servers: %w", err)
+		return nil, nil, fmt.Errorf("listing servers: %w", err)
 	}
 
 	serverIDs := map[string]uint64{}
 	for _, server := range servers.Items {
 		if !strings.HasPrefix(server.Name, ServerNamePrefix) {
-			return nil, fmt.Errorf("unexpected server name %q, should be %s<number>", server.Name, ServerNamePrefix)
+			return nil, nil, fmt.Errorf("unexpected server name %q, should be %s<number>", server.Name, ServerNamePrefix)
 		}
 
 		serverID, err := strconv.ParseUint(server.Name[len(ServerNamePrefix):], 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("parsing server id: %w", err)
+			return nil, nil, fmt.Errorf("parsing server id: %w", err)
 		}
 
 		serverIDs[server.Name] = serverID
@@ -700,20 +700,20 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 	vlanNS := &wiringapi.VLANNamespace{}
 	if err := kube.Get(ctx, client.ObjectKey{Name: opts.VLANNamespace, Namespace: metav1.NamespaceDefault}, vlanNS); err != nil {
-		return nil, fmt.Errorf("getting VLAN namespace %s: %w", opts.VLANNamespace, err)
+		return nil, nil, fmt.Errorf("getting VLAN namespace %s: %w", opts.VLANNamespace, err)
 	}
 	nextVLAN, stopVLAN := iter.Pull(VLANsFrom(vlanNS.Spec.Ranges...))
 	defer stopVLAN()
 
 	ipNS := &vpcapi.IPv4Namespace{}
 	if err := kube.Get(ctx, client.ObjectKey{Name: opts.IPv4Namespace, Namespace: metav1.NamespaceDefault}, ipNS); err != nil {
-		return nil, fmt.Errorf("getting IPv4 namespace %s: %w", opts.IPv4Namespace, err)
+		return nil, nil, fmt.Errorf("getting IPv4 namespace %s: %w", opts.IPv4Namespace, err)
 	}
 	prefixes := []netip.Prefix{}
 	for _, prefix := range ipNS.Spec.Subnets {
 		prefix, err := netip.ParsePrefix(prefix)
 		if err != nil {
-			return nil, fmt.Errorf("parsing IPv4 namespace %s prefix %q: %w", opts.IPv4Namespace, prefix, err)
+			return nil, nil, fmt.Errorf("parsing IPv4 namespace %s prefix %q: %w", opts.IPv4Namespace, prefix, err)
 		}
 		prefixes = append(prefixes, prefix)
 	}
@@ -748,7 +748,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	for _, server := range servers.Items {
 		if opts.VPCMode != vpcapi.VPCModeL2VNI {
 			if sa, err := getServerAttachState(ctx, kube, &server, false); err != nil {
-				return nil, fmt.Errorf("checking server %q attachment state: %w", server.Name, err)
+				return nil, nil, fmt.Errorf("checking server %q attachment state: %w", server.Name, err)
 			} else if sa.ESLAG {
 				eslagServers[server.Name] = true
 				slog.Warn("Skipping ESLAG-connected server", "server", server.Name)
@@ -769,19 +769,19 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 		conns := &wiringapi.ConnectionList{}
 		if err := kube.List(ctx, conns, wiringapi.MatchingLabelsForListLabelServer(server.Name)); err != nil {
-			return nil, fmt.Errorf("listing connections for server %q: %w", server.Name, err)
+			return nil, nil, fmt.Errorf("listing connections for server %q: %w", server.Name, err)
 		}
 		if len(conns.Items) == 0 {
-			return nil, fmt.Errorf("no connections for server %q", server.Name)
+			return nil, nil, fmt.Errorf("no connections for server %q", server.Name)
 		}
 		if len(conns.Items) > 1 {
-			return nil, fmt.Errorf("multiple connections for server %q", server.Name)
+			return nil, nil, fmt.Errorf("multiple connections for server %q", server.Name)
 		}
 		conn := conns.Items[0]
 
 		switches, _, _, _, err := conn.Spec.Endpoints()
 		if err != nil {
-			return nil, fmt.Errorf("getting connection %q endpoints: %w", conn.Name, err)
+			return nil, nil, fmt.Errorf("getting connection %q endpoints: %w", conn.Name, err)
 		}
 		isMclag := false
 		for _, sw := range switches {
@@ -816,7 +816,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		if vpc.Spec.Subnets[subnetName] == nil {
 			subnet, ok := nextPrefix()
 			if !ok {
-				return nil, fmt.Errorf("no more subnets available")
+				return nil, nil, fmt.Errorf("no more subnets available")
 			}
 
 			var dhcpOpts *vpcapi.VPCDHCPOptions
@@ -830,7 +830,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 			vlan, ok := nextVLAN()
 			if !ok {
-				return nil, fmt.Errorf("no more vlans available")
+				return nil, nil, fmt.Errorf("no more vlans available")
 			}
 			dhcp := vpcapi.VPCDHCP{}
 			if !hostBGP && !opts.P2P {
@@ -850,7 +850,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		if opts.P2P {
 			subnet, err := netip.ParsePrefix(vpc.Spec.Subnets[subnetName].Subnet)
 			if err != nil {
-				return nil, fmt.Errorf("parsing vpc subnet %s/%s %q: %w", vpcName, subnetName, vpc.Spec.Subnets[subnetName].Subnet, err)
+				return nil, nil, fmt.Errorf("parsing vpc subnet %s/%s %q: %w", vpcName, subnetName, vpc.Spec.Subnets[subnetName].Subnet, err)
 			}
 
 			b := subnet.Masked().Addr().As4()
@@ -864,7 +864,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 		expectedSubnet, err := netip.ParsePrefix(vpc.Spec.Subnets[subnetName].Subnet)
 		if err != nil {
-			return nil, fmt.Errorf("parsing vpc subnet %s/%s %q: %w", vpcName, subnetName, vpc.Spec.Subnets[subnetName].Subnet, err)
+			return nil, nil, fmt.Errorf("parsing vpc subnet %s/%s %q: %w", vpcName, subnetName, vpc.Spec.Subnets[subnetName].Subnet, err)
 		}
 		expectedSubnets[server.Name] = expectedSubnet
 		if opts.P2P {
@@ -916,7 +916,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 			})
 		}
 		if confErr != nil {
-			return nil, fmt.Errorf("getting conf cmd for server %q: %w", server.Name, confErr)
+			return nil, nil, fmt.Errorf("getting conf cmd for server %q: %w", server.Name, confErr)
 		}
 
 		netconfs[server.Name] = confCmd
@@ -924,7 +924,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 	if opts.WaitSwitchesReady {
 		if err := WaitReady(ctx, kube, WaitReadyOpts{AppliedFor: 15 * time.Second, Timeout: 10 * time.Minute}); err != nil {
-			return nil, fmt.Errorf("waiting for ready: %w", err)
+			return nil, nil, fmt.Errorf("waiting for ready: %w", err)
 		}
 	}
 
@@ -934,12 +934,12 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 	existingAttaches := &vpcapi.VPCAttachmentList{}
 	if err := kube.List(ctx, existingAttaches); err != nil {
-		return nil, fmt.Errorf("listing existing attachments: %w", err)
+		return nil, nil, fmt.Errorf("listing existing attachments: %w", err)
 	}
 	for _, attach := range existingAttaches.Items {
 		if opts.ForceCleanup || !attachNames[attach.Name] {
 			if err := kube.Delete(ctx, &attach); err != nil {
-				return nil, fmt.Errorf("deleting attachment %q: %w", attach.Name, err)
+				return nil, nil, fmt.Errorf("deleting attachment %q: %w", attach.Name, err)
 			}
 			slog.Info("Deleted", "attachment", attach.Name)
 			changed = true
@@ -948,13 +948,13 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 	existingVPCs := &vpcapi.VPCList{}
 	if err := kube.List(ctx, existingVPCs); err != nil {
-		return nil, fmt.Errorf("listing existing VPCs: %w", err)
+		return nil, nil, fmt.Errorf("listing existing VPCs: %w", err)
 	}
 	deletedVPCs := false
 	for _, vpc := range existingVPCs.Items {
 		if opts.ForceCleanup || !vpcNames[vpc.Name] {
 			if err := kube.Delete(ctx, &vpc); err != nil {
-				return nil, fmt.Errorf("deleting VPC %q: %w", vpc.Name, err)
+				return nil, nil, fmt.Errorf("deleting VPC %q: %w", vpc.Name, err)
 			}
 			slog.Info("Deleted", "vpc", vpc.Name)
 			changed = true
@@ -971,7 +971,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 
 		if deletedVPCs && opts.WaitSwitchesReady {
 			if err := WaitReady(ctx, kube, WaitReadyOpts{AppliedFor: 15 * time.Second, Timeout: 10 * time.Minute}); err != nil {
-				return nil, fmt.Errorf("waiting for switches after VPC deletion: %w", err)
+				return nil, nil, fmt.Errorf("waiting for switches after VPC deletion: %w", err)
 			}
 		}
 	}
@@ -979,7 +979,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	for _, vpc := range vpcs {
 		iterChanged, err := CreateOrUpdateVpc(ctx, kube, vpc)
 		if err != nil {
-			return nil, fmt.Errorf("creating or updating vpc %q: %w", vpc.Name, err)
+			return nil, nil, fmt.Errorf("creating or updating vpc %q: %w", vpc.Name, err)
 		}
 		changed = changed || iterChanged
 	}
@@ -994,7 +994,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 			return nil
 		})
 		if err != nil {
-			return nil, fmt.Errorf("creating or updating vpc attachment %q: %w", attach.Name, err)
+			return nil, nil, fmt.Errorf("creating or updating vpc attachment %q: %w", attach.Name, err)
 		}
 
 		switch res {
@@ -1011,12 +1011,12 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		// TODO remove it when we can actually know that changes to VPC/VPCAttachment are reflected in agents
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("sleeping before waiting for ready: %w", ctx.Err())
+			return nil, nil, fmt.Errorf("sleeping before waiting for ready: %w", ctx.Err())
 		case <-time.After(15 * time.Second):
 		}
 
 		if err := WaitReady(ctx, kube, WaitReadyOpts{AppliedFor: 15 * time.Second, Timeout: 10 * time.Minute}); err != nil {
-			return nil, fmt.Errorf("waiting for ready: %w", err)
+			return nil, nil, fmt.Errorf("waiting for ready: %w", err)
 		}
 	}
 
@@ -1123,17 +1123,17 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, fmt.Errorf("configuring servers: %w", err)
+		return nil, nil, fmt.Errorf("configuring servers: %w", err)
 	}
 
 	slog.Info("All servers configured and verified", "took", time.Since(start))
 
-	endpoints, err := CollectServerEndpoints(ctx, kube, SSHResolverFromMap(sshConfigs), nil)
+	endpoints, dropped, err := CollectServerEndpoints(ctx, kube, SSHResolverFromMap(sshConfigs), nil)
 	if err != nil {
-		return nil, fmt.Errorf("collecting server endpoints: %w", err)
+		return nil, nil, fmt.Errorf("collecting server endpoints: %w", err)
 	}
 
-	return endpoints, nil
+	return endpoints, dropped, nil
 }
 
 type SetupPeeringsOpts struct {
@@ -1852,6 +1852,12 @@ func buildExternalEndpoints(externals []vpcapi.External) []*Endpoint {
 // pools) and external-originated traffic are NOT modeled — callers must
 // Add() explicit entries for those.
 //
+// Pairs the reachability helpers cannot evaluate (peering shapes behind
+// reachCheckUnsupported) get an explicit VerdictUnknown entry instead of
+// being left out: absence means Deny to Lookup, which would assert
+// unreachability nobody established. The test is expected to overlay the
+// real expectation; ConnectivityMatrix.Validate fails the run otherwise.
+//
 // TODO: IsServerReachable takes only (srcName, dstName) and so returns the
 // same verdict for every (src_ep, dst_ep) pair sharing those names. For a
 // server with multiple (vpc, subnet) attachments this is incorrect when
@@ -1874,8 +1880,20 @@ func populateConnectivityMatrix(ctx context.Context, kube kclient.Reader, m *Con
 				r, err := IsServerReachable(ctx, kube, src.Server.Name, dst.Server.Name, gatewayEnabled)
 				if err != nil {
 					if errors.Is(err, reachCheckUnsupported) {
+						// Record the pair as unevaluated rather than
+						// leaving it absent: absence reads as Deny and
+						// would be asserted as such. The test must
+						// overlay the real expectation (Validate
+						// enforces it).
+						m.Add(ConnectivityExpectation{
+							Pair:    EndpointPair{Source: src, Destination: dst},
+							Verdict: VerdictUnknown,
+							Detail:  err.Error(),
+						})
+
 						continue
 					}
+
 					return fmt.Errorf("checking %s -> %s: %w", src.Server.Name, dst.Server.Name, err)
 				}
 				if r.Reachable {
@@ -1891,8 +1909,17 @@ func populateConnectivityMatrix(ctx context.Context, kube kclient.Reader, m *Con
 					r, err := IsExternalSubnetReachable(ctx, kube, src.Server.Name, prefix.String(), gatewayEnabled)
 					if err != nil {
 						if errors.Is(err, reachCheckUnsupported) {
+							// As above; a later prefix that does resolve
+							// to Allow overwrites this entry.
+							m.Add(ConnectivityExpectation{
+								Pair:    EndpointPair{Source: src, Destination: dst},
+								Verdict: VerdictUnknown,
+								Detail:  err.Error(),
+							})
+
 							continue
 						}
+
 						return fmt.Errorf("checking %s -> %s/%s: %w", src.Server.Name, dst.External.ExternalName, prefix.String(), err)
 					}
 					if r.Reachable {
@@ -2102,11 +2129,14 @@ type PingError struct {
 	Source      string
 	Destination string
 	Expected    bool
-	Sent        int
-	Received    int
-	Lost        []int
-	CmdOutput   string
-	Msg         string
+	// Why: what made Expected what it is (matrix Reason/Peering, or the
+	// live reachability check's).
+	Why       string
+	Sent      int
+	Received  int
+	Lost      []int
+	CmdOutput string
+	Msg       string
 }
 
 func (pe *PingError) Error() string {
@@ -2115,8 +2145,8 @@ func (pe *PingError) Error() string {
 		lost = fmt.Sprintf(", lost=%v", pe.Lost)
 	}
 
-	return fmt.Sprintf("ping %s -> %s: %s (sent %d, rcvd %d%s, expected %v)",
-		pe.Source, pe.Destination, pe.Msg, pe.Sent, pe.Received, lost, pe.Expected)
+	return fmt.Sprintf("ping %s -> %s: %s (sent %d, rcvd %d%s, expected %v%s)",
+		pe.Source, pe.Destination, pe.Msg, pe.Sent, pe.Received, lost, pe.Expected, whySuffix(pe.Why))
 }
 
 // parsePingLostSeqs returns the ICMP sequence numbers in 1..sent that have no
@@ -2158,8 +2188,11 @@ func parsePingLostSeqs(stdout string, sent int) []int {
 }
 
 type IperfError struct {
-	Source          string
-	Destination     string
+	Source      string
+	Destination string
+	// Why: what made the expectation what it is (matrix Reason/Peering,
+	// or the live reachability check's).
+	Why             string
 	MinSpeed        string
 	SentSpeed       string
 	RcvdSpeed       string
@@ -2181,6 +2214,7 @@ func (ie *IperfError) Error() string {
 	if ie.SentSpeed != "" {
 		rs += fmt.Sprintf(" (sent %s, rcvd %s, min expected %s)", ie.SentSpeed, ie.RcvdSpeed, ie.MinSpeed)
 	}
+	rs += whySuffix(ie.Why)
 
 	return rs
 }
@@ -2190,11 +2224,40 @@ type CurlError struct {
 	Expected bool
 	Output   string
 	Msg      string
+	// Why: what made Expected what it is (matrix Reason/Peering, or the
+	// live reachability check's).
+	Why string
 }
 
 func (ce *CurlError) Error() string {
-	return fmt.Sprintf("curl from %s: %s (expected %v)",
-		ce.Source, ce.Msg, ce.Expected)
+	return fmt.Sprintf("curl from %s: %s (expected %v%s)",
+		ce.Source, ce.Msg, ce.Expected, whySuffix(ce.Why))
+}
+
+// expectationWhy renders why a probe was expected to succeed or fail, so a
+// failure message says more than "expected true": which peering the verdict
+// came from. An empty Reason is reported as such rather than guessed at —
+// on a Deny it is the matrix's default-isolation answer, which is also what
+// a lost entry looks like, and callers that pass a bare expectation have no
+// reason to state.
+func expectationWhy(r Reachability) string {
+	switch {
+	case r.Reason != "" && r.Peering != "":
+		return fmt.Sprintf("%s %q", r.Reason, r.Peering)
+	case r.Reason != "":
+		return string(r.Reason)
+	default:
+		return "no reason recorded"
+	}
+}
+
+// whySuffix formats a Why for appending to an error message.
+func whySuffix(why string) string {
+	if why == "" {
+		return ""
+	}
+
+	return ", because: " + why
 }
 
 type TestConnectivityOpts struct {
@@ -2306,7 +2369,7 @@ func runPingIperfPair(ctx context.Context, opts TestConnectivityOpts, args pingI
 	slog.Debug("Checking connectivity", logArgs...)
 
 	var errs []error
-	if pe := checkPing(ctx, opts.PingsCount, args.Pings, args.From, args.To, args.FromSSH, args.ToIP, nil, args.Expected.Reachable); pe != nil {
+	if pe := checkPing(ctx, opts.PingsCount, args.Pings, args.From, args.To, args.FromSSH, args.ToIP, nil, args.Expected); pe != nil {
 		return append(errs, pe)
 	}
 
@@ -2577,7 +2640,7 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 
 					// switching to 1.0.0.1 since the previously used target 8.8.8.8 was giving us issue
 					// when curling over virtual external peerings
-					if ce := checkCurl(ctx, opts, curls, serverA, client, "1.0.0.1", expectedReachable.Reachable); ce != nil {
+					if ce := checkCurl(ctx, opts, curls, serverA, client, "1.0.0.1", expectedReachable); ce != nil {
 						return ce
 					}
 
@@ -2962,14 +3025,15 @@ func retrySSHCmd(ctx context.Context, ssh *sshutil.Config, cmd string, target st
 	return stdout, stderr, nil
 }
 
-func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted, from, to string, fromSSH *sshutil.Config, toIP netip.Addr, sourceIP *netip.Addr, expected bool) *PingError {
+func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted, from, to string, fromSSH *sshutil.Config, toIP netip.Addr, sourceIP *netip.Addr, expected Reachability) *PingError {
 	if pingCount <= 0 {
 		return nil
 	}
 	pe := &PingError{
 		Source:      from,
 		Destination: to,
-		Expected:    expected,
+		Expected:    expected.Reachable,
+		Why:         expectationWhy(expected),
 	}
 
 	if semaphore != nil {
@@ -2984,14 +3048,14 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(pingCount+30)*time.Second)
 	defer cancel()
 
-	slog.Debug("Running ping", "from", from, "to", toIP.String(), "sourceIP", sourceIP, "expected", expected)
+	slog.Debug("Running ping", "from", from, "to", toIP.String(), "sourceIP", sourceIP, "expected", expected.Reachable)
 	cmd := "ping -c 1 -W 1"
 	if sourceIP != nil {
 		cmd += " -I " + sourceIP.String()
 	}
 	cmd += " " + toIP.String()
 
-	if stdout, stderr, err := retrySSHCmd(ctx, fromSSH, cmd, from); err != nil && expected {
+	if stdout, stderr, err := retrySSHCmd(ctx, fromSSH, cmd, from); err != nil && expected.Reachable {
 		slog.Warn("Warm-up ping failed, continuing anyway", "err", err, "stdout", stdout, "stderr", stderr)
 	}
 
@@ -3050,14 +3114,14 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 	pingFail := err != nil && pe.Received == 0
 
 	slog.Debug("Ping result", "from", from, "to", to,
-		"expected", expected, "ok", pingOk, "fail", pingFail, "err", err, "stdout", stdout, "stderr", stderr)
+		"expected", expected.Reachable, "ok", pingOk, "fail", pingFail, "err", err, "stdout", stdout, "stderr", stderr)
 
 	// When a ping that should have succeeded fails, surface the per-packet
 	// (timestamped, via -D) output at warn level so the loss pattern is visible
 	// next to the error without re-running with -v. Negative tests fail pings by
 	// design, so only do this when reachability was expected.
 	logExpectedFailure := func() {
-		if expected {
+		if expected.Reachable {
 			slog.Warn("Ping failed (expected reachable)", "from", from, "to", to,
 				"sent", pe.Sent, "rcvd", pe.Received, "lost", pe.Lost, "stdout", stdout, "stderr", stderr)
 		}
@@ -3075,14 +3139,14 @@ func checkPing(ctx context.Context, pingCount int, semaphore *semaphore.Weighted
 		return pe
 	}
 
-	if expected && !pingOk {
+	if expected.Reachable && !pingOk {
 		logExpectedFailure()
 		pe.Msg = "should be reachable but ping failed"
 
 		return pe
 	}
 
-	if !expected && !pingFail {
+	if !expected.Reachable && !pingFail {
 		pe.Msg = "should not be reachable but ping succeeded"
 
 		return pe
@@ -3171,6 +3235,9 @@ func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string,
 		}
 
 		ies := runIPerf3Test(ctx, opts, from, to, fromSSH, toIP, iPerfsMinSpeed, bidir)
+		for _, ie := range ies {
+			ie.Why = expectationWhy(reachability)
+		}
 		if len(ies) == 0 {
 			if attempt > 0 {
 				slog.Info("iperf3 test succeeded on retry", "from", from, "to", to, "bidir", bidir, "attempt", attempt+1)
@@ -3315,13 +3382,14 @@ func isReportableIperfError(ie *IperfError) bool {
 	return ie.ClientMsg != "" || ie.ServerMsg != ""
 }
 
-func checkCurl(ctx context.Context, opts TestConnectivityOpts, curls *semaphore.Weighted, from string, fromSSH *sshutil.Config, toIP string, expected bool) *CurlError {
+func checkCurl(ctx context.Context, opts TestConnectivityOpts, curls *semaphore.Weighted, from string, fromSSH *sshutil.Config, toIP string, expected Reachability) *CurlError {
 	if opts.CurlsCount <= 0 {
 		return nil
 	}
 	ce := &CurlError{
 		Source:   from,
-		Expected: expected,
+		Expected: expected.Reachable,
+		Why:      expectationWhy(expected),
 	}
 
 	if err := curls.Acquire(ctx, 1); err != nil {
@@ -3356,7 +3424,7 @@ func checkCurl(ctx context.Context, opts TestConnectivityOpts, curls *semaphore.
 		curlOk := err == nil && strings.Contains(stdout, "301 Moved")
 		curlFail := err != nil && !strings.Contains(stdout, "301 Moved")
 
-		slog.Debug("Curl result", "from", from, "to", toIP, "expected", expected, "ok", curlOk, "fail", curlFail, "err", err, "stdout", stdout, "stderr", stderr)
+		slog.Debug("Curl result", "from", from, "to", toIP, "expected", expected.Reachable, "ok", curlOk, "fail", curlFail, "err", err, "stdout", stdout, "stderr", stderr)
 
 		if curlOk == curlFail {
 			if err != nil {
@@ -3368,13 +3436,13 @@ func checkCurl(ctx context.Context, opts TestConnectivityOpts, curls *semaphore.
 			return ce
 		}
 
-		if expected && !curlOk {
+		if expected.Reachable && !curlOk {
 			ce.Msg = "should be reachable but curl failed"
 
 			return ce
 		}
 
-		if !expected && !curlFail {
+		if !expected.Reachable && !curlFail {
 			ce.Msg = "should not be reachable but curl succeeded"
 
 			return ce

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -568,10 +568,7 @@ func ResolveDefaultServerMTU(ctx context.Context, kube kclient.Client, opts *Set
 
 // SetupVPCs creates VPCs and VPC attachments per opts, configures servers,
 // and returns one Endpoint per (server, vpc, subnet) attachment with the
-// discovered IP and HostBGP flag populated. ESLAG servers skipped in non-L2VNI
-// modes are not included in the returned list. Callers that want to drive
-// matrix-based connectivity tests pass the result to BuildConnectivityMatrix;
-// CLI and vlabrunner callers discard it.
+// discovered IP and HostBGP flag populated.
 func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) ([]*Endpoint, []DroppedEndpoint, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
@@ -725,14 +722,6 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		nextPrefix()
 	}
 
-	// Collect MCLAG switches for later (needed for hostbgp validation)
-	mclagSwitches := map[string]bool{}
-	for _, sw := range switchList.Items {
-		if sw.Spec.Redundancy.Type == meta.RedundancyTypeMCLAG {
-			mclagSwitches[sw.Name] = true
-		}
-	}
-
 	serverInSubnet := 0
 	subnetInVPC := 0
 	vpcID := 0
@@ -779,19 +768,9 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		}
 		conn := conns.Items[0]
 
-		switches, _, _, _, err := conn.Spec.Endpoints()
-		if err != nil {
-			return nil, nil, fmt.Errorf("getting connection %q endpoints: %w", conn.Name, err)
-		}
-		isMclag := false
-		for _, sw := range switches {
-			_, found := mclagSwitches[sw]
-			isMclag = isMclag || found
-		}
-
 		vpcName := fmt.Sprintf("vpc-%02d", vpcID+1)
 		subnetName := fmt.Sprintf("subnet-%02d", subnetInVPC+1)
-		hostBGP := opts.HostBGPSubnet && !hostBGPDoneForVPC && conn.Spec.Unbundled != nil && !isMclag
+		hostBGP := opts.HostBGPSubnet && !hostBGPDoneForVPC && conn.Spec.Unbundled != nil
 		if hostBGP {
 			hostBGPDoneForVPC = true
 		}
@@ -1847,16 +1826,9 @@ func buildExternalEndpoints(externals []vpcapi.External) []*Endpoint {
 
 // populateConnectivityMatrix iterates all endpoint pairs in m.AllEndpoints
 // and adds an allow expectation when the cluster's current peering state
-// reports the pair as reachable. Reverse-direction expectations are emitted
-// independently. NAT translation details (SNAT/DNAT/port-forward/masquerade
-// pools) and external-originated traffic are NOT modeled — callers must
-// Add() explicit entries for those.
-//
-// Pairs the reachability helpers cannot evaluate (peering shapes behind
-// reachCheckUnsupported) get an explicit VerdictUnknown entry instead of
-// being left out: absence means Deny to Lookup, which would assert
-// unreachability nobody established. The test is expected to overlay the
-// real expectation; ConnectivityMatrix.Validate fails the run otherwise.
+// reports the pair as reachable. NAT translation details
+// (SNAT/DNAT/port-forward/masquerade pools) and external-originated traffic
+// are NOT modeled — callers must Add() explicit entries for those.
 //
 // TODO: IsServerReachable takes only (srcName, dstName) and so returns the
 // same verdict for every (src_ep, dst_ep) pair sharing those names. For a
@@ -1880,11 +1852,6 @@ func populateConnectivityMatrix(ctx context.Context, kube kclient.Reader, m *Con
 				r, err := IsServerReachable(ctx, kube, src.Server.Name, dst.Server.Name, gatewayEnabled)
 				if err != nil {
 					if errors.Is(err, reachCheckUnsupported) {
-						// Record the pair as unevaluated rather than
-						// leaving it absent: absence reads as Deny and
-						// would be asserted as such. The test must
-						// overlay the real expectation (Validate
-						// enforces it).
 						m.Add(ConnectivityExpectation{
 							Pair:    EndpointPair{Source: src, Destination: dst},
 							Verdict: VerdictUnknown,
@@ -1909,8 +1876,6 @@ func populateConnectivityMatrix(ctx context.Context, kube kclient.Reader, m *Con
 					r, err := IsExternalSubnetReachable(ctx, kube, src.Server.Name, prefix.String(), gatewayEnabled)
 					if err != nil {
 						if errors.Is(err, reachCheckUnsupported) {
-							// As above; a later prefix that does resolve
-							// to Allow overwrites this entry.
 							m.Add(ConnectivityExpectation{
 								Pair:    EndpointPair{Source: src, Destination: dst},
 								Verdict: VerdictUnknown,
@@ -1933,8 +1898,6 @@ func populateConnectivityMatrix(ctx context.Context, kube kclient.Reader, m *Con
 						break
 					}
 				}
-				// external-as-source and external-to-external paths are not
-				// auto-generated; the reachability helpers don't model them.
 			}
 		}
 	}
@@ -1942,11 +1905,6 @@ func populateConnectivityMatrix(ctx context.Context, kube kclient.Reader, m *Con
 	return nil
 }
 
-// DoSetupPeerings reconciles VPC/external/gateway peerings to match the
-// caller's specs (deletes anything not in the spec, creates or updates the
-// rest), optionally waits for switches to converge, and returns. It is
-// matrix-agnostic: callers that need a post-peering ConnectivityMatrix
-// invoke BuildConnectivityMatrix afterward.
 func DoSetupPeerings(ctx context.Context, kube client.Client, vpcPeerings map[string]*vpcapi.VPCPeeringSpec,
 	externalPeerings map[string]*vpcapi.ExternalPeeringSpec, gwPeerings map[string]*gwapi.PeeringSpec,
 	waitReady bool,
@@ -2129,14 +2087,12 @@ type PingError struct {
 	Source      string
 	Destination string
 	Expected    bool
-	// Why: what made Expected what it is (matrix Reason/Peering, or the
-	// live reachability check's).
-	Why       string
-	Sent      int
-	Received  int
-	Lost      []int
-	CmdOutput string
-	Msg       string
+	Why         string // what made the expectation what it is
+	Sent        int
+	Received    int
+	Lost        []int
+	CmdOutput   string
+	Msg         string
 }
 
 func (pe *PingError) Error() string {
@@ -2188,11 +2144,9 @@ func parsePingLostSeqs(stdout string, sent int) []int {
 }
 
 type IperfError struct {
-	Source      string
-	Destination string
-	// Why: what made the expectation what it is (matrix Reason/Peering,
-	// or the live reachability check's).
-	Why             string
+	Source          string
+	Destination     string
+	Why             string // what made the expectation what it is
 	MinSpeed        string
 	SentSpeed       string
 	RcvdSpeed       string
@@ -2224,9 +2178,7 @@ type CurlError struct {
 	Expected bool
 	Output   string
 	Msg      string
-	// Why: what made Expected what it is (matrix Reason/Peering, or the
-	// live reachability check's).
-	Why string
+	Why      string // what made Expected what it is
 }
 
 func (ce *CurlError) Error() string {
@@ -2234,12 +2186,6 @@ func (ce *CurlError) Error() string {
 		ce.Source, ce.Msg, ce.Expected, whySuffix(ce.Why))
 }
 
-// expectationWhy renders why a probe was expected to succeed or fail, so a
-// failure message says more than "expected true": which peering the verdict
-// came from. An empty Reason is reported as such rather than guessed at —
-// on a Deny it is the matrix's default-isolation answer, which is also what
-// a lost entry looks like, and callers that pass a bare expectation have no
-// reason to state.
 func expectationWhy(r Reachability) string {
 	switch {
 	case r.Reason != "" && r.Peering != "":
@@ -2276,12 +2222,6 @@ type TestConnectivityOpts struct {
 	RequireAllServers bool
 }
 
-// prepareConnectivityTest does the shared prelude work for connectivity
-// tests: SSH config map for all vlab VMs, kube client with a cache, switch
-// list and the IPerfsMinSpeed adjustment based on switch types, and
-// optional WaitReady. The caller must call cleanup when finished to release
-// the kube cache. opts is mutated in place to apply the IPerfsMinSpeed
-// adjustment.
 func (c *Config) prepareConnectivityTest(ctx context.Context, vlab *VLAB, opts *TestConnectivityOpts) (sshConfigs map[string]*sshutil.Config, kube kclient.Client, cleanup func(), err error) {
 	sshConfigs = map[string]*sshutil.Config{}
 	for _, vm := range vlab.VMs {
@@ -2336,10 +2276,6 @@ func (c *Config) prepareConnectivityTest(ctx context.Context, vlab *VLAB, opts *
 	return sshConfigs, kube, cacheCancel, nil
 }
 
-// pingIperfPairArgs holds the resolved inputs for one directional
-// ping+iperf check between two endpoints. The caller is responsible for
-// looking up the source SSH config, destination IP, expected reachability,
-// and the bidir flag before invoking runPingIperfPair.
 type pingIperfPairArgs struct {
 	From     string
 	To       string
@@ -2351,9 +2287,6 @@ type pingIperfPairArgs struct {
 	Iperfs   *semaphore.Weighted
 }
 
-// runPingIperfPair runs ping and (when enabled and not lex-skipped in bidir
-// mode) iperf for one (From → To) pair, returning every encountered error
-// so the caller can route them.
 func runPingIperfPair(ctx context.Context, opts TestConnectivityOpts, args pingIperfPairArgs) []error {
 	logArgs := []any{
 		"from", args.From,

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -425,38 +425,59 @@ func GetServerNetconfCmd(conn *wiringapi.Connection, opts ServerNetconfOpts) (st
 	return netconfCmd, nil
 }
 
-// TODO: multi subnet support once test-connectivity supports it
-func getServerHostBGPCmd(conn *wiringapi.Connection, vlan uint16, subnet netip.Prefix, serversInSubnet int) (string, error) {
-	if conn == nil {
-		return "", fmt.Errorf("connection is nil")
+type HostBGPParams struct {
+	VPCLabel     string
+	Connections  []*wiringapi.Connection
+	VLAN         uint16
+	Subnet       netip.Prefix
+	ServerOffset int
+}
+
+func getServerHostBGPCmd(params []HostBGPParams) (string, error) {
+	if len(params) == 0 {
+		return "", fmt.Errorf("no params provided")
 	}
 
-	cmd := fmt.Sprintf("vpc:v=%d:i=", vlan)
-	interfaces := []string{}
-	switch {
-	case conn.Spec.Unbundled != nil:
-		interfaces = append(interfaces, conn.Spec.Unbundled.Link.Server.LocalPortName())
-	case conn.Spec.Bundled != nil:
-		for _, link := range conn.Spec.Bundled.Links {
-			interfaces = append(interfaces, link.Server.LocalPortName())
+	cmd := ""
+	for i, param := range params {
+		if i > 0 {
+			cmd += " "
 		}
-	case conn.Spec.ESLAG != nil:
-		for _, link := range conn.Spec.ESLAG.Links {
-			interfaces = append(interfaces, link.Server.LocalPortName())
+		if len(param.Connections) == 0 {
+			return "", fmt.Errorf("no connections provided")
 		}
-	default:
-		return "", fmt.Errorf("unexpected connection type for conn %q", conn.Name)
-	}
+		interfaces := []string{}
+		for _, conn := range param.Connections {
+			if conn == nil {
+				return "", fmt.Errorf("connection is nil")
+			}
+			switch {
+			case conn.Spec.Unbundled != nil:
+				interfaces = append(interfaces, conn.Spec.Unbundled.Link.Server.LocalPortName())
+			case conn.Spec.Bundled != nil:
+				for _, link := range conn.Spec.Bundled.Links {
+					interfaces = append(interfaces, link.Server.LocalPortName())
+				}
+			case conn.Spec.ESLAG != nil:
+				for _, link := range conn.Spec.ESLAG.Links {
+					interfaces = append(interfaces, link.Server.LocalPortName())
+				}
+			default:
+				return "", fmt.Errorf("unexpected connection type for conn %q", conn.Name)
+			}
+		}
 
-	cmd += strings.Join(interfaces, ":i=")
-	addr := subnet.Addr()
-	for range serversInSubnet {
-		addr = addr.Next()
+		cmd += fmt.Sprintf("%s:v=%d:i=", param.VPCLabel, param.VLAN)
+		cmd += strings.Join(interfaces, ":i=")
+		addr := param.Subnet.Addr()
+		for range param.ServerOffset {
+			addr = addr.Next()
+		}
+		if !addr.IsValid() {
+			return "", fmt.Errorf("failed to get IP address from subnet %s", param.Subnet.String())
+		}
+		cmd += ":a=" + addr.String() + "/32"
 	}
-	if !addr.IsValid() {
-		return "", fmt.Errorf("failed to get IP address from subnet %s", subnet.String())
-	}
-	cmd += ":a=" + addr.String() + "/32"
 
 	return cmd, nil
 }
@@ -882,7 +903,15 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		var confErr error
 
 		if hostBGP {
-			confCmd, confErr = getServerHostBGPCmd(&conn, vlan, expectedSubnet, serverInSubnet)
+			confCmd, confErr = getServerHostBGPCmd([]HostBGPParams{
+				{
+					VPCLabel:     vpcName,
+					Connections:  []*wiringapi.Connection{&conn},
+					VLAN:         vlan,
+					Subnet:       expectedSubnet,
+					ServerOffset: serverInSubnet,
+				},
+			})
 		} else if opts.P2P {
 			confCmd, confErr = GetServerNetconfCmd(&conn, ServerNetconfOpts{
 				P2P: p2p.String(),

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -3364,6 +3364,172 @@ func isReportableIperfError(ie *IperfError) bool {
 	return ie.ClientMsg != "" || ie.ServerMsg != ""
 }
 
+// ncProbeMarker prefixes the exit code the TCP probe echoes after nc, so the
+// connection result is read from the marker rather than from the SSH command's
+// own exit status (which conflates transport failures with a refused connect).
+const ncProbeMarker = "NCRC="
+
+func parseNCReturnCode(stdout string) (int, bool) {
+	for _, line := range strings.Split(stdout, "\n") {
+		rest, found := strings.CutPrefix(strings.TrimSpace(line), ncProbeMarker)
+		if !found {
+			continue
+		}
+		rc, err := strconv.Atoi(strings.TrimSpace(rest))
+		if err != nil {
+			return 0, false
+		}
+
+		return rc, true
+	}
+
+	return 0, false
+}
+
+// checkTCPPort asserts that a TCP connection from `from` to toIP:port matches
+// expected. It runs `nc -zw2 <ip> <port>` on the source: a completed handshake
+// means the path is open (allow), a refused/timed-out connect (nc exit 1) means
+// it is blocked (deny).
+func checkTCPPort(ctx context.Context, sem *semaphore.Weighted, from string, fromSSH *sshutil.Config, toIP netip.Addr, port uint16, expected bool) *IperfError {
+	target := fmt.Sprintf("%s:%d", toIP.String(), port)
+	ie := &IperfError{Source: from, Destination: target}
+
+	if sem != nil {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			ie.ClientMsg = fmt.Sprintf("acquiring iperf3 semaphore: %s", err)
+
+			return ie
+		}
+		defer sem.Release(1)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Append the marker so the shell exits 0 whenever it ran; a non-nil err
+	// then unambiguously means the probe itself could not execute.
+	cmd := fmt.Sprintf("nc -zw2 %s %d; echo %s$?", toIP.String(), port, ncProbeMarker)
+	stdout, stderr, err := retrySSHCmd(ctx, fromSSH, cmd, from)
+	if err != nil {
+		ie.ClientMsg = fmt.Sprintf("TCP probe could not run: %s: %s", err, strings.TrimSpace(stderr))
+
+		return ie
+	}
+
+	rc, ok := parseNCReturnCode(stdout)
+	if !ok {
+		ie.ClientMsg = fmt.Sprintf("TCP probe produced no result marker (stdout %q, stderr %q)", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+
+		return ie
+	}
+
+	var connectOk bool
+	switch rc {
+	case 0:
+		connectOk = true
+	case 1:
+		// nc -z exits 1 on connection refused or -w timeout: a genuine block.
+		connectOk = false
+	default:
+		// e.g. 127 (nc not found) — a probe/environment failure, not a verdict.
+		ie.ClientMsg = fmt.Sprintf("TCP probe returned unexpected exit code %d (stdout %q, stderr %q)", rc, strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+
+		return ie
+	}
+
+	slog.Debug("TCP port probe result", "from", from, "to", target, "expected", expected, "ok", connectOk, "rc", rc, "stderr", stderr)
+
+	if expected && !connectOk {
+		ie.ClientMsg = "should be reachable but TCP connect was refused/timed out"
+
+		return ie
+	}
+	if !expected && connectOk {
+		ie.ClientMsg = "should not be reachable but TCP connect succeeded"
+
+		return ie
+	}
+
+	return nil
+}
+
+// udpDenyLossThreshold and udpAllowLossThreshold bound the datagram-loss
+// interpretation of a UDP probe: near-total loss (or a control-
+// channel error / zero datagrams) means the path is blocked, low-enough loss
+// means it is open.
+const (
+	udpDenyLossThreshold  = 99.0
+	udpAllowLossThreshold = 90.0
+)
+
+// NOTE: iperf3 -u first opens a TCP control channel on the target port, so this
+// cannot distinguish "TCP denied + UDP allowed" on the same port (the control
+// channel would be blocked). Callers must avoid that combination.
+func checkUDPPort(ctx context.Context, opts TestConnectivityOpts, sem *semaphore.Weighted, from string, fromSSH *sshutil.Config, toIP netip.Addr, port uint16, expected bool) *IperfError {
+	target := fmt.Sprintf("%s:%d", toIP.String(), port)
+	ie := &IperfError{Source: from, Destination: target}
+
+	if sem != nil {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			ie.ClientMsg = fmt.Sprintf("acquiring iperf3 semaphore: %s", err)
+
+			return ie
+		}
+		defer sem.Release(1)
+	}
+
+	secs := opts.IPerfsSeconds
+	if secs <= 0 {
+		secs = 3
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(secs+30)*time.Second)
+	defer cancel()
+
+	cmd := fmt.Sprintf("sudo docker exec iperf3 timeout %d iperf3 -u -J -c %s -p %d -t %d -b 10M -l 1000", secs+25, toIP.String(), port, secs)
+	stdout, stderr, err := retrySSHCmd(ctx, fromSSH, cmd, from)
+	report, parseErr := parseIPerf3Report([]byte(stdout))
+
+	if parseErr != nil {
+		ie.ClientMsg = fmt.Sprintf("iperf3 UDP probe produced no parseable report (cmd err: %v, stderr: %q): %s", err, strings.TrimSpace(stderr), parseErr)
+
+		return ie
+	}
+
+	reportErr := report.Error
+	packets := report.End.Sum.Packets
+	lost := report.End.Sum.LostPackets
+	lostPercent := report.End.Sum.LostPercent
+	delivered := reportErr == "" && packets > 0 && lostPercent < udpAllowLossThreshold
+	blocked := reportErr != "" || packets == 0 || lostPercent >= udpDenyLossThreshold
+
+	slog.Debug("UDP port probe result", "from", from, "to", target, "expected", expected,
+		"delivered", delivered, "blocked", blocked, "packets", packets, "lost", lost, "lostPercent", lostPercent,
+		"err", err, "reportErr", reportErr, "stderr", stderr)
+
+	if expected {
+		if !delivered {
+			if reportErr != "" {
+				ie.ClientMsg = fmt.Sprintf("should be reachable but UDP probe reported error: %s", reportErr)
+			} else {
+				ie.ClientMsg = fmt.Sprintf("should be reachable but UDP datagrams not delivered (packets %d, loss %.1f%%)", packets, lostPercent)
+			}
+
+			return ie
+		}
+
+		return nil
+	}
+
+	// expected == deny.
+	if !blocked {
+		ie.ClientMsg = fmt.Sprintf("should not be reachable but UDP datagrams delivered (packets %d, loss %.1f%%)", packets, lostPercent)
+
+		return ie
+	}
+
+	return nil
+}
+
 func checkCurl(ctx context.Context, opts TestConnectivityOpts, curls *semaphore.Weighted, from string, fromSSH *sshutil.Config, toIP string, expected Reachability) *CurlError {
 	if opts.CurlsCount <= 0 {
 		return nil
@@ -3450,11 +3616,19 @@ type iperf3ReportEnd struct {
 	SumReceived             iperf3ReportSum `json:"sum_received"`
 	SumSentBidirReverse     iperf3ReportSum `json:"sum_sent_bidir_reverse"`
 	SumReceivedBidirReverse iperf3ReportSum `json:"sum_received_bidir_reverse"`
+	// Sum holds the UDP client summary (iperf3 -u reports it here rather than
+	// in sum_sent/sum_received). Carries the datagram/loss counters.
+	Sum iperf3ReportSum `json:"sum"`
 }
 
 type iperf3ReportSum struct {
 	Bytes         int64   `json:"bytes"`
 	BitsPerSecond float64 `json:"bits_per_second"`
+	// UDP-only fields (populated by iperf3 -u).
+	Packets     int64   `json:"packets"`
+	LostPackets int64   `json:"lost_packets"`
+	LostPercent float64 `json:"lost_percent"`
+	JitterMs    float64 `json:"jitter_ms"`
 }
 
 func parseIPerf3Report(data []byte) (*iperf3Report, error) {

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -755,6 +755,17 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 	expectedSubnets := map[string]netip.Prefix{}
 	eslagServers := make(map[string]bool, 0)
 	hostBGPServers := map[string]bool{}
+	// Rolls the counters forward so the next server starts a fresh subnet,
+	// moving on to the next VPC once this one is full of subnets.
+	nextSubnet := func() {
+		serverInSubnet = 0
+		subnetInVPC++
+		if subnetInVPC >= opts.SubnetsPerVPC {
+			subnetInVPC = 0
+			vpcID++
+			hostBGPDoneForVPC = false
+		}
+	}
 	for _, server := range servers.Items {
 		if opts.VPCMode != vpcapi.VPCModeL2VNI {
 			if sa, err := getServerAttachState(ctx, kube, &server, false); err != nil {
@@ -767,14 +778,7 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 			}
 		}
 		if serverInSubnet >= opts.ServersPerSubnet {
-			serverInSubnet = 0
-			subnetInVPC++
-		}
-		if subnetInVPC >= opts.SubnetsPerVPC {
-			serverInSubnet = 0
-			subnetInVPC = 0
-			vpcID++
-			hostBGPDoneForVPC = false
+			nextSubnet()
 		}
 
 		conns := &wiringapi.ConnectionList{}
@@ -798,6 +802,17 @@ func (c *Config) SetupVPCs(ctx context.Context, vlab *VLAB, opts SetupVPCsOpts) 
 		vpcName := fmt.Sprintf("vpc-%02d", vpcID+1)
 		subnetName := fmt.Sprintf("subnet-%02d", subnetInVPC+1)
 		hostBGP := multihomed || (opts.HostBGPSubnet && !hostBGPDoneForVPC && conn.Spec.Unbundled != nil)
+		// A hostBGP subnet has DHCP disabled and only accepts unbundled
+		// attachments, so a subnet shared between hostBGP and regular servers is
+		// rejected by the API or leaves a server without an address. Start a
+		// fresh subnet instead.
+		if last := len(vpcs) - 1; last >= 0 && vpcs[last].Name == vpcName {
+			if s := vpcs[last].Spec.Subnets[subnetName]; s != nil && s.HostBGP != hostBGP {
+				nextSubnet()
+				vpcName = fmt.Sprintf("vpc-%02d", vpcID+1)
+				subnetName = fmt.Sprintf("subnet-%02d", subnetInVPC+1)
+			}
+		}
 		if hostBGP {
 			hostBGPDoneForVPC = true
 		}

--- a/pkg/hhfab/vlabbuilder.go
+++ b/pkg/hhfab/vlabbuilder.go
@@ -55,7 +55,7 @@ type VLABBuilderDefault struct {
 	ESLAGServers        uint8             // number of ESLAG servers to generate for ESLAG switches
 	UnbundledServers    uint8             // number of unbundled servers to generate for switches (only for one of the first switch in the redundancy group or orphan switch)
 	BundledServers      uint8             // number of bundled servers to generate for switches (only for one of the second switch in the redundancy group or orphan switch)
-	MultiHomedServers   uint8             // number of multi-homed servers (2 connections to 2 different orphan leaves)
+	MultiHomedServers   uint8             // number of multi-homed servers (2 connections to 2 different leaves, preferably orphans)
 	NoSwitches          bool              // do not generate any switches
 	GatewayUplinks      uint8             // number of uplinks for gateway node to the spines
 	GatewayDriver       string            // gateway driver to use for gateway node
@@ -219,8 +219,8 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 		b.ESLAGServers = 0
 	}
 
-	if b.MultiHomedServers > 0 && b.OrphanLeafsCount < 2 {
-		return fmt.Errorf("at least two orphan leaves are needed for multihomed servers") //nolint:goerr113
+	if b.MultiHomedServers > 0 && b.OrphanLeafsCount+totalESLAGLeafs < 2 {
+		return fmt.Errorf("at least two leaves are needed for multihomed servers") //nolint:goerr113
 	}
 
 	if b.ExtESLAGConnCount > totalESLAGLeafs {
@@ -364,6 +364,7 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 	externalConns := []wiringapi.Connection{}
 	extESLAGConns := uint8(0)
 	extOrphanConns := uint8(0)
+	mhLeaves := []string{}
 
 	for eslagID := uint8(0); eslagID < uint8(len(eslagLeafGroups)); eslagID++ { //nolint:gosec
 		sg := fmt.Sprintf("eslag-%d", eslagID+1)
@@ -376,6 +377,10 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 		for eslagLeafID := uint8(0); eslagLeafID < leafs; eslagLeafID++ {
 			leafName := fmt.Sprintf("leaf-%02d", leafID+eslagLeafID)
 			leafNames = append(leafNames, leafName)
+			// add eslag leaves to candidates for multihomed servers if there are not enough orphan laves
+			if b.OrphanLeafsCount < 2 {
+				mhLeaves = append(mhLeaves, leafName)
+			}
 
 			if _, err := b.createSwitch(ctx, leafName, wiringapi.SwitchSpec{
 				Role:        wiringapi.SwitchRoleServerLeaf,
@@ -485,7 +490,6 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 		}
 	}
 
-	orphanLeaves := []string{}
 	for idx := uint8(1); idx <= b.OrphanLeafsCount; idx++ {
 		leafName := fmt.Sprintf("leaf-%02d", leafID)
 
@@ -495,7 +499,7 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 		}, nil); err != nil {
 			return err
 		}
-		orphanLeaves = append(orphanLeaves, leafName)
+		mhLeaves = append(mhLeaves, leafName)
 
 		if extOrphanConns < b.ExtOrphanConnCount {
 			var err error
@@ -562,16 +566,16 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 		}
 	}
 
-	orphanIdx := 0
+	mhIdx := 0
 	for range int(b.MultiHomedServers) {
 		serverName := fmt.Sprintf("server-%02d", serverID)
-		orphan1 := orphanLeaves[orphanIdx]
-		orphanIdx = (orphanIdx + 1) % len(orphanLeaves)
-		orphan2 := orphanLeaves[orphanIdx]
-		orphanIdx = (orphanIdx + 1) % len(orphanLeaves)
+		leaf1 := mhLeaves[mhIdx]
+		mhIdx = (mhIdx + 1) % len(mhLeaves)
+		leaf2 := mhLeaves[mhIdx]
+		mhIdx = (mhIdx + 1) % len(mhLeaves)
 
 		if _, err := b.createServer(ctx, serverName, wiringapi.ServerSpec{
-			Description: fmt.Sprintf("S-%02d MultiHomed %s + %s", serverID, orphan1, orphan2),
+			Description: fmt.Sprintf("S-%02d MultiHomed %s + %s", serverID, leaf1, leaf2),
 		}); err != nil {
 			return err
 		}
@@ -580,7 +584,7 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 			Unbundled: &wiringapi.ConnUnbundled{
 				Link: wiringapi.ServerToSwitchLink{
 					Server: wiringapi.BasePortName{Port: b.nextServerPort(serverName)},
-					Switch: wiringapi.BasePortName{Port: b.nextSwitchPort(orphan1)},
+					Switch: wiringapi.BasePortName{Port: b.nextSwitchPort(leaf1)},
 				},
 			},
 		}); err != nil {
@@ -590,7 +594,7 @@ func (b *VLABBuilderDefault) Build(ctx context.Context, l *apiutil.Loader, fabri
 			Unbundled: &wiringapi.ConnUnbundled{
 				Link: wiringapi.ServerToSwitchLink{
 					Server: wiringapi.BasePortName{Port: b.nextServerPort(serverName)},
-					Switch: wiringapi.BasePortName{Port: b.nextSwitchPort(orphan2)},
+					Switch: wiringapi.BasePortName{Port: b.nextSwitchPort(leaf2)},
 				},
 			},
 		}); err != nil {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -694,7 +694,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						InterfaceMTU:      opts.InterfaceMTU,
 					}
 					slog.Debug("Running setup-vpcs", "opts", setupVPCsOpts)
-					if _, err := c.SetupVPCs(ctx, vlab, setupVPCsOpts); err != nil {
+					if _, _, err := c.SetupVPCs(ctx, vlab, setupVPCsOpts); err != nil {
 						return c.handleShutdownWithPause(ctx, vlab, opts, fmt.Errorf("setting up VPCs: %w", err))
 					}
 				case OnReadySetupPeerings:


### PR DESCRIPTION
An attempt to address most of the comments on https://github.com/githedgehog/fabricator/pull/1761, kept as a separate branch in case we decide to merge the connectivity test refactor as it currently is while we address them.

Includes a manual pass to clean a big chunk of the AI comment slop. I kept what I thought was useful (e.g. gotchas and clarifications).

Also includes other stuff that was stacked on top of test-connectivity as separate PRs (i.e. multihomed unbundled support and ACLs release tests), since it was asked by the reviewers.

Does not include the hostbgp release test for the moment, as rebasing it on top of the connectivity refactor implies substantial changes and I want to make sure I'm not breaking it before committing to the change