### PR TITLE
ci: extend docker readiness wait from 30s to 90s

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Docker readiness check
         run: |
-          for i in $(seq 1 30); do
+          for i in $(seq 1 90); do
             docker info > /dev/null 2>&1 && echo "Docker ready after ${i}s" && break
             echo "Waiting for Docker... ${i}s"
             sleep 1


### PR DESCRIPTION
Each hlab job gets a fresh per-pod dockerd, not the host's long-lived one, so the readiness check races that daemon's cold start. On the single hlab node (env-ci-1) this cold start also shares the box with a persistent background precache loop and a zot registry, which can push the daemon's startup past 30s. Extends the wait from 30s to 90s.

We are not hitting this on a daily basis. Last week twice. But I think it's worth trying.

```
HLAB Docker Daemon Unavailable
   Jobs: 2
   Description: HLAB runner docker daemon not running during test-docs build step
   Source filter: ^ci/.*/h-
   Issue: https://github.com/githedgehog/fabricator/issues/1742 ○
   Example: Cannot connect to the Docker daemon at unix:///run/docker/docker.sock. Is the docker daemon running?

   Affected jobs:
     ✗ https://github.com/githedgehog/fabricator/actions/runs/30983151862/job/92232892305 (master: h-gw-iso-l2vni-rt / Docker readiness check) [env-ci-1.l 08-05 09:04→09:05]
     ✗ https://github.com/githedgehog/fabricator/actions/runs/30532164023/job/90840722225 (ema/test-connectivity-review: h-gw-iso-l2vni-rt / Docker readiness check) [env-ci-1.l 07-30 12:43→12:44]
```

Fixes #1742