### PR TITLE
chore(recipe): close the ignition file after writing it

### DIFF
--- a/pkg/fab/recipe/build.go
+++ b/pkg/fab/recipe/build.go
@@ -391,6 +391,8 @@ func buildUSBImage(ctx context.Context, opts buildInstallOpts) error {
 	if err != nil {
 		return fmt.Errorf("creating ignition file: %w", err)
 	}
+	defer ignFile.Close()
+
 	if _, err := ignFile.Write(ign); err != nil {
 		return fmt.Errorf("writing ignition: %w", err)
 	}


### PR DESCRIPTION
The ignition file written into the install image was opened and never closed, leaking a file descriptor per installer built in ISO mode, where diskfs hands back a real os.File in the build workspace.

No behavior change. Close is a no-op in both backends of go-diskfs v1.4.2-hh3 (iso9660 sets a closed flag, fat32 drops its filesystem pointer), and durability already comes from O_SYNC in ISO mode and from the explicit fat32 Commit in USB mode. This just makes the ignition write match diskFSCopyFile a few lines below, which already defers Close on the same kind of handle.

Found while triaging #1834, unrelated to that failure.
