### PR TITLE
feat(testing): control how much traffic iperf3 probes send

### DIFF
--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -90,10 +90,26 @@ const (
 	FlagGatewayLogLevel           = "gateway-log-level"
 	FlagGatewayTag                = "gateway-tag"
 	FlagShowTech                  = "show-tech"
+	FlagIPerfs                    = "iperfs"
 	FlagIPerfsSpeed               = "iperfs-speed"
+	FlagIPerfsMode                = "iperfs-mode"
 	FlagReleaseTestOnReadyOnly    = "release-test-on-ready-only"
+	FlagReleaseTestIPerfs         = "release-test-iperfs"
+	FlagReleaseTestIPerfsMode     = "release-test-iperfs-mode"
 	FlagOnReadyOnly               = "on-ready-only"
 )
+
+// iperfsModeUsage is the shared usage text for the iperf3 mode flags.
+var iperfsModeUsage = fmt.Sprintf("how much traffic each iperf3 probe sends: %q measures throughput, %q only proves the TCP path works", hhfab.IPerfsModeFull, hhfab.IPerfsModeSmoke)
+
+func parseIPerfsMode(flag, value string) (hhfab.IPerfsMode, error) {
+	mode := hhfab.IPerfsMode(value)
+	if mode != "" && !slices.Contains(hhfab.IPerfsModes, mode) {
+		return "", fmt.Errorf("invalid --%s %q, must be one of %v", flag, value, hhfab.IPerfsModes) //nolint:goerr113
+	}
+
+	return mode, nil
+}
 
 func main() {
 	if err := Run(context.Background()); err != nil {
@@ -1137,6 +1153,18 @@ func Run(ctx context.Context) error {
 								Aliases: []string{"rt-or"},
 								Usage:   "run only the special on-ready suite (used when --ready=release-test)",
 							},
+							&cli.IntFlag{
+								Name:        FlagReleaseTestIPerfs,
+								Aliases:     []string{"rt-iperfs"},
+								Usage:       "seconds of iperf3 test to run between each pair of reachable servers, 0 to disable (used when --ready=release-test)",
+								DefaultText: "3",
+							},
+							&cli.StringFlag{
+								Name:    FlagReleaseTestIPerfsMode,
+								Aliases: []string{"rt-iperfs-mode"},
+								Usage:   iperfsModeUsage + " (used when --ready=release-test)",
+								Value:   string(hhfab.IPerfsModeFull),
+							},
 							&cli.UintFlag{
 								Category: FlagCatVMSizes,
 								Name:     "control-cpus",
@@ -1209,6 +1237,21 @@ func Run(ctx context.Context) error {
 								return err
 							}
 
+							rtIPerfsMode, err := parseIPerfsMode(FlagReleaseTestIPerfsMode, c.String(FlagReleaseTestIPerfsMode))
+							if err != nil {
+								return err
+							}
+							var rtIPerfs *int
+							// Only override the suite defaults when the flag was
+							// actually passed.
+							if c.IsSet(FlagReleaseTestIPerfs) {
+								iperfs := c.Int(FlagReleaseTestIPerfs)
+								if iperfs < 0 {
+									return fmt.Errorf("--%s must be >= 0, got %d", FlagReleaseTestIPerfs, iperfs) //nolint:goerr113
+								}
+								rtIPerfs = &iperfs
+							}
+
 							if err := hhfab.VLABUp(ctx, workDir, cacheDir, hhfab.VLABUpOpts{
 								HydrateMode:          hhfab.HydrateMode(hydrateMode),
 								ReCreate:             c.Bool(FlagNameReCreate),
@@ -1248,6 +1291,8 @@ func Run(ctx context.Context) error {
 									ReleaseTestRegexes:       c.StringSlice(FlagReleaseTestRegexes),
 									ReleaseTestRegexesInvert: c.Bool(FlagReleaseTestRegexesInvert),
 									ReleaseTestOnReadyOnly:   c.Bool(FlagReleaseTestOnReadyOnly),
+									ReleaseTestIPerfs:        rtIPerfs,
+									ReleaseTestIPerfsMode:    rtIPerfsMode,
 									InterfaceMTU:             ifMTU,
 								},
 							}); err != nil {
@@ -1551,7 +1596,7 @@ Examples:
 								Value: 5,
 							},
 							&cli.IntFlag{
-								Name:  "iperfs",
+								Name:  FlagIPerfs,
 								Usage: "seconds of iperf3 test to run between each pair of reachable servers (0 to disable)",
 								Value: 10,
 							},
@@ -1559,6 +1604,11 @@ Examples:
 								Name:  FlagIPerfsSpeed,
 								Usage: "minimum speed in Mbits/s for iperf3 test to consider successful (0 to not check speeds)",
 								Value: 8200,
+							},
+							&cli.StringFlag{
+								Name:  FlagIPerfsMode,
+								Usage: iperfsModeUsage,
+								Value: string(hhfab.IPerfsModeFull),
 							},
 							&cli.IntFlag{
 								Name:  "curls",
@@ -1602,11 +1652,19 @@ Examples:
 							if cliTOS > 255 {
 								return fmt.Errorf("tos value must be between 0 and 255, got %d", cliTOS) //nolint:goerr113
 							}
+							iperfsMode, err := parseIPerfsMode(FlagIPerfsMode, c.String(FlagIPerfsMode))
+							if err != nil {
+								return err
+							}
+							if iperfsMode.Smoke() && c.IsSet(FlagIPerfsSpeed) {
+								slog.Warn("iperf3 smoke probes measure no throughput, ignoring", "flag", FlagIPerfsSpeed)
+							}
 							if err := hhfab.DoVLABTestConnectivity(ctx, workDir, cacheDir, hhfab.TestConnectivityOpts{
 								WaitSwitchesReady: c.Bool("wait-switches-ready"),
 								PingsCount:        c.Int("pings"),
-								IPerfsSeconds:     c.Int("iperfs"),
+								IPerfsSeconds:     c.Int(FlagIPerfs),
 								IPerfsMinSpeed:    c.Float64(FlagIPerfsSpeed),
+								IPerfsMode:        iperfsMode,
 								CurlsCount:        c.Int("curls"),
 								Sources:           c.StringSlice("source"),
 								Destinations:      c.StringSlice("destination"),
@@ -1723,6 +1781,16 @@ Examples:
 								Usage: "minimum speed in Mbits/s for iperf3 test to consider successful (0 to not check speeds)",
 								Value: 8200,
 							},
+							&cli.IntFlag{
+								Name:        FlagIPerfs,
+								Usage:       "seconds of iperf3 test to run between each pair of reachable servers (0 to disable)",
+								DefaultText: "3, or 10 with --extended",
+							},
+							&cli.StringFlag{
+								Name:  FlagIPerfsMode,
+								Usage: iperfsModeUsage,
+								Value: string(hhfab.IPerfsModeFull),
+							},
 							&cli.BoolFlag{
 								Name:    FlagOnReadyOnly,
 								Aliases: []string{"on-ready", "o"},
@@ -1734,6 +1802,13 @@ Examples:
 							iperfsSpeed := c.Float64(FlagIPerfsSpeed)
 							if iperfsSpeed < 0 {
 								return fmt.Errorf("--%s must be >= 0, got %g", FlagIPerfsSpeed, iperfsSpeed) //nolint:goerr113
+							}
+							iperfsMode, err := parseIPerfsMode(FlagIPerfsMode, c.String(FlagIPerfsMode))
+							if err != nil {
+								return err
+							}
+							if iperfsMode.Smoke() && c.IsSet(FlagIPerfsSpeed) {
+								slog.Warn("iperf3 smoke probes measure no throughput, ignoring", "flag", FlagIPerfsSpeed)
 							}
 							opts := hhfab.ReleaseTestOpts{
 								Regexes:        c.StringSlice(FlagRegEx),
@@ -1747,7 +1822,17 @@ Examples:
 								ListTests:      c.Bool(FlagListTests),
 								ShowTechDump:   c.Bool(FlagShowTech),
 								IPerfsMinSpeed: iperfsSpeed,
+								IPerfsMode:     iperfsMode,
 								OnReadyTest:    c.Bool(FlagOnReadyOnly),
+							}
+							// Only override the suite defaults, which depend on
+							// --extended, when the flag was actually passed.
+							if c.IsSet(FlagIPerfs) {
+								iperfs := c.Int(FlagIPerfs)
+								if iperfs < 0 {
+									return fmt.Errorf("--%s must be >= 0, got %d", FlagIPerfs, iperfs) //nolint:goerr113
+								}
+								opts.IPerfsSeconds = &iperfs
 							}
 							if err := hhfab.DoVLABReleaseTest(ctx, workDir, cacheDir, opts); err != nil {
 								return fmt.Errorf("release-test: %w", err)

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -1659,11 +1659,19 @@ Examples:
 							if iperfsMode.Smoke() && c.IsSet(FlagIPerfsSpeed) {
 								slog.Warn("iperf3 smoke probes measure no throughput, ignoring", "flag", FlagIPerfsSpeed)
 							}
+							iperfs := c.Int(FlagIPerfs)
+							if iperfs < 0 {
+								return fmt.Errorf("--%s must be >= 0, got %d", FlagIPerfs, iperfs) //nolint:goerr113
+							}
+							iperfsSpeed := c.Float64(FlagIPerfsSpeed)
+							if iperfsSpeed < 0 {
+								return fmt.Errorf("--%s must be >= 0, got %g", FlagIPerfsSpeed, iperfsSpeed) //nolint:goerr113
+							}
 							if err := hhfab.DoVLABTestConnectivity(ctx, workDir, cacheDir, hhfab.TestConnectivityOpts{
 								WaitSwitchesReady: c.Bool("wait-switches-ready"),
 								PingsCount:        c.Int("pings"),
-								IPerfsSeconds:     c.Int(FlagIPerfs),
-								IPerfsMinSpeed:    c.Float64(FlagIPerfsSpeed),
+								IPerfsSeconds:     iperfs,
+								IPerfsMinSpeed:    iperfsSpeed,
 								IPerfsMode:        iperfsMode,
 								CurlsCount:        c.Int("curls"),
 								Sources:           c.StringSlice("source"),

--- a/pkg/hhfab/matrix.go
+++ b/pkg/hhfab/matrix.go
@@ -601,7 +601,8 @@ func (c *Config) TestConnectivityWithMatrix(ctx context.Context, vlab *VLAB, opt
 	if matrix == nil {
 		return fmt.Errorf("connectivity matrix must be non-nil") //nolint:goerr113
 	}
-	if opts.PingsCount == 0 && opts.IPerfsSeconds == 0 && opts.CurlsCount == 0 {
+	// <= 0 rather than == 0: see the same guard in TestConnectivity.
+	if opts.PingsCount <= 0 && opts.IPerfsSeconds <= 0 && opts.CurlsCount <= 0 {
 		return fmt.Errorf("at least one of pings, iperfs or curls should be enabled") //nolint:goerr113
 	}
 	start := time.Now()

--- a/pkg/hhfab/matrix.go
+++ b/pkg/hhfab/matrix.go
@@ -436,7 +436,7 @@ func runMatrixServerServerPhase(ctx context.Context, opts TestConnectivityOpts, 
 
 			expected := reachabilityFromExpectation(entry)
 			bidir := false
-			if opts.IPerfsSeconds > 0 && expected.Reachable && deps.inSources(dst.Server.Name) && deps.inDestinations(src.Server.Name) {
+			if opts.IPerfsSeconds > 0 && !opts.IPerfsMode.Smoke() && expected.Reachable && deps.inSources(dst.Server.Name) && deps.inDestinations(src.Server.Name) {
 				reverse := matrix.Lookup(dst, src, ProtoPort{})
 				if reverse.Verdict == VerdictAllow {
 					// bidir iperf3 uses one TCP session; both halves share
@@ -753,9 +753,8 @@ func runMatrixIperfPortForward(ctx context.Context, opts TestConnectivityOpts, i
 	}
 	defer iperfs.Release(1)
 
-	secs := opts.IPerfsSeconds
-	cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 -J -c %s -p %d -t %d",
-		secs+25, toIP.String(), toPort, secs)
+	timeoutSecs, iperfArgs := iperf3ClientArgs(opts, toIP, toPort, 1, false)
+	cmd := fmt.Sprintf("toolbox -E LD_PRELOAD=/lib/x86_64-linux-gnu/libgcc_s.so.1 -q timeout %d iperf3 %s", timeoutSecs, iperfArgs)
 	if _, _, iperfErr := retrySSHCmd(ctx, ssh, cmd, from); iperfErr != nil {
 		return &IperfError{Source: from, Destination: target, ClientMsg: iperfErr.Error()}
 	}

--- a/pkg/hhfab/rt_base.go
+++ b/pkg/hhfab/rt_base.go
@@ -105,6 +105,16 @@ func makeTestCtx(ctx context.Context, kube kclient.Client, setupOpts SetupVPCsOp
 		testCtx.tcOpts.IPerfsSeconds = 10
 		testCtx.tcOpts.CurlsCount = 3
 	}
+	testCtx.tcOpts.IPerfsMode = rtOpts.IPerfsMode
+	if rtOpts.IPerfsSeconds != nil {
+		testCtx.tcOpts.IPerfsSeconds = *rtOpts.IPerfsSeconds
+		if testCtx.tcOpts.IPerfsSeconds == 0 {
+			slog.Info("iperf3 probes disabled, tests that only probe with iperf3 will be skipped")
+		}
+	}
+	if testCtx.tcOpts.IPerfsMode.Smoke() && testCtx.tcOpts.IPerfsSeconds > 0 {
+		slog.Info("Running iperf3 probes in smoke mode, no throughput is measured")
+	}
 	testCtx.wipeBetweenTests = wipeBetweenTests
 	testCtx.extended = rtOpts.Extended
 	testCtx.failFast = rtOpts.FailFast
@@ -285,6 +295,7 @@ type SkipFlags struct {
 	NoLoki            bool `xml:"-"` // skip if Loki is not configured or available
 	NoProm            bool `xml:"-"` // skip if Prometheus is not configured or available
 	NoServers         bool `xml:"-"` // skip if there are no servers in the fabric
+	NoIperf           bool `xml:"-"` // skip if iperf3 probes are disabled
 
 	/* Note about subinterfaces; they are required in the following cases:
 	 * 1. when using VPC loopback workaround - it's applied when we have a pair of vpcs or vpc and external both attached on a switch with peering between them
@@ -330,6 +341,9 @@ func (sf *SkipFlags) PrettyPrint() string {
 	}
 	if sf.NoProm {
 		parts = append(parts, "NoProm")
+	}
+	if sf.NoIperf {
+		parts = append(parts, "NoIperf")
 	}
 	if len(parts) == 0 {
 		return "None"
@@ -638,115 +652,52 @@ func failAllTests(suite *JUnitTestSuite, err error) *JUnitTestSuite {
 	return suite
 }
 
+// skipReason returns the message explaining why the test cannot run in an
+// environment described by env, or an empty string when it can run.
+func (test *JUnitTestCase) skipReason(env SkipFlags) string {
+	switch {
+	case test.SkipFlags.ExtendedOnly && !env.ExtendedOnly:
+		return "Extended tests are not enabled"
+	case test.SkipFlags.VirtualSwitch && env.VirtualSwitch:
+		return "There are virtual switches"
+	case test.SkipFlags.NoBGPExternals && env.NoBGPExternals:
+		return "There are no viable externals"
+	case test.SkipFlags.NoStaticExternals && env.NoStaticExternals:
+		return "There are no viable static externals"
+	case test.SkipFlags.SubInterfaces && env.SubInterfaces:
+		return "There are switches that do not support subinterfaces"
+	case test.SkipFlags.RoCE && env.RoCE:
+		return "There are no switches that support RoCE"
+	case test.SkipFlags.NoFabricLink && env.NoFabricLink:
+		return "There are no fabric (i.e. spine-leaf) links between the switches"
+	case test.SkipFlags.NoMeshLink && env.NoMeshLink:
+		return "There are no mesh (i.e. leaf-leaf) links between the switches"
+	case test.SkipFlags.NoGateway && env.NoGateway:
+		return "Gateway is not enabled or no gateways available"
+	case test.SkipFlags.NoLoki && env.NoLoki:
+		return "Loki is not configured or available"
+	case test.SkipFlags.NoProm && env.NoProm:
+		return "Prometheus is not configured or available"
+	case test.SkipFlags.NoServers && env.NoServers:
+		return "There are no servers in the fabric"
+	case test.SkipFlags.NoIperf && env.NoIperf:
+		return "iperf3 probes are disabled"
+	}
+
+	return ""
+}
+
 func selectAndRunSuite(ctx context.Context, testCtx *VPCPeeringTestCtx, suite *JUnitTestSuite, regexes []*regexp.Regexp, invertRegex bool, skipFlags SkipFlags) (*JUnitTestSuite, error) {
 	suite = regexpSelection(regexes, invertRegex, suite)
 	for i, test := range suite.TestCases {
 		if test.Skipped != nil {
 			continue
 		}
-		if test.SkipFlags.ExtendedOnly && !skipFlags.ExtendedOnly {
+		if reason := test.skipReason(skipFlags); reason != "" {
 			suite.TestCases[i].Skipped = &Skipped{
-				Message: "Extended tests are not enabled",
+				Message: reason,
 			}
 			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.VirtualSwitch && skipFlags.VirtualSwitch {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are virtual switches",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoBGPExternals && skipFlags.NoBGPExternals {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are no viable externals",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoStaticExternals && skipFlags.NoStaticExternals {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are no viable static externals",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.SubInterfaces && skipFlags.SubInterfaces {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are switches that do not support subinterfaces",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.RoCE && skipFlags.RoCE {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are no switches that support RoCE",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoFabricLink && skipFlags.NoFabricLink {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are no fabric (i.e. spine-leaf) links between the switches",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoMeshLink && skipFlags.NoMeshLink {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are no mesh (i.e. leaf-leaf) links between the switches",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoGateway && skipFlags.NoGateway {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "Gateway is not enabled or no gateways available",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoLoki && skipFlags.NoLoki {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "Loki is not configured or available",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoProm && skipFlags.NoProm {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "Prometheus is not configured or available",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoServers && skipFlags.NoServers {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are no servers in the fabric",
-			}
-			suite.Skipped++
-
-			continue
-		}
-		if test.SkipFlags.NoStaticExternals && skipFlags.NoStaticExternals {
-			suite.TestCases[i].Skipped = &Skipped{
-				Message: "There are no static externals configured",
-			}
-			suite.Skipped++
-
-			continue
 		}
 	}
 	if suite.Skipped == suite.Tests {
@@ -872,6 +823,7 @@ func RunReleaseTestSuites(ctx context.Context, vlabCfg *Config, vlab *VLAB, rtOp
 	skipFlags := SkipFlags{
 		ExtendedOnly: rtOpts.Extended,
 		NoServers:    noServers,
+		NoIperf:      testCtx.tcOpts.IPerfsSeconds <= 0,
 	}
 	connList := &wiringapi.ConnectionList{}
 	if err := kube.List(ctx, connList, kclient.MatchingLabels{wiringapi.LabelConnectionType: wiringapi.ConnectionTypeMesh}); err != nil {

--- a/pkg/hhfab/rt_base_test.go
+++ b/pkg/hhfab/rt_base_test.go
@@ -109,3 +109,50 @@ func TestRegexpSelection(t *testing.T) {
 		})
 	}
 }
+
+func TestSkipReason(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		test     SkipFlags
+		env      SkipFlags
+		expected string
+	}{
+		{
+			name: "no requirements",
+			env:  SkipFlags{NoIperf: true, NoGateway: true},
+		},
+		{
+			name: "iperf required and available",
+			test: SkipFlags{NoIperf: true},
+		},
+		{
+			name:     "iperf required and disabled",
+			test:     SkipFlags{NoIperf: true},
+			env:      SkipFlags{NoIperf: true},
+			expected: "iperf3 probes are disabled",
+		},
+		{
+			name:     "gateway wins over iperf",
+			test:     SkipFlags{NoGateway: true, NoIperf: true},
+			env:      SkipFlags{NoGateway: true, NoIperf: true},
+			expected: "Gateway is not enabled or no gateways available",
+		},
+		{
+			name:     "extended only",
+			test:     SkipFlags{ExtendedOnly: true},
+			expected: "Extended tests are not enabled",
+		},
+		{
+			name: "extended only and enabled",
+			test: SkipFlags{ExtendedOnly: true},
+			env:  SkipFlags{ExtendedOnly: true},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tc := JUnitTestCase{Name: test.name, SkipFlags: test.test}
+			if reason := tc.skipReason(test.env); reason != test.expected {
+				t.Errorf("skipReason = %q, expected %q", reason, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/hhfab/rt_nat_external_tests.go
+++ b/pkg/hhfab/rt_nat_external_tests.go
@@ -999,6 +999,7 @@ func getExternalNATTestCases() []JUnitTestCase {
 			SkipFlags: SkipFlags{
 				NoGateway:      true,
 				NoBGPExternals: true,
+				NoIperf:        true,
 			},
 		},
 		{
@@ -1039,6 +1040,7 @@ func getExternalNATTestCases() []JUnitTestCase {
 			SkipFlags: SkipFlags{
 				NoGateway:         true,
 				NoStaticExternals: true,
+				NoIperf:           true,
 			},
 		},
 		{

--- a/pkg/hhfab/rt_nat_tests.go
+++ b/pkg/hhfab/rt_nat_tests.go
@@ -941,6 +941,7 @@ func getNATTestCases() []JUnitTestCase {
 			F:    gatewayPeeringPortForwardNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
+				NoIperf:   true,
 			},
 		},
 		{
@@ -948,6 +949,7 @@ func getNATTestCases() []JUnitTestCase {
 			F:    gatewayPeeringMasqueradePortForwardNATTest,
 			SkipFlags: SkipFlags{
 				NoGateway: true,
+				NoIperf:   true,
 			},
 		},
 	}

--- a/pkg/hhfab/rt_single_vpc_suite.go
+++ b/pkg/hhfab/rt_single_vpc_suite.go
@@ -107,6 +107,7 @@ func makeSingleVPCSuite() *JUnitTestSuite {
 			SkipFlags: SkipFlags{
 				RoCE:      true,
 				NoServers: true,
+				NoIperf:   true,
 			},
 		},
 	}
@@ -1591,6 +1592,11 @@ outer:
 
 	dscpOpts := testCtx.tcOpts
 	dscpOpts.IPerfsDSCP = 24 // Mapped to traffic class 3
+	// The UC3 counter thresholds below need sustained traffic, which a smoke
+	// probe cannot produce, so this test always sends at full rate. Its
+	// traffic stays within the leaf and never reaches the gateway dataplane,
+	// which is what smoke mode exists to spare.
+	dscpOpts.IPerfsMode = IPerfsModeFull
 
 	slog.Debug("Clearing queue counters on switch", "switch", swName)
 	if err := execConfigCmd(ctx, swSSH, swName, "clear queue counters"); err != nil {

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -2363,7 +2363,10 @@ func runPingIperfPair(ctx context.Context, opts TestConnectivityOpts, args pingI
 }
 
 func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConnectivityOpts) error {
-	if opts.PingsCount == 0 && opts.IPerfsSeconds == 0 && opts.CurlsCount == 0 {
+	// <= 0 rather than == 0: a negative count disables its probe further down
+	// the same as 0 does, so comparing to 0 alone would let an all-negative
+	// opts through and report success without running anything.
+	if opts.PingsCount <= 0 && opts.IPerfsSeconds <= 0 && opts.CurlsCount <= 0 {
 		return fmt.Errorf("at least one of pings, iperfs or curls should be enabled")
 	}
 	start := time.Now()
@@ -3739,6 +3742,9 @@ func ReleaseTest(ctx context.Context, c *Config, vlab *VLAB, opts ReleaseTestOpt
 	}
 	if opts.IPerfsMode != "" && !slices.Contains(IPerfsModes, opts.IPerfsMode) {
 		return fmt.Errorf("invalid iperfs mode %q, must be one of %v", opts.IPerfsMode, IPerfsModes)
+	}
+	if opts.IPerfsSeconds != nil && *opts.IPerfsSeconds < 0 {
+		return fmt.Errorf("invalid iperfs seconds %d, must be >= 0", *opts.IPerfsSeconds)
 	}
 	if opts.IPerfsSeconds != nil && *opts.IPerfsSeconds == 0 && opts.IPerfsMode.Smoke() {
 		slog.Warn("iperf3 probes are disabled, ignoring iperfs mode", "mode", opts.IPerfsMode)

--- a/pkg/hhfab/testing.go
+++ b/pkg/hhfab/testing.go
@@ -2197,6 +2197,36 @@ func (ce *CurlError) Error() string {
 		ce.Source, ce.Msg, ce.Expected)
 }
 
+// IPerfsMode selects how much traffic every iperf3 probe puts on the wire.
+type IPerfsMode string
+
+const (
+	// IPerfsModeFull runs iperf3 at line rate for IPerfsSeconds and asserts
+	// the measured throughput against IPerfsMinSpeed.
+	IPerfsModeFull IPerfsMode = "full"
+	// IPerfsModeSmoke transfers a single small block, just enough to prove
+	// the TCP path works, and asserts nothing about speed.
+	IPerfsModeSmoke IPerfsMode = "smoke"
+
+	// iperf3SmokeBytes is the total volume transferred in smoke mode, and
+	// iperf3SmokeBlockSize the size of a single write. iperf3 sends whole
+	// blocks and stops once the total is reached, so without the matching
+	// block size a small total would still put one default 128K block on
+	// the wire.
+	iperf3SmokeBytes     = "1K"
+	iperf3SmokeBlockSize = "1K"
+)
+
+// IPerfsModes lists the accepted values of IPerfsMode. The empty value is
+// also accepted and resolves to IPerfsModeFull.
+var IPerfsModes = []IPerfsMode{IPerfsModeFull, IPerfsModeSmoke}
+
+// Smoke reports whether the mode is the low-volume one. The zero value is
+// full, so opts built without the field keep the throughput behavior.
+func (m IPerfsMode) Smoke() bool {
+	return m == IPerfsModeSmoke
+}
+
 type TestConnectivityOpts struct {
 	WaitSwitchesReady bool
 	PingsCount        int
@@ -2206,6 +2236,7 @@ type TestConnectivityOpts struct {
 	IPerfsParallel    int64
 	IPerfsDSCP        uint8
 	IPerfsTOS         uint8
+	IPerfsMode        IPerfsMode
 	CurlsCount        int
 	CurlsParallel     int64
 	Sources           []string
@@ -2513,7 +2544,7 @@ func (c *Config) TestConnectivity(ctx context.Context, vlab *VLAB, opts TestConn
 					clientA := clientAR.(*sshutil.Config)
 
 					bidir := false
-					if opts.IPerfsSeconds > 0 && expectedReachable.Reachable && requestedPairs[[2]string{serverB, serverA}] {
+					if opts.IPerfsSeconds > 0 && !opts.IPerfsMode.Smoke() && expectedReachable.Reachable && requestedPairs[[2]string{serverB, serverA}] {
 						revReachable, err := IsServerReachable(ctx, kube, serverB, serverA, c.Fab.Spec.Config.Gateway.Enable)
 						if err != nil {
 							errChan <- fmt.Errorf("checking reverse reachability for bidir: %w", err)
@@ -3146,6 +3177,12 @@ func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string,
 	}
 
 	iPerfsMinSpeed := opts.IPerfsMinSpeed
+	// Smoke probes transfer a single small block, so there is no meaningful
+	// speed to assert. Zeroing the floor here also neutralizes the low-speed
+	// retry loop below, which only fires on SendSpeedTooLow.
+	if opts.IPerfsMode.Smoke() {
+		iPerfsMinSpeed = 0
+	}
 	// Gateway peering uses kernel-based dataplane; observed sustained throughput on HLAB is
 	// ~5-6.5 Gbps with periodic real packet loss, so cap floor at 5000 to avoid flake.
 	if reachability.Reason == ReachabilityReasonGatewayPeering {
@@ -3199,6 +3236,47 @@ func checkIPerf(ctx context.Context, opts TestConnectivityOpts, from, to string,
 	return lastErrors
 }
 
+// iperf3FullStreams is the number of parallel streams a full-mode throughput
+// probe between two servers uses.
+const iperf3FullStreams = 4
+
+// iperf3SmokeTimeoutSeconds bounds a smoke probe. The transfer itself is
+// instant, so the budget only has to cover connection setup.
+const iperf3SmokeTimeoutSeconds = 25
+
+// iperf3ClientArgs builds the iperf3 client invocation shared by the
+// server-to-server throughput probe and the port-forward NAT probe: the
+// `timeout` budget in seconds and the iperf3 arguments themselves. Each
+// caller wraps them in its own way of reaching an iperf3 binary. toPort 0
+// leaves iperf3 on its default port, and streams and bidir only apply in
+// full mode.
+func iperf3ClientArgs(opts TestConnectivityOpts, toIP netip.Addr, toPort uint16, streams int, bidir bool) (int, string) {
+	args := fmt.Sprintf("-J -c %s", toIP.String())
+	if toPort > 0 {
+		args += fmt.Sprintf(" -p %d", toPort)
+	}
+
+	timeout := iperf3SmokeTimeoutSeconds
+	if opts.IPerfsMode.Smoke() {
+		args += fmt.Sprintf(" -P 1 -n %s -l %s", iperf3SmokeBytes, iperf3SmokeBlockSize)
+	} else {
+		timeout = opts.IPerfsSeconds + 25
+		args += fmt.Sprintf(" -P %d -t %d", streams, opts.IPerfsSeconds)
+		if bidir {
+			args += " --bidir"
+		}
+	}
+
+	if opts.IPerfsDSCP > 0 {
+		args += fmt.Sprintf(" --dscp %d", opts.IPerfsDSCP)
+	}
+	if opts.IPerfsTOS > 0 {
+		args += fmt.Sprintf(" --tos %d", opts.IPerfsTOS)
+	}
+
+	return timeout, args
+}
+
 func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to string, fromSSH *sshutil.Config, toIP netip.Addr, iPerfsMinSpeed float64, bidir bool) []*IperfError {
 	minSpeedStr := asMbps(iPerfsMinSpeed * 1_000_000)
 	// Forward direction: client (`from`) sends to server (`to`).
@@ -3209,25 +3287,18 @@ func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to stri
 		rev = &IperfError{Source: to, Destination: from, MinSpeed: minSpeedStr}
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(opts.IPerfsSeconds+30)*time.Second)
+	timeoutSecs, iperfArgs := iperf3ClientArgs(opts, toIP, 0, iperf3FullStreams, bidir)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSecs+5)*time.Second)
 	defer cancel()
 
-	slog.Debug("Running iperf3", "from", from, "to", to, "bidir", bidir)
+	slog.Debug("Running iperf3", "from", from, "to", to, "bidir", bidir, "mode", opts.IPerfsMode)
 
 	// Run the iperf3 client inside the always-on iperf3 container instead of spawning a per-test
 	// toolbox container on the client VM. The fresh container plus the JSON result buffer can
 	// push the 768 MB server VM into ENOMEM during result aggregation. `docker exec` reuses the
 	// running container's namespaces and adds only the iperf3 client process itself.
-	cmd := fmt.Sprintf("sudo docker exec iperf3 timeout %d iperf3 -P 4 -J -c %s -t %d", opts.IPerfsSeconds+25, toIP.String(), opts.IPerfsSeconds)
-	if bidir {
-		cmd += " --bidir"
-	}
-	if opts.IPerfsDSCP > 0 {
-		cmd += fmt.Sprintf(" --dscp %d", opts.IPerfsDSCP)
-	}
-	if opts.IPerfsTOS > 0 {
-		cmd += fmt.Sprintf(" --tos %d", opts.IPerfsTOS)
-	}
+	cmd := fmt.Sprintf("sudo docker exec iperf3 timeout %d iperf3 %s", timeoutSecs, iperfArgs)
 
 	stdout, stderr, err := retrySSHCmd(ctx, fromSSH, cmd, from)
 	report, parseErr := parseIPerf3Report([]byte(stdout))
@@ -3251,7 +3322,7 @@ func runIPerf3Test(ctx context.Context, opts TestConnectivityOpts, from, to stri
 	fwdSent := report.End.SumSent
 	fwdRcvd := report.End.SumReceived
 	logArgs := []any{
-		"from", from, "to", to, "bidir", bidir,
+		"from", from, "to", to, "bidir", bidir, "mode", opts.IPerfsMode,
 		"sendSpeed", asMbps(fwdSent.BitsPerSecond),
 		"receiveSpeed", asMbps(fwdRcvd.BitsPerSecond),
 		"sent", asMB(float64(fwdSent.Bytes)),
@@ -3649,7 +3720,12 @@ type ReleaseTestOpts struct {
 	ListTests      bool
 	ShowTechDump   bool
 	IPerfsMinSpeed float64
-	OnReadyTest    bool
+	// IPerfsSeconds overrides the per-pair iperf3 duration, 0 disabling
+	// iperf3 altogether. Nil keeps the suite defaults, which depend on
+	// Extended, so callers that do not care must leave it unset.
+	IPerfsSeconds *int
+	IPerfsMode    IPerfsMode
+	OnReadyTest   bool
 }
 
 func ReleaseTest(ctx context.Context, c *Config, vlab *VLAB, opts ReleaseTestOpts) error {
@@ -3660,6 +3736,12 @@ func ReleaseTest(ctx context.Context, c *Config, vlab *VLAB, opts ReleaseTestOpt
 	}
 	if !slices.Contains(vpcapi.VPCModes, opts.VPCMode) {
 		return fmt.Errorf("invalid VPC mode %q, must be one of %v", opts.VPCMode, vpcapi.VPCModes)
+	}
+	if opts.IPerfsMode != "" && !slices.Contains(IPerfsModes, opts.IPerfsMode) {
+		return fmt.Errorf("invalid iperfs mode %q, must be one of %v", opts.IPerfsMode, IPerfsModes)
+	}
+	if opts.IPerfsSeconds != nil && *opts.IPerfsSeconds == 0 && opts.IPerfsMode.Smoke() {
+		slog.Warn("iperf3 probes are disabled, ignoring iperfs mode", "mode", opts.IPerfsMode)
 	}
 
 	return RunReleaseTestSuites(ctx, c, vlab, opts)

--- a/pkg/hhfab/testing_test.go
+++ b/pkg/hhfab/testing_test.go
@@ -375,6 +375,73 @@ rtt min/avg/max/mdev = 0.611/0.912/1.308/0.251 ms
 	}
 }
 
+func TestIPerf3ClientArgs(t *testing.T) {
+	toIP := netip.MustParseAddr("10.0.1.10")
+
+	for _, test := range []struct {
+		name            string
+		opts            TestConnectivityOpts
+		toPort          uint16
+		streams         int
+		bidir           bool
+		expectedTimeout int
+		expected        string
+	}{
+		{
+			name:            "full unset mode",
+			opts:            TestConnectivityOpts{IPerfsSeconds: 3},
+			streams:         iperf3FullStreams,
+			expectedTimeout: 28,
+			expected:        "-J -c 10.0.1.10 -P 4 -t 3",
+		},
+		{
+			name:            "full explicit mode bidir",
+			opts:            TestConnectivityOpts{IPerfsSeconds: 10, IPerfsMode: IPerfsModeFull},
+			streams:         iperf3FullStreams,
+			bidir:           true,
+			expectedTimeout: 35,
+			expected:        "-J -c 10.0.1.10 -P 4 -t 10 --bidir",
+		},
+		{
+			name:            "full with port and marking",
+			opts:            TestConnectivityOpts{IPerfsSeconds: 3, IPerfsDSCP: 24, IPerfsTOS: 96},
+			toPort:          15201,
+			streams:         1,
+			expectedTimeout: 28,
+			expected:        "-J -c 10.0.1.10 -p 15201 -P 1 -t 3 --dscp 24 --tos 96",
+		},
+		{
+			name:            "smoke",
+			opts:            TestConnectivityOpts{IPerfsSeconds: 3, IPerfsMode: IPerfsModeSmoke},
+			streams:         iperf3FullStreams,
+			expectedTimeout: iperf3SmokeTimeoutSeconds,
+			expected:        "-J -c 10.0.1.10 -P 1 -n 1K -l 1K",
+		},
+		{
+			name:            "smoke ignores bidir and duration",
+			opts:            TestConnectivityOpts{IPerfsSeconds: 10, IPerfsMode: IPerfsModeSmoke},
+			streams:         iperf3FullStreams,
+			bidir:           true,
+			expectedTimeout: iperf3SmokeTimeoutSeconds,
+			expected:        "-J -c 10.0.1.10 -P 1 -n 1K -l 1K",
+		},
+		{
+			name:            "smoke with port and marking",
+			opts:            TestConnectivityOpts{IPerfsSeconds: 3, IPerfsMode: IPerfsModeSmoke, IPerfsDSCP: 24, IPerfsTOS: 96},
+			toPort:          15201,
+			streams:         1,
+			expectedTimeout: iperf3SmokeTimeoutSeconds,
+			expected:        "-J -c 10.0.1.10 -p 15201 -P 1 -n 1K -l 1K --dscp 24 --tos 96",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			timeout, args := iperf3ClientArgs(test.opts, toIP, test.toPort, test.streams, test.bidir)
+			require.Equal(t, test.expectedTimeout, timeout)
+			require.Equal(t, test.expected, args)
+		})
+	}
+}
+
 func mapSlice[IN, OUT any](f func(IN) OUT, in []IN) []OUT {
 	out := make([]OUT, len(in))
 	for i, v := range in {

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -109,6 +109,8 @@ type VLABRunOpts struct {
 	ReleaseTestRegexes       []string
 	ReleaseTestRegexesInvert bool
 	ReleaseTestOnReadyOnly   bool
+	ReleaseTestIPerfs        *int
+	ReleaseTestIPerfsMode    IPerfsMode
 	InterfaceMTU             uint16
 }
 
@@ -763,6 +765,8 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 						InvertRegex:    opts.ReleaseTestRegexesInvert,
 						ShowTechDump:   true,
 						IPerfsMinSpeed: 8200,
+						IPerfsSeconds:  opts.ReleaseTestIPerfs,
+						IPerfsMode:     opts.ReleaseTestIPerfsMode,
 						OnReadyTest:    opts.ReleaseTestOnReadyOnly,
 					}
 					slog.Debug("Running release-test", "opts", releaseTestOpts)


### PR DESCRIPTION
Release tests probe every reachable pair with ping and iperf3, and external peerings with curl. The iperf3 probe was introduced to catch traffic being forwarded by the switch CPU instead of the ASIC, which is rare now, and its volume is a problem when the gateway dataplane runs with debug logging: a 3 second run at line rate produces millions of log lines and degrades the dataplane.

Two new flags, both defaulting to current behavior:

`--iperfs <seconds>` sets the per-pair duration, mirroring `test-connectivity`. `0` disables iperf3 altogether, and the five tests whose only probe is iperf3 then report SKIP rather than passing without probing anything: the four port-forward NAT tests (the port-forward phase is gated on the duration, and the server-to-server phase skips those pairs by design) and the RoCE test (it asserts on queue counters fed by DSCP-marked iperf3 traffic). It only overrides the suite default, 3 seconds or 10 with `--extended`, when actually passed.

`--iperfs-mode full|smoke` keeps every iperf3 probe but shrinks it. `smoke` sends `-P 1 -n 1K -l 1K`, one TCP segment, with no throughput assertion and no bidirectional session. Both `-n` and `-l` are needed: iperf3 writes in `-l` sized blocks and stops once the total is reached, so `-n 1K` alone still puts one default 128K block on the wire.

Both are also available as `--release-test-iperfs` and `--release-test-iperfs-mode` on `vlab up --ready=release-test`, and `--iperfs-mode` is on `test-connectivity` too.

The RoCE test pins full mode on its own opts copy: its UC3 counter thresholds need sustained traffic, and its traffic stays within the leaf and never reaches the gateway dataplane, which is what smoke mode exists to spare.

Two supporting refactors: the server-to-server and port-forward NAT probes had independent iperf3 command lines and now share one builder, and the skip flag chain in `selectAndRunSuite` became a pure `skipReason` method. Both are covered by new table tests.

## Test plan

- [ ] `release-test --iperfs=0 -r "Port Forward|RoCE"` reports the five tests SKIP with a reason
- [ ] `test-connectivity --iperfs-mode=smoke` passes and logs `mode=smoke`
- [ ] `release-test --iperfs-mode=smoke -r "Port Forward"` passes, so port translation is still verified end to end
- [ ] `release-test --iperfs-mode=smoke -r "RoCE"` passes via the pinned full-rate probe
- [ ] tcpdump packet count per smoke probe, against a curl probe as the reference
- [ ] dataplane debug log line count for one gateway peering test in each mode
- [ ] one default run with neither flag, confirming unchanged behavior
