### PR TITLE
feat: add support for extra hhfab cache dirs

### DIFF
--- a/.github/workflows/run-vlab.yaml
+++ b/.github/workflows/run-vlab.yaml
@@ -106,6 +106,7 @@ env:
   slug: "${{ inputs.hybrid && 'h' || 'v' }}-${{ inputs.upgradefrom && 'up' || '' }}${{ inputs.upgradefrom }}${{ inputs.upgradefrom && '-' || '' }}${{ inputs.fabricmode != 'spine-leaf' && inputs.fabricmode || '' }}${{ inputs.mesh && 'mesh-' || '' }}${{ inputs.gateway && 'gw-' || '' }}${{ inputs.includeonie && 'onie-' || '' }}${{ inputs.buildmode }}-${{ inputs.vpcmode }}${{ inputs.releasetest && '-rt' || '' }}${{ inputs.releasetest_regex != '' && 'r' || '' }}${{ (inputs.custom_init_args != '' || inputs.custom_gen_args != '') && '-custom' || '' }}"
   # env vars to configure hhfab
   HHFAB_REG_REPO: 127.0.0.1:30000
+  HHFAB_EXTRA_CACHE_DIRS: /hostcache/.hhfab-cache
   HHFAB_VLAB_COLLECT: true
   HHFAB_VLAB_COLLECT_FORCE: ${{ inputs.collect_show_tech }}
 
@@ -165,6 +166,7 @@ jobs:
           path: "./lab-ci"
 
       - name: Pre-populate hhfab-cache
+        if: ${{ inputs.upgradefrom == '26.01' || inputs.upgradefrom == '26.02' }}
         run: |
           if [ -d "/hostcache/.hhfab-cache" ]; then
             rsync -aW --inplace --exclude='download-*' --stats /hostcache/.hhfab-cache ~/

--- a/cmd/hhfab/main.go
+++ b/cmd/hhfab/main.go
@@ -168,6 +168,15 @@ func Run(ctx context.Context) error {
 		Category:    FlagCatGlobal,
 	}
 
+	extraCacheDirs := cli.StringSlice{}
+	extraCacheDirsFlag := &cli.StringSliceFlag{
+		Name:        "extra-cache-dir",
+		Usage:       "additional read-only cache `DIR`s (same layout as --cache-dir) to look up already downloaded files in, comma-separated or repeated",
+		EnvVars:     []string{"HHFAB_EXTRA_CACHE_DIRS"},
+		Destination: &extraCacheDirs,
+		Category:    FlagCatGlobal,
+	}
+
 	fabricModes := []string{}
 	for _, m := range meta.FabricModes {
 		fabricModes = append(fabricModes, string(m))
@@ -404,6 +413,10 @@ func Run(ctx context.Context) error {
 				args = append(args, "cache", cacheDir)
 			}
 
+			if len(extraCacheDirs.Value()) > 0 {
+				args = append(args, "extraCaches", extraCacheDirs.Value())
+			}
+
 			slog.Info("Hedgehog Fabricator", args...)
 
 			return nil
@@ -413,6 +426,7 @@ func Run(ctx context.Context) error {
 	defaultFlags := []cli.Flag{
 		workDirFlag,
 		cacheDirFlag,
+		extraCacheDirsFlag,
 		verboseFlag,
 		briefFlag,
 	}
@@ -849,7 +863,7 @@ func Run(ctx context.Context) error {
 				}),
 				Before: before(false),
 				Action: func(c *cli.Context) error {
-					if err := hhfab.Build(ctx, workDir, cacheDir, hhfab.BuildOpts{
+					if err := hhfab.Build(ctx, workDir, cacheDir, extraCacheDirs.Value(), hhfab.BuildOpts{
 						HydrateMode:          hhfab.HydrateMode(hydrateMode),
 						BuildMode:            recipe.BuildMode(c.String(FlagNameBuildMode)),
 						BuildControls:        c.Bool(FlagNameBuildControls),
@@ -878,7 +892,7 @@ func Run(ctx context.Context) error {
 				}),
 				Before: before(false),
 				Action: func(c *cli.Context) error {
-					if err := hhfab.Precache(ctx, workDir, cacheDir, hhfab.PrecacheOpts{
+					if err := hhfab.Precache(ctx, workDir, cacheDir, extraCacheDirs.Value(), hhfab.PrecacheOpts{
 						All:  c.Bool("all"),
 						VLAB: c.Bool("vlab"),
 					}); err != nil {
@@ -1209,7 +1223,7 @@ func Run(ctx context.Context) error {
 								return err
 							}
 
-							if err := hhfab.VLABUp(ctx, workDir, cacheDir, hhfab.VLABUpOpts{
+							if err := hhfab.VLABUp(ctx, workDir, cacheDir, extraCacheDirs.Value(), hhfab.VLABUpOpts{
 								HydrateMode:          hhfab.HydrateMode(hydrateMode),
 								ReCreate:             c.Bool(FlagNameReCreate),
 								BuildMode:            recipe.BuildMode(c.String(FlagNameBuildMode)),

--- a/pkg/artificer/downloader.go
+++ b/pkg/artificer/downloader.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -31,17 +32,43 @@ const (
 )
 
 type Downloader struct {
-	cacheDir   string
-	repo       string
-	prefix     string
-	orasClient *auth.Client
-	m          sync.Mutex
+	cacheDir string
+	// extraCacheDirs are read-only caches with the same layout as the primary one, only used for lookups
+	extraCacheDirs []string
+	repo           string
+	prefix         string
+	orasClient     *auth.Client
+	m              sync.Mutex
 }
 
-func NewDownloaderWithDockerCreds(cacheDir, repo, prefix string) (*Downloader, error) {
+func NewDownloaderWithDockerCreds(cacheDir string, extraCacheDirs []string, repo, prefix string) (*Downloader, error) {
 	cacheDir = filepath.Join(cacheDir, Version)
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating cache dir %q: %w", cacheDir, err)
+	}
+
+	extra := []string{}
+	for _, dir := range extraCacheDirs {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+
+		dir = filepath.Join(filepath.Clean(dir), Version)
+		if dir == cacheDir || slices.Contains(extra, dir) {
+			continue
+		}
+
+		if stat, err := os.Stat(dir); err != nil {
+			slog.Warn("Ignoring extra cache dir", "dir", dir, "err", err)
+
+			continue
+		} else if !stat.IsDir() {
+			slog.Warn("Ignoring extra cache dir, not a directory", "dir", dir)
+
+			continue
+		}
+
+		extra = append(extra, dir)
 	}
 
 	storeOpts := credentials.StoreOptions{}
@@ -50,18 +77,63 @@ func NewDownloaderWithDockerCreds(cacheDir, repo, prefix string) (*Downloader, e
 		return nil, fmt.Errorf("creating docker credential store: %w", err)
 	}
 
-	slog.Info("Downloader", "cache", cacheDir, "repo", repo, "prefix", prefix)
+	slog.Info("Downloader", "cache", cacheDir, "extraCaches", extra, "repo", repo, "prefix", prefix)
 
 	return &Downloader{
-		cacheDir: cacheDir,
-		repo:     repo,
-		prefix:   prefix,
+		cacheDir:       cacheDir,
+		extraCacheDirs: extra,
+		repo:           repo,
+		prefix:         prefix,
 		orasClient: &auth.Client{
 			Client:     retry.DefaultClient,
 			Cache:      auth.DefaultCache,
 			Credential: credentials.Credential(credStore),
 		},
 	}, nil
+}
+
+// lookupCache returns the path to the cached entry in the primary or, if not found there, in one of the
+// read-only extra cache dirs. It returns an empty string if the entry isn't cached anywhere.
+func (d *Downloader) lookupCache(cacheName string) (string, error) {
+	cachePath := filepath.Join(d.cacheDir, cacheName)
+
+	stat, err := os.Stat(cachePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("stat cache %q: %w", cachePath, err)
+	}
+	if err == nil {
+		if !stat.IsDir() {
+			return "", fmt.Errorf("cache %q is not a directory", cachePath) //nolint:goerr113
+		}
+
+		slog.Debug("Using cache", "entry", cacheName, "dir", d.cacheDir)
+
+		return cachePath, nil
+	}
+
+	for _, dir := range d.extraCacheDirs {
+		extraPath := filepath.Join(dir, cacheName)
+
+		stat, err := os.Stat(extraPath)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				slog.Debug("Skipping extra cache entry", "path", extraPath, "err", err)
+			}
+
+			continue
+		}
+		if !stat.IsDir() {
+			slog.Debug("Skipping extra cache entry, not a directory", "path", extraPath)
+
+			continue
+		}
+
+		slog.Debug("Using extra cache", "entry", cacheName, "dir", dir)
+
+		return extraPath, nil
+	}
+
+	return "", nil
 }
 
 type CachePathFunc func(cachePath string) error
@@ -126,17 +198,15 @@ func (d *Downloader) getORAS(ctx context.Context, name string, version meta.Vers
 
 	cacheName := name + "@" + string(version)
 	cacheName = strings.ReplaceAll(cacheName, "/", "_") + ".oras"
-	cachePath := filepath.Join(d.cacheDir, cacheName)
 
-	stat, err := os.Stat(cachePath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("stat cache %q: %w", cachePath, err)
-	}
-	if err == nil && !stat.IsDir() {
-		return "", fmt.Errorf("cache %q is not a directory", cachePath) //nolint:goerr113
+	cachePath, err := d.lookupCache(cacheName)
+	if err != nil {
+		return "", err
 	}
 
-	if err != nil && errors.Is(err, os.ErrNotExist) {
+	if cachePath == "" {
+		cachePath = filepath.Join(d.cacheDir, cacheName)
+
 		tmp, err := os.MkdirTemp(d.cacheDir, "download-*")
 		if err != nil {
 			return "", fmt.Errorf("creating temp dir: %w", err)
@@ -258,17 +328,15 @@ func (d *Downloader) getOCI(ctx context.Context, name string, version meta.Versi
 	defer d.m.Unlock()
 
 	cacheName := ociCacheName(name, version)
-	cachePath := filepath.Join(d.cacheDir, cacheName)
 
-	stat, err := os.Stat(cachePath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("stat cache %q: %w", cachePath, err)
-	}
-	if err == nil && !stat.IsDir() {
-		return "", fmt.Errorf("cache %q is not a directory", cachePath) //nolint:goerr113
+	cachePath, err := d.lookupCache(cacheName)
+	if err != nil {
+		return "", err
 	}
 
-	if err != nil && errors.Is(err, os.ErrNotExist) {
+	if cachePath == "" {
+		cachePath = filepath.Join(d.cacheDir, cacheName)
+
 		tmp, err := os.MkdirTemp(d.cacheDir, "download-*")
 		if err != nil {
 			return "", fmt.Errorf("creating temp dir: %w", err)

--- a/pkg/artificer/downloader_test.go
+++ b/pkg/artificer/downloader_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package artificer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDownloaderLookupCache(t *testing.T) {
+	primary := t.TempDir()
+	extra1 := t.TempDir()
+	extra2 := t.TempDir()
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	must(os.MkdirAll(filepath.Join(primary, "in-primary.oras"), 0o700))
+	must(os.MkdirAll(filepath.Join(extra1, "in-primary.oras"), 0o700))
+	must(os.MkdirAll(filepath.Join(extra2, "in-extra2.oci"), 0o700))
+	must(os.WriteFile(filepath.Join(extra1, "not-a-dir.oras"), []byte("x"), 0o600))
+
+	d := &Downloader{cacheDir: primary, extraCacheDirs: []string{extra1, extra2}}
+
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{"in-primary.oras", filepath.Join(primary, "in-primary.oras")}, // primary wins over extra1
+		{"in-extra2.oci", filepath.Join(extra2, "in-extra2.oci")},      // found in second extra
+		{"not-a-dir.oras", ""}, // non-dir in extra is skipped
+		{"missing.oras", ""},   // nowhere
+	} {
+		got, err := d.lookupCache(tc.name)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+
+	// non-dir in primary is an error
+	must(os.WriteFile(filepath.Join(primary, "bad.oras"), []byte("x"), 0o600))
+	if _, err := d.lookupCache("bad.oras"); err == nil {
+		t.Error("expected error for non-dir primary cache entry")
+	}
+}

--- a/pkg/hhfab/cmdair.go
+++ b/pkg/hhfab/cmdair.go
@@ -8,7 +8,7 @@ import (
 )
 
 func AirGenerate(ctx context.Context, workDir, cacheDir string, hMode HydrateMode) error {
-	cfg, err := load(ctx, workDir, cacheDir, true, hMode, "")
+	cfg, err := load(ctx, workDir, cacheDir, nil, true, hMode, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/hhfab/cmdbuild.go
+++ b/pkg/hhfab/cmdbuild.go
@@ -26,8 +26,8 @@ type BuildOpts struct {
 	ObservabilityTargets string
 }
 
-func Build(ctx context.Context, workDir, cacheDir string, opts BuildOpts) error {
-	c, err := load(ctx, workDir, cacheDir, true, opts.HydrateMode, opts.SetJoinToken)
+func Build(ctx context.Context, workDir, cacheDir string, extraCacheDirs []string, opts BuildOpts) error {
+	c, err := load(ctx, workDir, cacheDir, extraCacheDirs, true, opts.HydrateMode, opts.SetJoinToken)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (c *Config) build(ctx context.Context, opts BuildOpts) error {
 		c.Fab.Spec.Config.Observability.Targets.Pyroscope[name] = target
 	}
 
-	d, err := artificer.NewDownloaderWithDockerCreds(c.CacheDir, c.Repo, c.Prefix)
+	d, err := artificer.NewDownloaderWithDockerCreds(c.CacheDir, c.ExtraCacheDirs, c.Repo, c.Prefix)
 	if err != nil {
 		return fmt.Errorf("creating downloader: %w", err)
 	}

--- a/pkg/hhfab/cmdcache.go
+++ b/pkg/hhfab/cmdcache.go
@@ -19,8 +19,8 @@ type PrecacheOpts struct {
 	VLAB bool
 }
 
-func Precache(ctx context.Context, workDir, cacheDir string, opts PrecacheOpts) error {
-	c, err := load(ctx, workDir, cacheDir, false, HydrateModeNever, "")
+func Precache(ctx context.Context, workDir, cacheDir string, extraCacheDirs []string, opts PrecacheOpts) error {
+	c, err := load(ctx, workDir, cacheDir, extraCacheDirs, false, HydrateModeNever, "")
 	if err != nil {
 		return err
 	}
@@ -29,7 +29,7 @@ func Precache(ctx context.Context, workDir, cacheDir string, opts PrecacheOpts) 
 }
 
 func (c *Config) precache(ctx context.Context, opts PrecacheOpts) error {
-	d, err := artificer.NewDownloaderWithDockerCreds(c.CacheDir, c.Repo, c.Prefix)
+	d, err := artificer.NewDownloaderWithDockerCreds(c.CacheDir, c.ExtraCacheDirs, c.Repo, c.Prefix)
 	if err != nil {
 		return fmt.Errorf("creating downloader: %w", err)
 	}

--- a/pkg/hhfab/cmdconfig.go
+++ b/pkg/hhfab/cmdconfig.go
@@ -38,8 +38,9 @@ var (
 )
 
 type Config struct {
-	WorkDir  string
-	CacheDir string
+	WorkDir        string
+	CacheDir       string
+	ExtraCacheDirs []string
 	RegistryConfig
 	Fab      fabapi.Fabricator
 	Controls []fabapi.ControlNode
@@ -265,7 +266,7 @@ func importFabricGateway(c InitConfig) error {
 }
 
 func Validate(ctx context.Context, workDir, cacheDir string, hMode HydrateMode) error {
-	_, err := load(ctx, workDir, cacheDir, true, hMode, "")
+	_, err := load(ctx, workDir, cacheDir, nil, true, hMode, "")
 	if err != nil {
 		return err
 	}
@@ -292,7 +293,7 @@ func Versions(ctx context.Context, workDir, cacheDir string, hMode HydrateMode) 
 		return nil
 	}
 
-	cfg, err := load(ctx, workDir, cacheDir, true, hMode, "")
+	cfg, err := load(ctx, workDir, cacheDir, nil, true, hMode, "")
 	if err != nil {
 		return err
 	}
@@ -309,7 +310,7 @@ func Versions(ctx context.Context, workDir, cacheDir string, hMode HydrateMode) 
 	return nil
 }
 
-func load(ctx context.Context, workDir, cacheDir string, wiringAndHydration bool, mode HydrateMode, setJoinToken string) (*Config, error) {
+func load(ctx context.Context, workDir, cacheDir string, extraCacheDirs []string, wiringAndHydration bool, mode HydrateMode, setJoinToken string) (*Config, error) {
 	if err := checkWorkCacheDir(workDir, cacheDir); err != nil {
 		return nil, err
 	}
@@ -355,6 +356,7 @@ func load(ctx context.Context, workDir, cacheDir string, wiringAndHydration bool
 	cfg := &Config{
 		WorkDir:        workDir,
 		CacheDir:       cacheDir,
+		ExtraCacheDirs: extraCacheDirs,
 		RegistryConfig: *regConf,
 		Fab:            f,
 		Controls:       controls,

--- a/pkg/hhfab/cmddiagram.go
+++ b/pkg/hhfab/cmddiagram.go
@@ -29,7 +29,7 @@ func Diagram(ctx context.Context, workDir, cacheDir string, live bool, format di
 	var client kclient.Reader
 
 	if !live {
-		c, err := load(ctx, workDir, cacheDir, true, HydrateModeIfNotPresent, "")
+		c, err := load(ctx, workDir, cacheDir, nil, true, HydrateModeIfNotPresent, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/hhfab/cmdvlab.go
+++ b/pkg/hhfab/cmdvlab.go
@@ -22,7 +22,7 @@ const (
 )
 
 func VLABGenerate(ctx context.Context, workDir, cacheDir string, builder VLABBuilder, target string) error {
-	cfg, err := load(ctx, workDir, cacheDir, false, HydrateModeNever, "")
+	cfg, err := load(ctx, workDir, cacheDir, nil, false, HydrateModeNever, "")
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ type VLABUpOpts struct {
 	VLABRunOpts
 }
 
-func VLABUp(ctx context.Context, workDir, cacheDir string, opts VLABUpOpts) error {
+func VLABUp(ctx context.Context, workDir, cacheDir string, extraCacheDirs []string, opts VLABUpOpts) error {
 	if opts.AutoUpgrade {
 		opts.BuildMode = recipe.BuildModeManual
 		opts.VLABRunOpts.BuildMode = recipe.BuildModeManual
@@ -81,7 +81,7 @@ func VLABUp(ctx context.Context, workDir, cacheDir string, opts VLABUpOpts) erro
 		return fmt.Errorf("--upgrade and --recreate (-f) are mutually exclusive: upgrade requires existing VMs") //nolint:goerr113
 	}
 
-	c, err := load(ctx, workDir, cacheDir, true, opts.HydrateMode, opts.SetJoinToken)
+	c, err := load(ctx, workDir, cacheDir, extraCacheDirs, true, opts.HydrateMode, opts.SetJoinToken)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func loadVLABForHelpers(ctx context.Context, workDir, cacheDir string) (*Config,
 		NoCreate:    true,
 	}
 
-	c, err := load(ctx, workDir, cacheDir, true, opts.HydrateMode, opts.SetJoinToken)
+	c, err := load(ctx, workDir, cacheDir, nil, true, opts.HydrateMode, opts.SetJoinToken)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/hhfab/vlabrunner.go
+++ b/pkg/hhfab/vlabrunner.go
@@ -276,7 +276,7 @@ func (c *Config) VLABRun(ctx context.Context, vlab *VLAB, opts VLABRunOpts) erro
 		disk += vm.Size.Disk
 	}
 
-	d, err := artificer.NewDownloaderWithDockerCreds(c.CacheDir, c.Repo, c.Prefix)
+	d, err := artificer.NewDownloaderWithDockerCreds(c.CacheDir, c.ExtraCacheDirs, c.Repo, c.Prefix)
 	if err != nil {
 		return fmt.Errorf("creating downloader: %w", err)
 	}


### PR DESCRIPTION
It allows us to avoid copying the cache every time on vlab/hlab jobs and instead just do a lookup in an extra locations. /hostcache/.hhfab-cache is already mounted read-only into runner pod, so it's safe to access it directly.