### PR TITLE
fix(ci): add unconditional fallback for the GOPROXY to direct

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+export GOPROXY := env("GOPROXY", "https://proxy.golang.org|direct")
+
 import "hack/tools.just"
 import "hack/diagrams.just"
 


### PR DESCRIPTION
The comma only falls back on HTTP 404/410. A stream error: INTERNAL_ERROR is not a 404, so Go gives up instead of trying the next entry. The pipe falls back on any error.